### PR TITLE
Cherry-pick Babelfish-related commits from BABEL_1_X_DEV__PG_13_6 - part 2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,11 +2,9 @@ name: CI
 
 on:
   push:
-    branches:
-      - 13_4
   pull_request:
     branches:
-      - 13_4
+      - BABEL_2_X_DEV__PG_14_2
 
 jobs:
   build-and-run-tests:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   push:
   pull_request:
-    branches:
-      - BABEL_2_X_DEV__PG_14_2
 
 jobs:
   build-and-run-tests:

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -6677,6 +6677,9 @@ ATExecAddColumn(List **wqueue, AlteredTableInfo *tab, Relation rel,
 					   list_make1_oid(rel->rd_rel->reltype),
 					   0);
 
+	if (sql_dialect == SQL_DIALECT_TSQL && check_or_set_default_typmod_hook)
+		(*check_or_set_default_typmod_hook)(colDef->typeName, &typmod, false);
+
 	/* construct new attribute's pg_attribute entry */
 	attribute.attrelid = myrelid;
 	namestrcpy(&(attribute.attname), colDef->colname);
@@ -11708,6 +11711,9 @@ ATPrepAlterColumnType(List **wqueue,
 	/* And the collation */
 	targetcollid = GetColumnDefCollation(NULL, def, targettype);
 
+	if (sql_dialect == SQL_DIALECT_TSQL && check_or_set_default_typmod_hook)
+		(*check_or_set_default_typmod_hook)(typeName, &targettypmod, false);
+
 	/* make sure datatype is legal for a column */
 	CheckAttributeType(colName, targettype, targetcollid,
 					   list_make1_oid(rel->rd_rel->reltype),
@@ -12027,6 +12033,9 @@ ATExecAlterColumnType(AlteredTableInfo *tab, Relation rel,
 	targettype = tform->oid;
 	/* And the collation */
 	targetcollid = GetColumnDefCollation(NULL, def, targettype);
+
+	if (sql_dialect == SQL_DIALECT_TSQL && check_or_set_default_typmod_hook)
+		(*check_or_set_default_typmod_hook)(typeName, &targettypmod, false);
 
 	/*
 	 * If there is a default expression for the column, get it and ensure we

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -1236,12 +1236,19 @@ DefineRelation(CreateStmt *stmt, char relkind, Oid ownerId,
 	 * created composite type as the desired table type.
 	 * So, remove the composite type's dependency on the relation, and record
 	 * the relation's dependency on the composite type.
+	 * Also, remove the relation's dependency on the owner, and record the
+	 * composite type's dependency on the owner.
 	 */
 	if (stmt->tsql_tabletype)
 	{
 		deleteDependencyRecordsForClass(typaddress->classId, typaddress->objectId,
 										RelationRelationId, DEPENDENCY_INTERNAL);
 		recordDependencyOn(&address, typaddress, DEPENDENCY_INTERNAL);
+
+		deleteSharedDependencyRecordsFor(address.classId, address.objectId,
+										 address.objectSubId);
+		recordDependencyOnOwner(typaddress->classId, typaddress->objectId,
+								ownerId);
 	}
 
 	/*

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -881,6 +881,8 @@ DefineRelation(CreateStmt *stmt, char relkind, Oid ownerId,
 			rawEnt->generated = colDef->generated;
 			rawDefaults = lappend(rawDefaults, rawEnt);
 			attr->atthasdef = true;
+
+			rawEnt->hasCollClause = colDef->collClause != NULL ? true : false;
 		}
 		else if (colDef->cooked_default != NULL)
 		{
@@ -6745,6 +6747,8 @@ ATExecAddColumn(List **wqueue, AlteredTableInfo *tab, Relation rel,
 
 		rawEnt->generated = colDef->generated;
 
+		rawEnt->hasCollClause = colDef->collClause != NULL ? true : false;
+
 		/*
 		 * This function is intended for CREATE TABLE, so it processes a
 		 * _list_ of defaults, but we just do one.
@@ -7462,6 +7466,9 @@ ATExecColumnDefault(Relation rel, const char *colName,
 		rawEnt->raw_default = newDefault;
 		rawEnt->missingMode = false;
 		rawEnt->generated = '\0';
+
+		/* Cannot have a COLLATE clause with ALTER TABLE ALTER COLUMN SET/DROP DEFAULT */
+		rawEnt->hasCollClause = false;
 
 		/*
 		 * This function is intended for CREATE TABLE, so it processes a

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -507,10 +507,15 @@ CreateTriggerFiringOn(CreateTrigStmt *stmt, const char *queryString,
 			 * it's not yet clear what INSERT OR UPDATE trigger should see.
 			 * This restriction could be lifted if we can decide on the right
 			 * semantics in a later release.
+			 * 
+			 * We shall allow TSQL to create multi-event triggers with 
+			 * transition tables , since TSQL doesn’t support PG’s insert on conflict,
+			 * Babelfish doesn’t support MERGE statement yet
 			 */
-			if (((TRIGGER_FOR_INSERT(tgtype) ? 1 : 0) +
+			if ((((TRIGGER_FOR_INSERT(tgtype) ? 1 : 0) +
 				 (TRIGGER_FOR_UPDATE(tgtype) ? 1 : 0) +
-				 (TRIGGER_FOR_DELETE(tgtype) ? 1 : 0)) != 1)
+				 (TRIGGER_FOR_DELETE(tgtype) ? 1 : 0)) != 1) 
+				 && sql_dialect != SQL_DIALECT_TSQL)
 				ereport(ERROR,
 						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 						 errmsg("transition tables cannot be specified for triggers with more than one event")));

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -548,8 +548,16 @@ CreateTriggerFiringOn(CreateTrigStmt *stmt, const char *queryString,
 
 			if (tt->isNew)
 			{
-				if (!(TRIGGER_FOR_INSERT(tgtype) ||
-					  TRIGGER_FOR_UPDATE(tgtype)))
+				if (sql_dialect == SQL_DIALECT_TSQL){
+					if (!(TRIGGER_FOR_DELETE(tgtype) ||
+						TRIGGER_FOR_UPDATE(tgtype) ||
+						TRIGGER_FOR_INSERT(tgtype)))
+						ereport(ERROR,
+								(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
+								 errmsg("OLD TABLE can only be specified for a INSERT or DELETE or UPDATE trigger")));
+				}
+				else if (!(TRIGGER_FOR_INSERT(tgtype) ||
+					TRIGGER_FOR_UPDATE(tgtype)))
 					ereport(ERROR,
 							(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
 							 errmsg("NEW TABLE can only be specified for an INSERT or UPDATE trigger")));
@@ -574,7 +582,7 @@ CreateTriggerFiringOn(CreateTrigStmt *stmt, const char *queryString,
 						TRIGGER_FOR_INSERT(tgtype)))
 						ereport(ERROR,
 								(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
-								 errmsg("TSQL: OLD TABLE can only be specified for a INSERT or DELETE or UPDATE trigger")));
+								 errmsg("OLD TABLE can only be specified for a INSERT or DELETE or UPDATE trigger")));
 
 				if (oldtablename != NULL)
 					ereport(ERROR,
@@ -4843,6 +4851,19 @@ MakeTransitionCaptureState(TriggerDesc *trigdesc, Oid relid, CmdType cmdType)
 			need_old = need_new = false;	/* keep compiler quiet */
 			break;
 	}
+
+	/**
+	 * In Tsql for babelfish, it allows to use deleted in after/instead of 
+	 * insert statment, and it allows to use inserted in after/instead of
+	 * delete statment as well, so we'll init both old and new transition tables
+	 * for Tsql dialect
+	 * */
+	if (sql_dialect == SQL_DIALECT_TSQL && (need_old || need_new))
+	{
+		need_old = true;
+		need_new = true;
+	}
+
 	if (!need_old && !need_new)
 		return NULL;
 

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -89,6 +89,12 @@ static HeapTuple ExecCallTriggerFunc(TriggerData *trigdata,
 									 FmgrInfo *finfo,
 									 Instrumentation *instr,
 									 MemoryContext per_tuple_context);
+static void InsteadofTriggerSaveEvent(EState *estate, ResultRelInfo *relinfo,
+								  int event, bool row_trigger,
+								  TupleTableSlot *oldtup, TupleTableSlot *newtup,
+								  List *recheckIndexes, Bitmapset *modifiedCols,
+								  TransitionCaptureState *transition_capture);
+
 static void AfterTriggerSaveEvent(EState *estate, ResultRelInfo *relinfo,
 								  int event, bool row_trigger,
 								  TupleTableSlot *oldtup, TupleTableSlot *newtup,
@@ -2224,7 +2230,8 @@ ExecCallTriggerFunc(TriggerData *trigdata,
 	Assert(((TRIGGER_FIRED_BY_INSERT(trigdata->tg_event) ||
 			 TRIGGER_FIRED_BY_UPDATE(trigdata->tg_event) ||
 			 TRIGGER_FIRED_BY_DELETE(trigdata->tg_event)) &&
-			TRIGGER_FIRED_AFTER(trigdata->tg_event) &&
+			(TRIGGER_FIRED_AFTER(trigdata->tg_event) ||
+			(TRIGGER_FIRED_INSTEAD(trigdata->tg_event) && sql_dialect == SQL_DIALECT_TSQL)) &&
 			!(trigdata->tg_event & AFTER_TRIGGER_DEFERRABLE) &&
 			!(trigdata->tg_event & AFTER_TRIGGER_INITDEFERRED)) ||
 		   (trigdata->tg_oldtable == NULL && trigdata->tg_newtable == NULL));
@@ -2295,60 +2302,6 @@ ExecCallTriggerFunc(TriggerData *trigdata,
 		InstrStopNode(instr + tgindx, 1);
 
 	return (HeapTuple) DatumGetPointer(result);
-}
-
-IOTState
-ExecISInsertTriggers(EState *estate, ResultRelInfo *relinfo)
-{
-	TriggerDesc *trigdesc;
-	int i;
-	TriggerData LocTriggerData;
-	IOTState prevState;
-	trigdesc = relinfo->ri_TrigDesc;
-	if (trigdesc == NULL)
-		return IOT_NOT_REQUIRED;
-	if (!trigdesc->trig_insert_instead_statement) {
-		set_iot_state(RelationGetRelid(relinfo->ri_RelationDesc), CMD_INSERT, IOT_NOT_REQUIRED);
-		return IOT_NOT_REQUIRED;
-	}
-
-	// if the trigger is already fired or not required
-	prevState = instead_stmt_triggers_fired(RelationGetRelid(relinfo->ri_RelationDesc), CMD_INSERT);
-	if (prevState != IOT_NOT_FIRED)
-		return prevState;
-	LocTriggerData.type = T_TriggerData;
-	LocTriggerData.tg_event = TRIGGER_EVENT_INSERT | TRIGGER_EVENT_INSTEAD;
-	LocTriggerData.tg_relation = relinfo->ri_RelationDesc;
-	LocTriggerData.tg_trigtuple = NULL;
-	LocTriggerData.tg_newtuple = NULL;
-	LocTriggerData.tg_trigslot = NULL;
-	LocTriggerData.tg_newslot = NULL;
-	LocTriggerData.tg_oldtable = NULL;
-	LocTriggerData.tg_newtable = NULL;
-	for (i = 0; i < trigdesc->numtriggers; i++)
-	{
-		Trigger    *trigger = &trigdesc->triggers[i];
-		HeapTuple   newtuple;
-		if (!TRIGGER_TYPE_MATCHES(trigger->tgtype,
-					TRIGGER_TYPE_STATEMENT,
-					TRIGGER_TYPE_INSTEAD,
-					TRIGGER_TYPE_INSERT))
-			continue;
-		if (!TriggerEnabled(estate, relinfo, trigger, LocTriggerData.tg_event, NULL, NULL, NULL))
-			continue;
-		LocTriggerData.tg_trigger = trigger;
-		newtuple = ExecCallTriggerFunc(
-				&LocTriggerData,
-				i,
-				relinfo->ri_TrigFunctions,
-				relinfo->ri_TrigInstrument,
-				GetPerTupleMemoryContext(estate));
-		if (newtuple)
-			ereport(ERROR,
-					(errcode(ERRCODE_E_R_I_E_TRIGGER_PROTOCOL_VIOLATED),
-					 errmsg("INSTEAD STATEMENT trigger cannot return a value")));
-	}
-	return IOT_FIRED;
 }
 
 void
@@ -2502,6 +2455,22 @@ ExecARInsertTriggers(EState *estate, ResultRelInfo *relinfo,
 							  true, NULL, slot,
 							  recheckIndexes, NULL,
 							  transition_capture);
+}
+
+void
+ExecIRInsertTriggersTSQL(EState *estate, ResultRelInfo *relinfo,
+					TupleTableSlot *slot,
+					TransitionCaptureState *transition_capture)
+{
+	TriggerDesc *trigdesc = relinfo->ri_TrigDesc;
+
+	if ((trigdesc && trigdesc->trig_insert_instead_statement) && 
+		(transition_capture && transition_capture->tcs_insert_new_table)){
+		InsteadofTriggerSaveEvent(estate, relinfo, TRIGGER_EVENT_INSERT,
+							  true, NULL, slot,
+							  NULL, NULL,
+							  transition_capture);
+	}
 }
 
 bool
@@ -4400,6 +4369,68 @@ AfterTriggerExecute(EState *estate,
 		InstrStopNode(instr + tgindx, 1);
 }
 
+IOTState
+ExecISInsertTriggers(EState *estate, ResultRelInfo *relinfo, TransitionCaptureState *transition_capture)
+{
+	TriggerDesc *trigdesc;
+    int i;
+	TriggerData LocTriggerData;
+    IOTState prevState;
+    trigdesc = relinfo->ri_TrigDesc;
+    if (trigdesc == NULL)
+       	return IOT_NOT_REQUIRED;
+    if (!trigdesc->trig_insert_instead_statement) 
+	{
+		set_iot_state(RelationGetRelid(relinfo->ri_RelationDesc), CMD_INSERT, IOT_NOT_REQUIRED);
+    		return IOT_NOT_REQUIRED;
+	}
+
+    // if the trigger is already fired or not required
+    prevState = instead_stmt_triggers_fired(RelationGetRelid(relinfo->ri_RelationDesc), CMD_INSERT);
+    if (prevState != IOT_NOT_FIRED)
+    	return prevState;
+    LocTriggerData.type = T_TriggerData;
+    LocTriggerData.tg_event = TRIGGER_EVENT_INSERT | TRIGGER_EVENT_INSTEAD;
+    LocTriggerData.tg_relation = relinfo->ri_RelationDesc;
+    LocTriggerData.tg_trigtuple = NULL;
+    LocTriggerData.tg_newtuple = NULL;
+    LocTriggerData.tg_trigslot = NULL;
+    /*
+    * Set up the tuplestore information to let the trigger have access to
+    * transition tables.  When we first make a transition table available to
+    * a trigger, mark it "closed" so that it cannot change anymore.  If any
+    * additional events of the same type get queued in the current trigger
+    * query level, they'll go into new transition tables.
+    */
+    LocTriggerData.tg_oldtable = LocTriggerData.tg_newtable = NULL;
+	LocTriggerData.tg_oldtable = transition_capture->tcs_private->old_tuplestore;
+	LocTriggerData.tg_newtable = transition_capture->tcs_private->new_tuplestore;
+    for (i = 0; i < trigdesc->numtriggers; i++)
+    {
+        Trigger    *trigger = &trigdesc->triggers[i];
+        HeapTuple   newtuple;
+        if (!TRIGGER_TYPE_MATCHES(trigger->tgtype,
+            TRIGGER_TYPE_STATEMENT,
+            TRIGGER_TYPE_INSTEAD,
+            TRIGGER_TYPE_INSERT))
+                continue;
+    	if (!TriggerEnabled(estate, relinfo, trigger, LocTriggerData.tg_event, NULL, NULL, NULL))
+            continue;
+        LocTriggerData.tg_trigger = trigger;
+        newtuple = ExecCallTriggerFunc(
+            &LocTriggerData,
+            i,
+        	relinfo->ri_TrigFunctions,
+            relinfo->ri_TrigInstrument,
+            GetPerTupleMemoryContext(estate));
+        if (newtuple)
+            ereport(ERROR,
+                (errcode(ERRCODE_E_R_I_E_TRIGGER_PROTOCOL_VIOLATED),
+                errmsg("INSTEAD STATEMENT trigger cannot return a value")));
+    }
+    return IOT_FIRED;
+}
+
 
 /*
  * afterTriggerMarkEvents()
@@ -5786,6 +5817,87 @@ AfterTriggerPendingOnRel(Oid relid)
 	}
 
 	return false;
+}
+
+static void
+InsteadofTriggerSaveEvent(EState *estate, ResultRelInfo *relinfo,
+					  int event, bool row_trigger,
+					  TupleTableSlot *oldslot, TupleTableSlot *newslot,
+					  List *recheckIndexes, Bitmapset *modifiedCols,
+					  TransitionCaptureState *transition_capture)
+{
+	if (row_trigger && transition_capture != NULL)
+	{
+		TupleTableSlot *original_insert_tuple = transition_capture->tcs_original_insert_tuple;
+		TupleConversionMap *map = relinfo->ri_ChildToRootMap;
+		bool		delete_old_table = transition_capture->tcs_delete_old_table;
+		bool		update_old_table = transition_capture->tcs_update_old_table;
+		bool		update_new_table = transition_capture->tcs_update_new_table;
+		bool		insert_new_table = transition_capture->tcs_insert_new_table;
+
+		/*
+		 * For INSERT events NEW should be non-NULL, for DELETE events OLD
+		 * should be non-NULL, whereas for UPDATE events normally both OLD and
+		 * NEW are non-NULL.  But for UPDATE events fired for capturing
+		 * transition tuples during UPDATE partition-key row movement, OLD is
+		 * NULL when the event is for a row being inserted, whereas NEW is
+		 * NULL when the event is for a row being deleted.
+		 */
+		Assert(!(event == TRIGGER_EVENT_DELETE && delete_old_table &&
+				 TupIsNull(oldslot)));
+		Assert(!(event == TRIGGER_EVENT_INSERT && insert_new_table &&
+				 TupIsNull(newslot)));
+
+		if (!TupIsNull(oldslot) &&
+			((event == TRIGGER_EVENT_DELETE && delete_old_table) ||
+			 (event == TRIGGER_EVENT_UPDATE && update_old_table)))
+		{
+			Tuplestorestate *old_tuplestore;
+
+			old_tuplestore = transition_capture->tcs_private->old_tuplestore;
+
+			if (map != NULL)
+			{
+				AfterTriggersTableData *table = transition_capture->tcs_private;
+				TupleTableSlot *storeslot;
+
+				storeslot = GetAfterTriggersStoreSlot(table, map->outdesc);
+				execute_attr_map_slot(map->attrMap, oldslot, storeslot);
+				tuplestore_puttupleslot(old_tuplestore, storeslot);
+			}
+			else
+				tuplestore_puttupleslot(old_tuplestore, oldslot);
+		}
+
+		if (!TupIsNull(newslot) &&
+			((event == TRIGGER_EVENT_INSERT && insert_new_table) ||
+			 (event == TRIGGER_EVENT_UPDATE && update_new_table)))
+		{
+			Tuplestorestate *new_tuplestore;
+
+			new_tuplestore = transition_capture->tcs_private->new_tuplestore;
+
+			if (original_insert_tuple != NULL)
+				tuplestore_puttupleslot(new_tuplestore,
+										original_insert_tuple);
+			else if (map != NULL)
+			{
+				AfterTriggersTableData *table = transition_capture->tcs_private;
+				TupleTableSlot *storeslot;
+
+				storeslot = GetAfterTriggersStoreSlot(table, map->outdesc);
+				execute_attr_map_slot(map->attrMap, newslot, storeslot);
+				tuplestore_puttupleslot(new_tuplestore, storeslot);
+			}
+			else
+				tuplestore_puttupleslot(new_tuplestore, newslot);
+		}
+
+		/*
+		 * transition tables are the only reason we're here, return. 
+		 */
+		return;
+	}
 }
 
 

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -2512,6 +2512,47 @@ ExecIRDeleteTriggersTSQL(EState *estate, ResultRelInfo *relinfo,
 	}
 }
 
+void ExecIRUpdateTriggersTSQL(EState *estate,
+								 ResultRelInfo *relinfo,
+								 ItemPointer tupleid,
+								 HeapTuple fdw_trigtuple,
+								 TupleTableSlot *newslot,
+					 			 List *recheckIndexes,
+								 TransitionCaptureState *transition_capture)
+{
+	TriggerDesc *trigdesc = relinfo->ri_TrigDesc;
+	TupleTableSlot *oldslot = ExecGetTriggerOldSlot(estate, relinfo);
+
+	ExecClearTuple(oldslot);
+	if ((trigdesc && trigdesc->trig_update_instead_statement) ||
+		(transition_capture &&
+		 (transition_capture->tcs_update_old_table ||
+		  transition_capture->tcs_update_new_table)))
+	{
+		/*
+		 * Note: if the UPDATE is converted into a DELETE+INSERT as part of
+		 * update-partition-key operation, then this function is also called
+		 * separately for DELETE and INSERT to capture transition table rows.
+		 * In such case, either old tuple or new tuple can be NULL.
+		 */
+		if (fdw_trigtuple == NULL && ItemPointerIsValid(tupleid))
+			GetTupleForTrigger(estate,
+							   NULL,
+							   relinfo,
+							   tupleid,
+							   LockTupleExclusive,
+							   oldslot,
+							   NULL);
+		else if (fdw_trigtuple != NULL)
+			ExecForceStoreHeapTuple(fdw_trigtuple, oldslot, false);
+
+		InsteadofTriggerSaveEvent(estate, relinfo, TRIGGER_EVENT_UPDATE,
+							  true, oldslot, newslot, recheckIndexes,
+							  ExecGetAllUpdatedCols(relinfo, estate),
+							  transition_capture);
+	}
+}
+
 bool
 ExecIRInsertTriggers(EState *estate, ResultRelInfo *relinfo,
 					 TupleTableSlot *slot)
@@ -2803,71 +2844,6 @@ ExecIRDeleteTriggers(EState *estate, ResultRelInfo *relinfo,
 			heap_freetuple(rettuple);
 	}
 	return true;
-}
-
-IOTState
-ExecISUpdateTriggers(EState *estate, ResultRelInfo *relinfo)
-{
-	TriggerDesc *trigdesc;
-	int			i;
-	TriggerData LocTriggerData;
-	Bitmapset  *updatedCols;
-	IOTState prevState;
-
-	trigdesc = relinfo->ri_TrigDesc;
-
-	if (trigdesc == NULL)
-		return IOT_NOT_REQUIRED;
-
-	if (!trigdesc->trig_update_instead_statement) {
-		set_iot_state(RelationGetRelid(relinfo->ri_RelationDesc), CMD_UPDATE, IOT_NOT_REQUIRED);
-		return IOT_NOT_REQUIRED;
-	}
-
-	prevState = instead_stmt_triggers_fired(RelationGetRelid(relinfo->ri_RelationDesc), CMD_UPDATE);
-	// if the trigger is already fired or not required
-	if (prevState != IOT_NOT_FIRED)
-		return prevState;
-
-	updatedCols = ExecGetAllUpdatedCols(relinfo, estate);
-
-	LocTriggerData.type = T_TriggerData;
-	LocTriggerData.tg_event = TRIGGER_EVENT_UPDATE |
-		TRIGGER_EVENT_INSTEAD;
-	LocTriggerData.tg_relation = relinfo->ri_RelationDesc;
-	LocTriggerData.tg_trigtuple = NULL;
-	LocTriggerData.tg_newtuple = NULL;
-	LocTriggerData.tg_oldtable = NULL;
-	LocTriggerData.tg_newtable = NULL;
-	LocTriggerData.tg_trigtuple = InvalidBuffer;
-	LocTriggerData.tg_newtuple = InvalidBuffer;
-	for (i = 0; i < trigdesc->numtriggers; i++)
-	{
-		Trigger    *trigger = &trigdesc->triggers[i];
-		HeapTuple	newtuple;
-
-		if (!TRIGGER_TYPE_MATCHES(trigger->tgtype,
-								  TRIGGER_TYPE_STATEMENT,
-								  TRIGGER_TYPE_INSTEAD,
-								  TRIGGER_TYPE_UPDATE))
-			continue;
-		if (!TriggerEnabled(estate, relinfo, trigger, LocTriggerData.tg_event,
-							updatedCols, NULL, NULL))
-			continue;
-
-		LocTriggerData.tg_trigger = trigger;
-		newtuple = ExecCallTriggerFunc(&LocTriggerData,
-									   i,
-									   relinfo->ri_TrigFunctions,
-									   relinfo->ri_TrigInstrument,
-									   GetPerTupleMemoryContext(estate));
-
-		if (newtuple)
-			ereport(ERROR,
-					(errcode(ERRCODE_E_R_I_E_TRIGGER_PROTOCOL_VIOLATED),
-					 errmsg("INSTEAD OF STATEMENT trigger cannot return a value")));
-	}
-	return IOT_FIRED;
 }
 
 void
@@ -4406,6 +4382,81 @@ ExecISInsertTriggers(EState *estate, ResultRelInfo *relinfo, TransitionCaptureSt
                 errmsg("INSTEAD STATEMENT trigger cannot return a value")));
     }
     return IOT_FIRED;
+}
+
+IOTState
+ExecISUpdateTriggers(EState *estate, ResultRelInfo *relinfo, TransitionCaptureState *transition_capture)
+{
+	TriggerDesc *trigdesc;
+	int			i;
+	TriggerData LocTriggerData;
+	Bitmapset  *updatedCols;
+	IOTState prevState;
+
+	trigdesc = relinfo->ri_TrigDesc;
+
+	if (trigdesc == NULL)
+		return IOT_NOT_REQUIRED;
+
+	if (!trigdesc->trig_update_instead_statement) {
+		set_iot_state(RelationGetRelid(relinfo->ri_RelationDesc), CMD_UPDATE, IOT_NOT_REQUIRED);
+		return IOT_NOT_REQUIRED;
+	}
+
+	prevState = instead_stmt_triggers_fired(RelationGetRelid(relinfo->ri_RelationDesc), CMD_UPDATE);
+	// if the trigger is already fired or not required
+	if (prevState != IOT_NOT_FIRED)
+		return prevState;
+
+	updatedCols = ExecGetAllUpdatedCols(relinfo, estate);
+
+	LocTriggerData.type = T_TriggerData;
+	LocTriggerData.tg_event = TRIGGER_EVENT_UPDATE |
+		TRIGGER_EVENT_INSTEAD;
+	LocTriggerData.tg_relation = relinfo->ri_RelationDesc;
+	LocTriggerData.tg_trigtuple = NULL;
+	LocTriggerData.tg_newtuple = NULL;
+	LocTriggerData.tg_trigtuple = InvalidBuffer;
+	LocTriggerData.tg_newtuple = InvalidBuffer;
+
+	/*
+    * Set up the tuplestore information to let the trigger have access to
+    * transition tables.  When we first make a transition table available to
+    * a trigger, mark it "closed" so that it cannot change anymore.  If any
+    * additional events of the same type get queued in the current trigger
+    * query level, they'll go into new transition tables.
+    */
+    LocTriggerData.tg_oldtable = LocTriggerData.tg_newtable = NULL;
+	LocTriggerData.tg_oldtable = transition_capture->tcs_private->old_tuplestore;
+	LocTriggerData.tg_newtable = transition_capture->tcs_private->new_tuplestore;
+
+	for (i = 0; i < trigdesc->numtriggers; i++)
+	{
+		Trigger    *trigger = &trigdesc->triggers[i];
+		HeapTuple	newtuple;
+
+		if (!TRIGGER_TYPE_MATCHES(trigger->tgtype,
+								  TRIGGER_TYPE_STATEMENT,
+								  TRIGGER_TYPE_INSTEAD,
+								  TRIGGER_TYPE_UPDATE))
+			continue;
+		if (!TriggerEnabled(estate, relinfo, trigger, LocTriggerData.tg_event,
+							updatedCols, NULL, NULL))
+			continue;
+
+		LocTriggerData.tg_trigger = trigger;
+		newtuple = ExecCallTriggerFunc(&LocTriggerData,
+									   i,
+									   relinfo->ri_TrigFunctions,
+									   relinfo->ri_TrigInstrument,
+									   GetPerTupleMemoryContext(estate));
+
+		if (newtuple)
+			ereport(ERROR,
+					(errcode(ERRCODE_E_R_I_E_TRIGGER_PROTOCOL_VIOLATED),
+					 errmsg("INSTEAD OF STATEMENT trigger cannot return a value")));
+	}
+	return IOT_FIRED;
 }
 
 IOTState

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -2473,6 +2473,37 @@ ExecIRInsertTriggersTSQL(EState *estate, ResultRelInfo *relinfo,
 	}
 }
 
+void
+ExecIRDeleteTriggersTSQL(EState *estate, ResultRelInfo *relinfo,
+					ItemPointer tupleid,
+					HeapTuple fdw_trigtuple,
+					TransitionCaptureState *transition_capture)
+{
+	TriggerDesc *trigdesc;
+	TupleTableSlot *slot;
+	trigdesc = relinfo->ri_TrigDesc;
+	if ((trigdesc && trigdesc->trig_delete_instead_statement) && 
+		(transition_capture && transition_capture->tcs_delete_old_table)){
+		Assert(HeapTupleIsValid(fdw_trigtuple) ^ ItemPointerIsValid(tupleid));
+		slot = ExecGetTriggerOldSlot(estate, relinfo);
+		if (fdw_trigtuple == NULL)
+			GetTupleForTrigger(estate,
+								NULL,
+								relinfo,
+								tupleid,
+								LockTupleExclusive,
+								slot,
+								NULL);
+		else
+			ExecForceStoreHeapTuple(fdw_trigtuple, slot, false);
+
+		InsteadofTriggerSaveEvent(estate, relinfo, TRIGGER_EVENT_DELETE,
+							true, slot, NULL,
+							NIL, NULL,
+							transition_capture);
+	}
+}
+
 bool
 ExecIRInsertTriggers(EState *estate, ResultRelInfo *relinfo,
 					 TupleTableSlot *slot)
@@ -2584,68 +2615,6 @@ ExecBSDeleteTriggers(EState *estate, ResultRelInfo *relinfo)
 					 errmsg("BEFORE STATEMENT trigger cannot return a value")));
 	}
 }
-
-IOTState
-ExecISDeleteTriggers(EState *estate, ResultRelInfo *relinfo)
-{
-	TriggerDesc *trigdesc;
-	int			i;
-	TriggerData LocTriggerData;
-	IOTState prevState;
-
-	trigdesc = relinfo->ri_TrigDesc;
-
-	if (trigdesc == NULL)
-		return IOT_NOT_REQUIRED;
-	if (!trigdesc->trig_delete_instead_statement) {
-		set_iot_state(RelationGetRelid(relinfo->ri_RelationDesc), CMD_DELETE, IOT_NOT_REQUIRED);
-		return IOT_NOT_REQUIRED;
-	}
-	prevState = instead_stmt_triggers_fired(RelationGetRelid(relinfo->ri_RelationDesc), CMD_DELETE);
-	// if the trigger is already fired or not required
-	if (prevState != IOT_NOT_FIRED)
-		return prevState;
-
-	LocTriggerData.type = T_TriggerData;
-	LocTriggerData.tg_event = TRIGGER_EVENT_DELETE |
-		TRIGGER_EVENT_INSTEAD;
-	LocTriggerData.tg_relation = relinfo->ri_RelationDesc;
-	LocTriggerData.tg_trigtuple = NULL;
-	LocTriggerData.tg_newtuple = NULL;
-	LocTriggerData.tg_oldtable = NULL;
-	LocTriggerData.tg_newtable = NULL;
-	LocTriggerData.tg_trigtuple = InvalidBuffer;
-	LocTriggerData.tg_newtuple = InvalidBuffer;
-	for (i = 0; i < trigdesc->numtriggers; i++)
-	{
-		Trigger    *trigger = &trigdesc->triggers[i];
-		HeapTuple	newtuple;
-
-		if (!TRIGGER_TYPE_MATCHES(trigger->tgtype,
-								  TRIGGER_TYPE_STATEMENT,
-								  TRIGGER_TYPE_INSTEAD,
-								  TRIGGER_TYPE_DELETE))
-			continue;
-		if (!TriggerEnabled(estate, relinfo, trigger, LocTriggerData.tg_event,
-							NULL, NULL, NULL))
-			continue;
-
-		LocTriggerData.tg_trigger = trigger;
-		newtuple = ExecCallTriggerFunc(&LocTriggerData,
-									   i,
-									   relinfo->ri_TrigFunctions,
-									   relinfo->ri_TrigInstrument,
-									   GetPerTupleMemoryContext(estate));
-
-		if (newtuple)
-			ereport(ERROR,
-					(errcode(ERRCODE_E_R_I_E_TRIGGER_PROTOCOL_VIOLATED),
-					 errmsg("INSTEAD STATEMENT trigger cannot return a value")));
-	}
-	return IOT_FIRED;
-}
-
-
 
 void
 ExecASDeleteTriggers(EState *estate, ResultRelInfo *relinfo,
@@ -4431,6 +4400,74 @@ ExecISInsertTriggers(EState *estate, ResultRelInfo *relinfo, TransitionCaptureSt
     return IOT_FIRED;
 }
 
+IOTState
+ExecISDeleteTriggers(EState *estate, ResultRelInfo *relinfo, TransitionCaptureState *transition_capture)
+{
+	TriggerDesc *trigdesc;
+	int			i;
+	TriggerData LocTriggerData;
+	IOTState prevState;
+
+	trigdesc = relinfo->ri_TrigDesc;
+
+	if (trigdesc == NULL)
+		return IOT_NOT_REQUIRED;
+	if (!trigdesc->trig_delete_instead_statement) {
+		set_iot_state(RelationGetRelid(relinfo->ri_RelationDesc), CMD_DELETE, IOT_NOT_REQUIRED);
+		return IOT_NOT_REQUIRED;
+	}
+	prevState = instead_stmt_triggers_fired(RelationGetRelid(relinfo->ri_RelationDesc), CMD_DELETE);
+	// if the trigger is already fired or not required
+	if (prevState != IOT_NOT_FIRED)
+		return prevState;
+
+	LocTriggerData.type = T_TriggerData;
+	LocTriggerData.tg_event = TRIGGER_EVENT_DELETE |
+		TRIGGER_EVENT_INSTEAD;
+	LocTriggerData.tg_relation = relinfo->ri_RelationDesc;
+	LocTriggerData.tg_trigtuple = NULL;
+	LocTriggerData.tg_newtuple = NULL;
+	LocTriggerData.tg_trigtuple = InvalidBuffer;
+	LocTriggerData.tg_newtuple = InvalidBuffer;
+	/*
+    * Set up the tuplestore information to let the trigger have access to
+    * transition tables.  When we first make a transition table available to
+    * a trigger, mark it "closed" so that it cannot change anymore.  If any
+    * additional events of the same type get queued in the current trigger
+    * query level, they'll go into new transition tables.
+    */
+    LocTriggerData.tg_oldtable = LocTriggerData.tg_newtable = NULL;
+	LocTriggerData.tg_oldtable = transition_capture->tcs_private->old_tuplestore;
+	LocTriggerData.tg_newtable = transition_capture->tcs_private->new_tuplestore;
+
+	for (i = 0; i < trigdesc->numtriggers; i++)
+	{
+		Trigger    *trigger = &trigdesc->triggers[i];
+		HeapTuple	newtuple;
+
+		if (!TRIGGER_TYPE_MATCHES(trigger->tgtype,
+								  TRIGGER_TYPE_STATEMENT,
+								  TRIGGER_TYPE_INSTEAD,
+								  TRIGGER_TYPE_DELETE))
+			continue;
+		if (!TriggerEnabled(estate, relinfo, trigger, LocTriggerData.tg_event,
+							NULL, NULL, NULL))
+			continue;
+
+		LocTriggerData.tg_trigger = trigger;
+		newtuple = ExecCallTriggerFunc(&LocTriggerData,
+									   i,
+									   relinfo->ri_TrigFunctions,
+									   relinfo->ri_TrigInstrument,
+									   GetPerTupleMemoryContext(estate));
+
+		if (newtuple)
+			ereport(ERROR,
+					(errcode(ERRCODE_E_R_I_E_TRIGGER_PROTOCOL_VIOLATED),
+					 errmsg("INSTEAD STATEMENT trigger cannot return a value")));
+	}
+	return IOT_FIRED;
+}
 
 /*
  * afterTriggerMarkEvents()
@@ -4858,6 +4895,21 @@ MakeTransitionCaptureState(TriggerDesc *trigdesc, Oid relid, CmdType cmdType)
 	return state;
 }
 
+bool
+isTsqlInsteadofTriggerExecution(EState *estate, ResultRelInfo *relinfo, TriggerEvent event)
+{
+	TriggerDesc *trigdesc;
+	int i;
+	trigdesc = relinfo->ri_TrigDesc;
+	for (i = 0; i < trigdesc->numtriggers; i++)
+	{
+		Trigger *trigger = &trigdesc->triggers[i];
+		if (TriggerEnabled(estate, relinfo, trigger, event, NULL, NULL, NULL)){
+			return true;
+		}
+	}
+	return false;
+}
 
 /* ----------
  * AfterTriggerBeginXact()

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -1706,6 +1706,15 @@ ExecUpdate(ModifyTableState *mtstate,
 	if (resultRelInfo->ri_projectReturning && sql_dialect == SQL_DIALECT_TSQL)
 		rslot = ExecProcessReturning(resultRelInfo, slot, planSlot);
 
+	if (resultRelInfo->ri_TrigDesc &&
+		resultRelInfo->ri_TrigDesc->trig_update_instead_statement &&
+		sql_dialect == SQL_DIALECT_TSQL && 
+		isTsqlInsteadofTriggerExecution(estate, resultRelInfo, TRIGGER_EVENT_INSTEAD))
+	{
+		ExecIRUpdateTriggersTSQL(estate, resultRelInfo, tupleid, oldtuple, slot, recheckIndexes, mtstate->mt_transition_capture);
+		return NULL;
+	}
+
 	/* INSTEAD OF ROW UPDATE Triggers */
 	if (resultRelInfo->ri_TrigDesc &&
 		resultRelInfo->ri_TrigDesc->trig_update_instead_row)
@@ -2314,10 +2323,10 @@ fireISTriggers(ModifyTableState *node)
 			ret = ExecISInsertTriggers(node->ps.state, resultRelInfo, node->mt_transition_capture);
 			if (plan->onConflictAction == ONCONFLICT_UPDATE)
 				ret = ExecISUpdateTriggers(node->ps.state,
-									 resultRelInfo);
+									 resultRelInfo, node->mt_transition_capture);
 			break;
 		case CMD_UPDATE:
-			ret = ExecISUpdateTriggers(node->ps.state, resultRelInfo);
+			ret = ExecISUpdateTriggers(node->ps.state, resultRelInfo, node->mt_transition_capture);
 			break;
 		case CMD_DELETE:
 			ret = ExecISDeleteTriggers(node->ps.state, resultRelInfo, node->mt_transition_capture);

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -1164,6 +1164,15 @@ ExecDelete(ModifyTableState *mtstate,
 		ExecClearTuple(slot);
 	}
 
+	if (resultRelInfo->ri_TrigDesc &&
+		resultRelInfo->ri_TrigDesc->trig_delete_instead_statement &&
+		sql_dialect == SQL_DIALECT_TSQL && 
+		isTsqlInsteadofTriggerExecution(estate, resultRelInfo, TRIGGER_EVENT_DELETE))
+	{
+		ExecIRDeleteTriggersTSQL(estate, resultRelInfo, tupleid, oldtuple, mtstate->mt_transition_capture);
+		return NULL;
+	}
+
 	/* INSTEAD OF ROW DELETE Triggers */
 	if (resultRelInfo->ri_TrigDesc &&
 		resultRelInfo->ri_TrigDesc->trig_delete_instead_row)
@@ -2311,7 +2320,7 @@ fireISTriggers(ModifyTableState *node)
 			ret = ExecISUpdateTriggers(node->ps.state, resultRelInfo);
 			break;
 		case CMD_DELETE:
-			ret = ExecISDeleteTriggers(node->ps.state, resultRelInfo);
+			ret = ExecISDeleteTriggers(node->ps.state, resultRelInfo, node->mt_transition_capture);
 			break;
 		default:
 			elog(ERROR, "unknown operation");

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -905,7 +905,8 @@ transformInsertStmt(ParseState *pstate, InsertStmt *stmt)
 	}
 
 	if (post_transform_insert_row_hook)
-		(*post_transform_insert_row_hook) (icolumns, exprList);
+		(*post_transform_insert_row_hook) (icolumns, exprList, 
+						RelationGetRelid(pstate->p_target_relation));
 
 	/*
 	 * Generate query's target list using the computed list of expressions.

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -15237,10 +15237,11 @@ qualified_name:
 						case 2:
 							$$->catalogname = downcaseIfTsqlAndCaseInsensitive($1);
 							$$->schemaname = downcaseIfTsqlAndCaseInsensitive(strVal(linitial($2)));
-							/* TSQL temp table names. Schema name is allowed but ignored for temp tables.*/
+							/* TSQL temp table names. Catalog and schema names allowed but ignored for temp tables.*/
 							if (strncmp(strVal(lsecond($2)), "#", 1) == 0 || strncmp(strVal(lsecond($2)), "##", 2) == 0)
 							{
 								$$->relpersistence = RELPERSISTENCE_TEMP;
+								$$->catalogname = NULL;
 								$$->schemaname = NULL;
 							}
 							$$->relname = downcaseIfTsqlAndCaseInsensitive(strVal(lsecond($2)));

--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -323,7 +323,17 @@ coerce_type(ParseState *pstate, Node *node,
 			/*
 			 * T-SQL has different rules for string literal datatype coercions
 			 */
-			(*coerce_string_literal_hook) (newcon, DatumGetCString(con->constvalue), ccontext);
+			result = (*coerce_string_literal_hook) (&pcbstate, targetTypeId,
+												  targetTypeMod, baseTypeMod,
+												  newcon, DatumGetCString(con->constvalue),
+												  ccontext, cformat, location);
+			if (result) /* runtimer error function returned */
+				return result;
+
+			/*
+			 * If the result is NULL, the newcon should be already updated properly.
+			 * Keep advancing the code.
+			 */
 		}
 		else
 		{

--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -864,6 +864,14 @@ transformColumnRef(ParseState *pstate, ColumnRef *cref)
 		}
 	}
 
+	if (pstate->p_column_ref_overwrite_hook && sql_dialect == SQL_DIALECT_TSQL)
+	{
+		Node *hookresult = pstate->p_column_ref_overwrite_hook(pstate, cref, node);
+
+		if (hookresult)
+			node = hookresult;
+	}
+
 	return node;
 }
 

--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -15,6 +15,7 @@
 
 #include "postgres.h"
 
+#include "catalog/namespace.h"
 #include "catalog/pg_type.h"
 #include "commands/dbcommands.h"
 #include "miscadmin.h"
@@ -84,6 +85,7 @@ static Expr *make_distinct_op(ParseState *pstate, List *opname,
 							  Node *ltree, Node *rtree, int location);
 static Node *make_nulltest_from_distinct(ParseState *pstate,
 										 A_Expr *distincta, Node *arg);
+static List *ExpandChecksumStar(ParseState *pstate, FuncCall *fn, int location);
 
 lookup_param_hook_type lookup_param_hook = NULL;
 /*
@@ -1416,6 +1418,8 @@ transformFuncCall(ParseState *pstate, FuncCall *fn)
 	Node	   *last_srf = pstate->p_last_srf;
 	List	   *targs;
 	ListCell   *args;
+      char *schemaname;
+      char *functionname;
 
 	/* Transform the list of arguments ... */
 	targs = NIL;
@@ -1444,6 +1448,20 @@ transformFuncCall(ParseState *pstate, FuncCall *fn)
 												 EXPR_KIND_ORDER_BY));
 		}
 	}
+        
+      DeconstructQualifiedName(fn->funcname, &schemaname, &functionname);
+
+      /* Firstly, we check whether the schema name is null or 'sys'.
+       * When the function name is checksum, we check if the argument is '*',
+       * if yes, then we traverse the table and get the column names from the
+       * table. We replace the argument '*' with the list of column names.
+       */
+
+      if (!schemaname || (strlen(schemaname) == 3 && strncmp(schemaname, "sys", 3) == 0))
+              if (strlen(functionname) == 8 &&
+                          strncmp(functionname, "checksum", 8) == 0 &&
+                          fn->agg_star == true)
+                      targs = ExpandChecksumStar(pstate, fn, fn->location);
 
 	/* ... and hand off to ParseFuncOrColumn */
 	return ParseFuncOrColumn(pstate,
@@ -3178,4 +3196,19 @@ ParseExprKindName(ParseExprKind exprKind)
 			 */
 	}
 	return "unrecognized expression kind";
+}
+
+// Expands checksum(*) to checksum(c1, c2, ...)
+List *
+ExpandChecksumStar(ParseState *pstate, FuncCall *fn, int location)
+{
+        List      *target = NIL;
+        ListCell   *lc;
+        foreach(lc, pstate->p_namespace)
+        {
+                ParseNamespaceItem *nsitem = (ParseNamespaceItem *) lfirst(lc);
+                target = list_concat(target, expandNSItemVars(nsitem, 0, location, NULL));
+        }
+        fn->agg_star = false;
+        return target;
 }

--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -2189,6 +2189,19 @@ transformCoalesceExpr(ParseState *pstate, CoalesceExpr *c)
 		newe = coerce_to_common_type(pstate, e,
 									 newc->coalescetype,
 									 "COALESCE");
+
+		/*
+		 * If we get a RelabelType node, we would need to adjust its typmod
+		 * as coerce_to_common_type function does not do length-coercion.
+		 * This is required when coercing a domain to its base type and since
+		 * domains are allowed to have typmod in TSQL mode, we should preserve
+		 * the typmod in this case.
+		 */
+		if (sql_dialect == SQL_DIALECT_TSQL && IsA(newe, RelabelType))
+		{
+			if (exprTypmod(newe) != exprTypmod(e))
+				((RelabelType *)newe)->resulttypmod = exprTypmod(e);
+		}
 		newcoercedargs = lappend(newcoercedargs, newe);
 	}
 

--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -1069,6 +1069,21 @@ func_select_candidate(int nargs,
 	}
 
 	/*
+	 * T-SQL allows bidirectional implcit castings (implicit downcasting with precision loss)
+	 * This behavior may cause to find too many multiple candidates.
+	 * If we resolve all the unknwon types but still too many candidates,
+	 * let's try to choose the best candidate by T-SQL precedence rule.
+	 */
+	if (nunknowns == 0 &&
+	    sql_dialect == SQL_DIALECT_TSQL &&
+	    func_select_candidate_hook != NULL)
+	{
+		last_candidate = func_select_candidate_hook(nargs, input_base_typeids, candidates, false);
+		if (last_candidate)
+			return last_candidate; /* last_candiate->next should be already NULL */
+	}
+
+	/*
 	 * Run through all candidates and keep those with the most matches on
 	 * exact types. Keep all candidates if none match.
 	 */
@@ -1160,21 +1175,6 @@ func_select_candidate(int nargs,
 
 	if (ncandidates == 1)
 		return candidates;
-
-	/*
-	 * T-SQL allows bidirectional implcit castings (implicit downcasting with precision loss)
-	 * This behavior may cause to find too many multiple candidates.
-	 * If we resolve all the unknwon types but still too many candidates,
-	 * let's try to choose the best candidate by T-SQL precedence rule.
-	 */
-	if (nunknowns == 0 &&
-	    sql_dialect == SQL_DIALECT_TSQL &&
-	    func_select_candidate_hook != NULL)
-	{
-		last_candidate = func_select_candidate_hook(nargs, input_base_typeids, candidates, false);
-		if (last_candidate)
-			return last_candidate; /* last_candiate->next should be already NULL */
-	}
 
 	/*
 	 * Still too many candidates?  Try assigning types for the unknown inputs.

--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -37,6 +37,7 @@
 
 func_select_candidate_hook_type func_select_candidate_hook = NULL;
 make_fn_arguments_from_stored_proc_probin_hook_type make_fn_arguments_from_stored_proc_probin_hook = NULL;
+report_proc_not_found_error_hook_type report_proc_not_found_error_hook = NULL;
 /* Possible error codes from LookupFuncNameInternal */
 typedef enum
 {
@@ -600,6 +601,9 @@ ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
 			if (retval)
 				return retval;
 		}
+
+		if (sql_dialect == SQL_DIALECT_TSQL && report_proc_not_found_error_hook)
+			report_proc_not_found_error_hook(funcname, argnames, nargs, pstate, location, proc_call);
 
 		/*
 		 * No function, and no column either.  Since we're dealing with

--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -1078,7 +1078,7 @@ func_select_candidate(int nargs,
 	    sql_dialect == SQL_DIALECT_TSQL &&
 	    func_select_candidate_hook != NULL)
 	{
-		last_candidate = func_select_candidate_hook(nargs, input_base_typeids, candidates, false);
+		last_candidate = func_select_candidate_hook(nargs, input_typeids, candidates, false);
 		if (last_candidate)
 			return last_candidate; /* last_candiate->next should be already NULL */
 	}
@@ -1269,7 +1269,7 @@ func_select_candidate(int nargs,
 		sql_dialect == SQL_DIALECT_TSQL &&
 		func_select_candidate_hook != NULL)
 	{
-		last_candidate = func_select_candidate_hook(nargs, input_base_typeids, candidates, true);
+		last_candidate = func_select_candidate_hook(nargs, input_typeids, candidates, true);
 		if (last_candidate)
 			return last_candidate; /* last_candiate->next should be already NULL */
 	}

--- a/src/backend/parser/parse_node.c
+++ b/src/backend/parser/parse_node.c
@@ -67,6 +67,7 @@ make_parsestate(ParseState *parentParseState)
 		pstate->p_pre_columnref_hook = parentParseState->p_pre_columnref_hook;
 		pstate->p_post_columnref_hook = parentParseState->p_post_columnref_hook;
 		pstate->p_post_expand_star_hook = parentParseState->p_post_expand_star_hook;
+		pstate->p_column_ref_overwrite_hook = parentParseState->p_column_ref_overwrite_hook;
 		pstate->p_paramref_hook = parentParseState->p_paramref_hook;
 		pstate->p_coerce_param_hook = parentParseState->p_coerce_param_hook;
 		pstate->p_ref_hook_state = parentParseState->p_ref_hook_state;

--- a/src/backend/parser/parse_node.c
+++ b/src/backend/parser/parse_node.c
@@ -66,6 +66,7 @@ make_parsestate(ParseState *parentParseState)
 		/* all hooks are copied from parent */
 		pstate->p_pre_columnref_hook = parentParseState->p_pre_columnref_hook;
 		pstate->p_post_columnref_hook = parentParseState->p_post_columnref_hook;
+		pstate->p_post_expand_star_hook = parentParseState->p_post_expand_star_hook;
 		pstate->p_paramref_hook = parentParseState->p_paramref_hook;
 		pstate->p_coerce_param_hook = parentParseState->p_coerce_param_hook;
 		pstate->p_ref_hook_state = parentParseState->p_ref_hook_state;

--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -58,6 +58,8 @@ typedef struct
 
 #define MAX_FUZZY_DISTANCE				3
 
+find_attr_by_name_from_relation_hook_type
+	find_attr_by_name_from_relation_hook = NULL;
 
 static ParseNamespaceItem *scanNameSpaceForRefname(ParseState *pstate,
 												   const char *refname,
@@ -3419,6 +3421,15 @@ int
 attnameAttNum(Relation rd, const char *attname, bool sysColOK)
 {
 	int			i;
+
+	/*
+	 * In T-SQL, we need to compare downcased attribute names
+	 * in addition to the original names
+	 */
+	if (sql_dialect == SQL_DIALECT_TSQL
+		&& pltsql_case_insensitive_identifiers
+		&& find_attr_by_name_from_relation_hook)
+		return (*find_attr_by_name_from_relation_hook)(rd, attname, sysColOK);
 
 	for (i = 0; i < RelationGetNumberOfAttributes(rd); i++)
 	{

--- a/src/backend/parser/parse_target.c
+++ b/src/backend/parser/parse_target.c
@@ -1135,6 +1135,7 @@ static List *
 ExpandColumnRefStar(ParseState *pstate, ColumnRef *cref,
 					bool make_target_entry)
 {
+	List	   *output;
 	List	   *fields = cref->fields;
 	int			numnames = list_length(fields);
 
@@ -1149,6 +1150,17 @@ ExpandColumnRefStar(ParseState *pstate, ColumnRef *cref,
 		 * need not handle the make_target_entry==false case here.
 		 */
 		Assert(make_target_entry);
+
+		/*
+		 * In TSQL mode, we want to preserve original case in SELECT * statements
+		 */
+		if (sql_dialect == SQL_DIALECT_TSQL && pstate->p_post_expand_star_hook)
+		{
+			output = ExpandAllTables(pstate, cref->location);
+			pstate->p_post_expand_star_hook(pstate, cref, output);
+			return output;
+		}
+
 		return ExpandAllTables(pstate, cref->location);
 	}
 	else

--- a/src/backend/parser/parse_target.c
+++ b/src/backend/parser/parse_target.c
@@ -1298,6 +1298,16 @@ ExpandColumnRefStar(ParseState *pstate, ColumnRef *cref,
 		}
 
 		/*
+		 * In TSQL mode, we want to preserve original case in SELECT relation.* statements
+		 */
+		if (make_target_entry && sql_dialect == SQL_DIALECT_TSQL && pstate->p_post_expand_star_hook)
+		{
+			output = ExpandSingleTable(pstate, nsitem, levels_up, cref->location,
+										make_target_entry);
+			pstate->p_post_expand_star_hook(pstate, cref, output);
+			return output;
+		}
+		/*
 		 * OK, expand the nsitem into fields.
 		 */
 		return ExpandSingleTable(pstate, nsitem, levels_up, cref->location,

--- a/src/backend/parser/scan.l
+++ b/src/backend/parser/scan.l
@@ -150,6 +150,15 @@ extern void core_yyset_column(int column_no, yyscan_t yyscanner);
 int sql_dialect = SQL_DIALECT_PG;
 bool pltsql_case_insensitive_identifiers = true;
 
+/* Some extensions, e.g., Babelfish,
+ * may include original PG lexer in addition to their own lexer.
+ * This macro allows to add additional logics only at the beginning of PG lexer.
+ * So you can undef the macro in your own lexer-related extension
+ * to exclude the PG-specific logic.
+ */
+#define PG_YYLEX
+core_yylex_hook_type core_yylex_hook = NULL;
+
 /* Please note that the following line will be replaced with the contents of given file name even if with starting with a comment */
 /*$$include "scan-tsql-prologue.l.h"*/
 %}
@@ -427,6 +436,18 @@ other			.
 /*$$include "scan-tsql-decl.l"*/
 
 %%
+%{
+#ifdef PG_YYLEX
+	if (sql_dialect == SQL_DIALECT_TSQL && core_yylex_hook)
+	{
+		/* This allows other extensions such as pg_stat_statements
+		 * call TSQL-specific yylex function seamlessly even
+		 * when they just call PG's core_yylex(...).
+		 */
+		return core_yylex_hook(yylval_param, yylloc_param, yyscanner);
+	}
+#endif
+%}
 
  /* Please note that the following line will be replaced with the contents of given file name even if with starting with a comment */
  /*$$include "scan-tsql-rule.l"*/

--- a/src/backend/postmaster/pgstat.c
+++ b/src/backend/postmaster/pgstat.c
@@ -363,6 +363,8 @@ static void pgstat_recv_replslot(PgStat_MsgReplSlot *msg, int len);
 static void pgstat_recv_tempfile(PgStat_MsgTempFile *msg, int len);
 
 pre_function_call_hook_type pre_function_call_hook = NULL;
+invalidate_stat_table_hook_type invalidate_stat_table_hook = NULL;
+guc_newval_hook_type guc_newval_hook = NULL;
 
 /* ------------------------------------------------------------
  * Public functions called from postmaster follow
@@ -4761,6 +4763,13 @@ pgstat_clear_snapshot(void)
 	 * forward the reset request.
 	 */
 	pgstat_clear_backend_activity_snapshot();
+
+	/*
+	 * Signal babelfishpg_tds extension (if loaded) to
+	 * mark the local TDS status table as invalid too
+	 */
+	if (invalidate_stat_table_hook)
+		(*invalidate_stat_table_hook)();
 }
 
 

--- a/src/backend/utils/adt/jsonpath_exec.c
+++ b/src/backend/utils/adt/jsonpath_exec.c
@@ -64,6 +64,7 @@
 #include "funcapi.h"
 #include "lib/stringinfo.h"
 #include "miscadmin.h"
+#include "parser/parser.h"
 #include "regex/regex.h"
 #include "utils/builtins.h"
 #include "utils/date.h"
@@ -723,6 +724,16 @@ executeItemOptUnwrapTarget(JsonPathExecContext *cxt, JsonPathItem *jsp,
 				int			size = JsonbArraySize(jb);
 				bool		singleton = size < 0;
 				bool		hasNext = jspGetNext(jsp, &elem);
+
+				if (JsonbType(jb) != jbvArray && sql_dialect == SQL_DIALECT_TSQL)
+				{
+					if (jspIgnoreStructuralErrors(cxt))
+						break;
+					else
+						RETURN_ERROR(ereport(ERROR,
+									(errcode(ERRCODE_SQL_JSON_ARRAY_NOT_FOUND),
+									errmsg("Property cannot be found on the specified JSON path"))));
+				}
 
 				if (singleton)
 					size = 1;

--- a/src/backend/utils/adt/like.c
+++ b/src/backend/utils/adt/like.c
@@ -22,6 +22,7 @@
 #include "catalog/pg_collation.h"
 #include "mb/pg_wchar.h"
 #include "miscadmin.h"
+#include "parser/parser.h"
 #include "utils/builtins.h"
 #include "utils/pg_locale.h"
 

--- a/src/backend/utils/adt/like_match.c
+++ b/src/backend/utils/adt/like_match.c
@@ -220,6 +220,20 @@ MatchText(const char *t, int tlen, const char *p, int plen,
 		NextByte(p, plen);
 	}
 
+	if (tlen > 0 && sql_dialect == SQL_DIALECT_TSQL)
+	{
+		/* End of pattern, but not of text.
+		 *
+		 * In T-SQL, trailing blanks, in the text to which the pattern is matched, are ignored.
+		 * For example, a text 'abc ' (abc followed by a single space) should be matched
+		 * by a pattern 'abc' (abc without a space).
+		 */
+		while (tlen > 0 && *t == ' ')
+			NextByte(t, tlen);
+		if (tlen <= 0)
+			return LIKE_TRUE;
+	}
+
 	if (tlen > 0)
 		return LIKE_FALSE;		/* end of pattern, but not of text */
 

--- a/src/backend/utils/adt/pgstatfuncs.c
+++ b/src/backend/utils/adt/pgstatfuncs.c
@@ -32,9 +32,16 @@
 #include "utils/inet.h"
 #include "utils/timestamp.h"
 
+tsql_has_pgstat_permissions_hook_type tsql_has_pgstat_permissions_hook = NULL;
+
 #define UINT32_ACCESS_ONCE(var)		 ((uint32)(*((volatile uint32 *)&(var))))
 
-#define HAS_PGSTAT_PERMISSIONS(role)	 (is_member_of_role(GetUserId(), ROLE_PG_READ_ALL_STATS) || has_privs_of_role(GetUserId(), role))
+/*
+ * Additionally if the babelfishpg_tsql extension is loaded, and if the current
+ * session user is sysadmin of babelfish db or has the privileges of a role that
+ * has permissions to view pg stats, then such a user can also view pg stats.
+ */
+#define HAS_PGSTAT_PERMISSIONS(role)	 (is_member_of_role(GetUserId(), ROLE_PG_READ_ALL_STATS) || has_privs_of_role(GetUserId(), role) || (tsql_has_pgstat_permissions_hook ? (*tsql_has_pgstat_permissions_hook)(role) : false))
 
 /* Global bgwriter statistics, from bgwriter.c */
 extern PgStat_MsgBgWriter bgwriterStats;

--- a/src/backend/utils/cache/inval.c
+++ b/src/backend/utils/cache/inval.c
@@ -1153,11 +1153,11 @@ CacheInvalidateHeapTuple(Relation relation,
 		return;
 
 	/*
-	 * We only need to worry about invalidation for tuples that are in system
-	 * catalogs; user-relation tuples are never in catcaches and can't affect
-	 * the relcache either.
+	 * We only need to worry about invalidation for tuples that are either in
+       * system catalogs or in babelfish catalogs ; user-relation tuples are
+       * never in catcaches and can't affect the relcache either.
 	 */
-	if (!IsCatalogRelation(relation))
+	if (!IsCatalogRelation(relation) && (!IsExtendedCatalogHook || !IsExtendedCatalogHook(relation->rd_id)))
 		return;
 
 	/*

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -181,6 +181,8 @@ static int	syslog_facility = LOG_LOCAL0;
 static int	syslog_facility = 0;
 #endif
 
+static void assign_lock_timeout(int newval, void *extra);
+static void assign_default_transaction_isolation(int newval, void *extra);
 static void assign_syslog_facility(int newval, void *extra);
 static void assign_syslog_ident(const char *newval, void *extra);
 static void assign_session_replication_role(int newval, void *extra);
@@ -2595,7 +2597,7 @@ static struct config_int ConfigureNamesInt[] =
 		},
 		&LockTimeout,
 		0, 0, INT_MAX,
-		NULL, NULL, NULL
+		NULL, assign_lock_timeout, NULL
 	},
 
 	{
@@ -4689,7 +4691,7 @@ static struct config_enum ConfigureNamesEnum[] =
 		},
 		&DefaultXactIsoLevel,
 		XACT_READ_COMMITTED, isolation_level_options,
-		NULL, NULL, NULL
+		NULL, assign_default_transaction_isolation, NULL
 	},
 
 	{
@@ -11747,6 +11749,20 @@ static void
 assign_log_destination(const char *newval, void *extra)
 {
 	Log_destination = *((int *) extra);
+}
+
+static void
+assign_lock_timeout(int newval, void *extra)
+{
+	if (guc_newval_hook)
+		(*guc_newval_hook)("lock_timeout", false, NULL, newval);
+}
+
+static void
+assign_default_transaction_isolation(int newval, void *extra)
+{
+	if (guc_newval_hook)
+		(*guc_newval_hook)("default_transaction_isolation", false, NULL, newval);
 }
 
 static void

--- a/src/include/catalog/heap.h
+++ b/src/include/catalog/heap.h
@@ -30,6 +30,7 @@ typedef struct RawColumnDefault
 	Node	   *raw_default;	/* default value (untransformed parse tree) */
 	bool		missingMode;	/* true if part of add column processing */
 	char		generated;		/* attgenerated setting */
+	bool		hasCollClause;	/* true if column has explicit COLLATE clause */
 } RawColumnDefault;
 
 typedef struct CookedConstraint

--- a/src/include/commands/tablecmds.h
+++ b/src/include/commands/tablecmds.h
@@ -113,4 +113,9 @@ extern PGDLLIMPORT InvokePreAddConstraintsHook_type InvokePreAddConstraintsHook;
 typedef bool (*check_extended_attoptions_hook_type) (Node *options);
 extern check_extended_attoptions_hook_type check_extended_attoptions_hook;
 
+typedef int (*find_attr_by_name_from_column_def_list_hook_type) (
+	const char *attributeName, List *schema);
+extern PGDLLIMPORT find_attr_by_name_from_column_def_list_hook_type
+	find_attr_by_name_from_column_def_list_hook;
+
 #endif							/* TABLECMDS_H */

--- a/src/include/commands/trigger.h
+++ b/src/include/commands/trigger.h
@@ -185,7 +185,8 @@ extern void ExecASInsertTriggers(EState *estate,
 								 ResultRelInfo *relinfo,
 								 TransitionCaptureState *transition_capture);
 extern IOTState ExecISInsertTriggers(EState *estate,
-								ResultRelInfo *relinfo);
+								ResultRelInfo *relinfo,
+								TransitionCaptureState *transition_capture);
 extern bool ExecBRInsertTriggers(EState *estate,
 								 ResultRelInfo *relinfo,
 								 TupleTableSlot *slot);
@@ -193,6 +194,10 @@ extern void ExecARInsertTriggers(EState *estate,
 								 ResultRelInfo *relinfo,
 								 TupleTableSlot *slot,
 								 List *recheckIndexes,
+								 TransitionCaptureState *transition_capture);
+extern void ExecIRInsertTriggersTSQL(EState *estate,
+								 ResultRelInfo *relinfo,
+								 TupleTableSlot *slot, 
 								 TransitionCaptureState *transition_capture);
 extern bool ExecIRInsertTriggers(EState *estate,
 								 ResultRelInfo *relinfo,

--- a/src/include/commands/trigger.h
+++ b/src/include/commands/trigger.h
@@ -204,6 +204,13 @@ extern void ExecIRDeleteTriggersTSQL(EState *estate,
 								 ItemPointer tupleid,
 								 HeapTuple fdw_trigtuple,
 								 TransitionCaptureState *transition_capture);
+extern void ExecIRUpdateTriggersTSQL(EState *estate,
+								 ResultRelInfo *relinfo,
+								 ItemPointer tupleid,
+								 HeapTuple fdw_trigtuple,
+								 TupleTableSlot *newslot,
+					 			 List *recheckIndexes,
+								 TransitionCaptureState *transition_capture);
 extern bool ExecIRInsertTriggers(EState *estate,
 								 ResultRelInfo *relinfo,
 								 TupleTableSlot *slot);
@@ -235,7 +242,8 @@ extern void ExecASUpdateTriggers(EState *estate,
 								 ResultRelInfo *relinfo,
 								 TransitionCaptureState *transition_capture);
 extern IOTState ExecISUpdateTriggers(EState *estate,
-								ResultRelInfo *relinfo);
+								ResultRelInfo *relinfo,
+								TransitionCaptureState *transition_capture);
 extern bool ExecBRUpdateTriggers(EState *estate,
 								 EPQState *epqstate,
 								 ResultRelInfo *relinfo,

--- a/src/include/commands/trigger.h
+++ b/src/include/commands/trigger.h
@@ -199,6 +199,11 @@ extern void ExecIRInsertTriggersTSQL(EState *estate,
 								 ResultRelInfo *relinfo,
 								 TupleTableSlot *slot, 
 								 TransitionCaptureState *transition_capture);
+extern void ExecIRDeleteTriggersTSQL(EState *estate,
+								 ResultRelInfo *relinfo,
+								 ItemPointer tupleid,
+								 HeapTuple fdw_trigtuple,
+								 TransitionCaptureState *transition_capture);
 extern bool ExecIRInsertTriggers(EState *estate,
 								 ResultRelInfo *relinfo,
 								 TupleTableSlot *slot);
@@ -208,7 +213,8 @@ extern void ExecASDeleteTriggers(EState *estate,
 								 ResultRelInfo *relinfo,
 								 TransitionCaptureState *transition_capture);
 extern IOTState ExecISDeleteTriggers(EState *estate,
-								ResultRelInfo *relinfo);
+								ResultRelInfo *relinfo,
+								TransitionCaptureState *transition_capture);
 extern bool ExecBRDeleteTriggers(EState *estate,
 								 EPQState *epqstate,
 								 ResultRelInfo *relinfo,
@@ -251,6 +257,8 @@ extern void ExecBSTruncateTriggers(EState *estate,
 								   ResultRelInfo *relinfo);
 extern void ExecASTruncateTriggers(EState *estate,
 								   ResultRelInfo *relinfo);
+
+extern bool isTsqlInsteadofTriggerExecution(EState *estate, ResultRelInfo *relinfo, TriggerEvent event);
 
 extern void AfterTriggerBeginXact(void);
 extern void AfterTriggerBeginQuery(void);

--- a/src/include/parser/analyze.h
+++ b/src/include/parser/analyze.h
@@ -43,7 +43,7 @@ typedef bool (*get_output_clause_status_hook_type) (void);
 extern PGDLLIMPORT get_output_clause_status_hook_type get_output_clause_status_hook;
 
 /* Hook for plugins to get control after an insert row transform */
-typedef void (*post_transform_insert_row_hook_type) (List *icolumns, List *exprList);
+typedef void (*post_transform_insert_row_hook_type) (List *icolumns, List *exprList, Oid relid);
 extern PGDLLIMPORT post_transform_insert_row_hook_type post_transform_insert_row_hook;
 
 extern Query *parse_analyze(RawStmt *parseTree, const char *sourceText,

--- a/src/include/parser/parse_coerce.h
+++ b/src/include/parser/parse_coerce.h
@@ -112,7 +112,12 @@ typedef CoercionPathType (*find_coercion_pathway_hook_type) (Oid sourceTypeId,
 typedef bool (*determine_datatype_precedence_hook_type) (Oid typeId1, Oid typeId2);
 
 /*
- * Other than PG, T-SQL may forbid casting from string literal to certain datatypes (i.e. binary, varbinary)
+ * T-SQL has different rules for string literal datatype coercions
+ */
+typedef void (*coerce_string_literal_hook_type) (Const *newcon, char *value, CoercionContext ccontext);
+
+/*
+ * T-SQL may forbid casting from string literal to certain datatypes (i.e. binary, varbinary)
  */
 typedef void (*validate_implicit_conversion_from_string_literal_hook_type) (Const *newcon, const char *value);
 

--- a/src/include/parser/parse_coerce.h
+++ b/src/include/parser/parse_coerce.h
@@ -111,4 +111,9 @@ typedef CoercionPathType (*find_coercion_pathway_hook_type) (Oid sourceTypeId,
  */
 typedef bool (*determine_datatype_precedence_hook_type) (Oid typeId1, Oid typeId2);
 
+/*
+ * Other than PG, T-SQL may forbid casting from string literal to certain datatypes (i.e. binary, varbinary)
+ */
+typedef void (*validate_implicit_conversion_from_string_literal_hook_type) (Const *newcon, const char *value);
+
 #endif							/* PARSE_COERCE_H */

--- a/src/include/parser/parse_coerce.h
+++ b/src/include/parser/parse_coerce.h
@@ -114,7 +114,15 @@ typedef bool (*determine_datatype_precedence_hook_type) (Oid typeId1, Oid typeId
 /*
  * T-SQL has different rules for string literal datatype coercions
  */
-typedef void (*coerce_string_literal_hook_type) (Const *newcon, char *value, CoercionContext ccontext);
+typedef Node *(*coerce_string_literal_hook_type) (ParseCallbackState *pcbstate,
+												  Oid targetTypeId,
+												  int32 targetTypeMod,
+												  int32 baseTypeMod,
+												  Const *newcon,
+												  char *value,
+												  CoercionContext ccontext,
+												  CoercionForm cformat,
+												  int location);
 
 /*
  * T-SQL may forbid casting from string literal to certain datatypes (i.e. binary, varbinary)

--- a/src/include/parser/parse_func.h
+++ b/src/include/parser/parse_func.h
@@ -78,5 +78,7 @@ typedef FuncCandidateList (*func_select_candidate_hook_type) (int nargs, Oid *in
 /* Hook interface to process function arguments using probin */
 typedef void (*make_fn_arguments_from_stored_proc_probin_hook_type)(ParseState *pstate,List *fargs,Oid *actual_arg_types,Oid *declared_arg_types,Oid funcid);
 extern PGDLLIMPORT make_fn_arguments_from_stored_proc_probin_hook_type make_fn_arguments_from_stored_proc_probin_hook;
+typedef void (*report_proc_not_found_error_hook_type) (List *names, List *argnames, int nargs, ParseState *pstate, int location, bool proc_call);
+extern PGDLLIMPORT report_proc_not_found_error_hook_type report_proc_not_found_error_hook;
 
 #endif							/* PARSE_FUNC_H */

--- a/src/include/parser/parse_node.h
+++ b/src/include/parser/parse_node.h
@@ -89,6 +89,7 @@ typedef enum ParseExprKind
 typedef Node *(*PreParseColumnRefHook) (ParseState *pstate, ColumnRef *cref);
 typedef Node *(*PostParseColumnRefHook) (ParseState *pstate, ColumnRef *cref, Node *var);
 typedef void (*PostParseExpandStarHook) (ParseState *pstate, ColumnRef *cref, List *l);
+typedef Node *(*ColumnRefOverwriteHook) (ParseState *pstate, ColumnRef *cref, Node *var);
 typedef Node *(*ParseParamRefHook) (ParseState *pstate, ParamRef *pref);
 typedef Node *(*CoerceParamHook) (ParseState *pstate, Param *param,
 								  Oid targetTypeId, int32 targetTypeMod,
@@ -221,6 +222,7 @@ struct ParseState
 	PreParseColumnRefHook p_pre_columnref_hook;
 	PostParseColumnRefHook p_post_columnref_hook;
 	PostParseExpandStarHook p_post_expand_star_hook;
+	ColumnRefOverwriteHook p_column_ref_overwrite_hook;
 	ParseParamRefHook p_paramref_hook;
 	CoerceParamHook p_coerce_param_hook;
 	void	   *p_ref_hook_state;	/* common passthrough link for above */

--- a/src/include/parser/parse_node.h
+++ b/src/include/parser/parse_node.h
@@ -88,6 +88,7 @@ typedef enum ParseExprKind
  */
 typedef Node *(*PreParseColumnRefHook) (ParseState *pstate, ColumnRef *cref);
 typedef Node *(*PostParseColumnRefHook) (ParseState *pstate, ColumnRef *cref, Node *var);
+typedef void (*PostParseExpandStarHook) (ParseState *pstate, ColumnRef *cref, List *l);
 typedef Node *(*ParseParamRefHook) (ParseState *pstate, ParamRef *pref);
 typedef Node *(*CoerceParamHook) (ParseState *pstate, Param *param,
 								  Oid targetTypeId, int32 targetTypeMod,
@@ -219,6 +220,7 @@ struct ParseState
 	 */
 	PreParseColumnRefHook p_pre_columnref_hook;
 	PostParseColumnRefHook p_post_columnref_hook;
+	PostParseExpandStarHook p_post_expand_star_hook;
 	ParseParamRefHook p_paramref_hook;
 	CoerceParamHook p_coerce_param_hook;
 	void	   *p_ref_hook_state;	/* common passthrough link for above */

--- a/src/include/parser/parse_relation.h
+++ b/src/include/parser/parse_relation.h
@@ -120,4 +120,9 @@ extern Oid	attnumTypeId(Relation rd, int attid);
 extern Oid	attnumCollationId(Relation rd, int attid);
 extern bool isQueryUsingTempRelation(Query *query);
 
+typedef int (*find_attr_by_name_from_relation_hook_type) (
+	Relation rd, const char *attname, bool sysColOK);
+extern PGDLLIMPORT find_attr_by_name_from_relation_hook_type
+	find_attr_by_name_from_relation_hook;
+
 #endif							/* PARSE_RELATION_H */

--- a/src/include/parser/parser.h
+++ b/src/include/parser/parser.h
@@ -90,7 +90,6 @@ extern PGDLLIMPORT bool standard_conforming_strings;
 extern int sql_dialect;
 extern bool pltsql_case_insensitive_identifiers;
 
-extern int datefirst;
 extern char* pltsql_server_collation_name;
 
 /* Primary entry point for the raw parsing functions */

--- a/src/include/parser/scanner.h
+++ b/src/include/parser/scanner.h
@@ -147,4 +147,7 @@ extern void setup_scanner_errposition_callback(ScannerCallbackState *scbstate,
 extern void cancel_scanner_errposition_callback(ScannerCallbackState *scbstate);
 extern void scanner_yyerror(const char *message, core_yyscan_t yyscanner) pg_attribute_noreturn();
 
+typedef int (*core_yylex_hook_type) (core_YYSTYPE * yylval_param,YYLTYPE * yylloc_param ,core_yyscan_t yyscanner);
+extern PGDLLIMPORT core_yylex_hook_type core_yylex_hook;
+
 #endif							/* SCANNER_H */

--- a/src/include/pgstat.h
+++ b/src/include/pgstat.h
@@ -1132,4 +1132,13 @@ extern void write_structdef_file(void);
 typedef void (*pre_function_call_hook_type) (const char *funcName);
 extern PGDLLIMPORT pre_function_call_hook_type pre_function_call_hook;
 
+typedef void (*invalidate_stat_table_hook_type) (void);
+extern PGDLLIMPORT invalidate_stat_table_hook_type invalidate_stat_table_hook;
+
+typedef void (*guc_newval_hook_type) (const char *guc, bool boolVal, const char *strVal, int intVal);
+extern PGDLLIMPORT guc_newval_hook_type guc_newval_hook;
+
+typedef bool (*tsql_has_pgstat_permissions_hook_type) (Oid role);
+extern PGDLLIMPORT tsql_has_pgstat_permissions_hook_type tsql_has_pgstat_permissions_hook;
+
 #endif							/* PGSTAT_H */

--- a/src/include/utils/jsonb.h
+++ b/src/include/utils/jsonb.h
@@ -385,6 +385,9 @@ extern JsonbValue *findJsonbValueFromContainer(JsonbContainer *sheader,
 extern JsonbValue *getKeyJsonValueFromContainer(JsonbContainer *container,
 												const char *keyVal, int keyLen,
 												JsonbValue *res);
+extern JsonbValue *tsqlGetKeyJsonValueFromContainer(JsonbContainer *container,
+												const char *keyVal, int keyLen,
+												JsonbValue *res);
 extern JsonbValue *getIthJsonbValueFromContainer(JsonbContainer *sheader,
 												 uint32 i);
 extern JsonbValue *pushJsonbValue(JsonbParseState **pstate,


### PR DESCRIPTION
# WARNING: DO NOT SQUASH COMMIT THIS PR!

### Description

Cherry-picked 32 Babelfish-related commits from `BABEL_1_X_DEV__PG_13_6`. During the cherry-pick, there were 5 merge conflicts from the below commits.

```
21b413a873 Support CHECKSUM(*) and CHECKSUM(c1, c2, ...)
a7c52140dd Part 1: Support inserted transition table for INSTEAD OF INSERT
07dedf85fc Support sys.dm_exec_sessions and sys.dm_exec_connections dynamic management view
e2df156806 Fix misevaluation of STABLE parameters in CALL within plpgsql.
3a9ac9ad19 Do not filter pushes based on branch name
```

Conflicted files are
```
.github/workflows/main.yml
src/backend/commands/functioncmds.c
src/backend/postmaster/pgstat.c
src/backend/utils/adt/pgstatfuncs.c
src/backend/commands/trigger.c
src/backend/parser/parse_expr.c
```

Original merge conflict diff: [pg14merge_2_diff.txt](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/files/8339028/pg14merge_2_diff.txt)

### Check List

- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
