### PR TITLE
Cherry-pick Babelfish-related commits from BABEL_1_X_DEV__PG_13_6 - part 3

### DIFF
--- a/src/backend/access/common/reloptions.c
+++ b/src/backend/access/common/reloptions.c
@@ -1468,6 +1468,9 @@ parseRelOptionsInternal(Datum options, bool validate,
 			if (sql_dialect == SQL_DIALECT_TSQL)
 				continue;
 
+			if (strncmp(text_str, "bbf_original_rel_name", 21) == 0)
+				continue;
+
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 					 errmsg("unrecognized parameter \"%s\"", s)));

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -41,6 +41,8 @@
 #include "utils/rel.h"
 #include "utils/rls.h"
 
+is_tsql_rowversion_or_timestamp_datatype_hook_type is_tsql_rowversion_or_timestamp_datatype_hook = NULL;
+
 /*
  *	 DoCopy executes the SQL COPY statement
  *
@@ -701,6 +703,10 @@ CopyGetAttnums(TupleDesc tupDesc, Relation rel, List *attnamelist)
 				continue;
 			if (TupleDescAttr(tupDesc, i)->attgenerated)
 				continue;
+			/* Skip TSQL ROWVERSION/TIMESTAMP column if it exists */
+			if (is_tsql_rowversion_or_timestamp_datatype_hook &&
+				is_tsql_rowversion_or_timestamp_datatype_hook(TupleDescAttr(tupDesc, i)->atttypid))
+				continue;
 			attnums = lappend_int(attnums, i + 1);
 		}
 	}
@@ -731,6 +737,13 @@ CopyGetAttnums(TupleDesc tupDesc, Relation rel, List *attnamelist)
 								 errmsg("column \"%s\" is a generated column",
 										name),
 								 errdetail("Generated columns cannot be used in COPY.")));
+					if (is_tsql_rowversion_or_timestamp_datatype_hook &&
+						is_tsql_rowversion_or_timestamp_datatype_hook(att->atttypid))
+						ereport(ERROR,
+								(errcode(ERRCODE_INVALID_COLUMN_REFERENCE),
+								 errmsg("column \"%s\" is a ROWVERSION/TIMESTAMP column",
+								 		name),
+								 errdetail("ROWVERSION/TIMESTAMP columns cannot be used in COPY.")));
 					attnum = att->attnum;
 					break;
 				}

--- a/src/backend/commands/typecmds.c
+++ b/src/backend/commands/typecmds.c
@@ -702,6 +702,7 @@ DefineDomain(CreateDomainStmt *stmt)
 	char	   *domainName;
 	char	   *domainArrayName;
 	Oid			domainNamespace;
+	SQLDialect  dialect;
 	AclResult	aclresult;
 	int16		internalLength;
 	Oid			inputProcedure;
@@ -809,7 +810,29 @@ DefineDomain(CreateDomainStmt *stmt)
 	if (stmt->collClause)
 		domaincoll = get_collation_oid(stmt->collClause->collname, false);
 	else
-		domaincoll = baseColl;
+	{
+		/*
+		 * For Babelfish, if we're creating domains under the sys schema
+		 * grab the correct collation. Initially support just the sys.name type.
+		 */
+		if (strcmp(get_namespace_name(domainNamespace), "sys") == 0 && strcmp(domainName, "name") == 0)
+		{
+			/*
+			 * Since CREATE DOMAIN does not work in T-SQL, we should be in the
+			 * Postgres dialect here. To ensure we have the correct
+			 * server collation oid, temporarily set dialect to TSQL.
+			 */
+			Assert(sql_dialect == SQL_DIALECT_PG);
+			dialect = sql_dialect;
+			sql_dialect = SQL_DIALECT_TSQL;
+			domaincoll = CLUSTER_COLLATION_OID();
+			sql_dialect = dialect;
+		}
+		else
+		{
+			domaincoll = baseColl;
+		}
+	}
 
 	/* Complain if COLLATE is applied to an uncollatable type */
 	if (OidIsValid(domaincoll) && !OidIsValid(baseColl))

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -71,6 +71,7 @@
 /* Hook for pltsql plugin */
 pltsql_identity_datatype_hook_type pltsql_identity_datatype_hook = NULL;
 post_transform_column_definition_hook_type post_transform_column_definition_hook = NULL;
+post_transform_table_definition_hook_type post_transform_table_definition_hook = NULL;
 
 /* State shared by transformCreateStmt and its subroutines */
 typedef struct
@@ -335,6 +336,11 @@ transformCreateStmt(CreateStmt *stmt, const char *queryString)
 	 * Postprocess extended statistics.
 	 */
 	transformExtendedStatistics(&cxt);
+
+	if (post_transform_table_definition_hook)
+	{
+		(* post_transform_table_definition_hook) (cxt.pstate, cxt.relation, cxt.relation->relname, &cxt.alist);
+	}
 
 	/*
 	 * Output results.

--- a/src/backend/replication/logical/proto.c
+++ b/src/backend/replication/logical/proto.c
@@ -13,6 +13,7 @@
 #include "postgres.h"
 
 #include "access/sysattr.h"
+#include "commands/copy.h"
 #include "catalog/pg_namespace.h"
 #include "catalog/pg_type.h"
 #include "libpq/pqformat.h"
@@ -505,6 +506,11 @@ logicalrep_write_tuple(StringInfo out, Relation rel, HeapTuple tuple, bool binar
 	{
 		if (TupleDescAttr(desc, i)->attisdropped || TupleDescAttr(desc, i)->attgenerated)
 			continue;
+
+		/* Skip TSQL ROWVERSION/TIMESTAMP column if it exists */
+		if (is_tsql_rowversion_or_timestamp_datatype_hook &&
+			is_tsql_rowversion_or_timestamp_datatype_hook(TupleDescAttr(desc, i)->atttypid))
+			continue;
 		nliveatts++;
 	}
 	pq_sendint16(out, nliveatts);
@@ -523,6 +529,11 @@ logicalrep_write_tuple(StringInfo out, Relation rel, HeapTuple tuple, bool binar
 		Form_pg_attribute att = TupleDescAttr(desc, i);
 
 		if (att->attisdropped || att->attgenerated)
+			continue;
+
+		/* Skip TSQL ROWVERSION/TIMESTAMP column if it exists */
+		if (is_tsql_rowversion_or_timestamp_datatype_hook &&
+			is_tsql_rowversion_or_timestamp_datatype_hook(att->atttypid))
 			continue;
 
 		if (isnull[i])
@@ -661,6 +672,11 @@ logicalrep_write_attrs(StringInfo out, Relation rel)
 	{
 		if (TupleDescAttr(desc, i)->attisdropped || TupleDescAttr(desc, i)->attgenerated)
 			continue;
+
+		/* Skip TSQL ROWVERSION/TIMESTAMP column if it exists */
+		if (is_tsql_rowversion_or_timestamp_datatype_hook &&
+			is_tsql_rowversion_or_timestamp_datatype_hook(TupleDescAttr(desc, i)->atttypid))
+			continue;
 		nliveatts++;
 	}
 	pq_sendint16(out, nliveatts);
@@ -677,6 +693,11 @@ logicalrep_write_attrs(StringInfo out, Relation rel)
 		uint8		flags = 0;
 
 		if (att->attisdropped || att->attgenerated)
+			continue;
+
+		/* Skip TSQL ROWVERSION/TIMESTAMP column if it exists */
+		if (is_tsql_rowversion_or_timestamp_datatype_hook &&
+			is_tsql_rowversion_or_timestamp_datatype_hook(att->atttypid))
 			continue;
 
 		/* REPLICA IDENTITY FULL means all columns are sent as part of key. */

--- a/src/backend/replication/logical/relation.c
+++ b/src/backend/replication/logical/relation.c
@@ -18,6 +18,7 @@
 #include "postgres.h"
 
 #include "access/table.h"
+#include "commands/copy.h"
 #include "catalog/namespace.h"
 #include "catalog/pg_subscription_rel.h"
 #include "executor/executor.h"
@@ -346,7 +347,9 @@ logicalrep_rel_open(LogicalRepRelId remoteid, LOCKMODE lockmode)
 			int			attnum;
 			Form_pg_attribute attr = TupleDescAttr(desc, i);
 
-			if (attr->attisdropped || attr->attgenerated)
+			if (attr->attisdropped || attr->attgenerated ||
+				(is_tsql_rowversion_or_timestamp_datatype_hook &&
+				is_tsql_rowversion_or_timestamp_datatype_hook(attr->atttypid)))
 			{
 				entry->attrmap->attnums[i] = -1;
 				continue;

--- a/src/backend/replication/logical/tablesync.c
+++ b/src/backend/replication/logical/tablesync.c
@@ -784,6 +784,11 @@ fetch_remote_table_info(char *nspname, char *relname,
 		Assert(!isnull);
 		lrel->atttyps[natt] = DatumGetObjectId(slot_getattr(slot, 2, &isnull));
 		Assert(!isnull);
+
+		if (is_tsql_rowversion_or_timestamp_datatype_hook &&
+			is_tsql_rowversion_or_timestamp_datatype_hook(lrel->atttyps[natt]))
+			continue;
+
 		if (DatumGetBool(slot_getattr(slot, 3, &isnull)))
 			lrel->attkeys = bms_add_member(lrel->attkeys, natt);
 

--- a/src/include/commands/copy.h
+++ b/src/include/commands/copy.h
@@ -86,4 +86,6 @@ extern uint64 DoCopyTo(CopyToState cstate);
 extern List *CopyGetAttnums(TupleDesc tupDesc, Relation rel,
 							List *attnamelist);
 
+typedef bool (*is_tsql_rowversion_or_timestamp_datatype_hook_type)(Oid oid);
+extern PGDLLIMPORT is_tsql_rowversion_or_timestamp_datatype_hook_type is_tsql_rowversion_or_timestamp_datatype_hook;
 #endif							/* COPY_H */

--- a/src/include/parser/parse_utilcmd.h
+++ b/src/include/parser/parse_utilcmd.h
@@ -24,7 +24,9 @@ typedef void (*pltsql_identity_datatype_hook_type) (ParseState *pstate,
 													ColumnDef *column);
 extern PGDLLIMPORT pltsql_identity_datatype_hook_type pltsql_identity_datatype_hook;
 typedef void (*post_transform_column_definition_hook_type) (ParseState *pstate, RangeVar* relation, ColumnDef *column, List **alist);
+typedef void (*post_transform_table_definition_hook_type) (ParseState *pstate, RangeVar* relation, char *relname, List **alist);
 extern PGDLLIMPORT post_transform_column_definition_hook_type post_transform_column_definition_hook;
+extern PGDLLIMPORT post_transform_table_definition_hook_type post_transform_table_definition_hook;
 
 extern List *transformCreateStmt(CreateStmt *stmt, const char *queryString);
 extern AlterTableStmt *transformAlterTableStmt(Oid relid, AlterTableStmt *stmt,

--- a/src/include/replication/logical.h
+++ b/src/include/replication/logical.h
@@ -11,8 +11,10 @@
 
 #include "access/xlog.h"
 #include "access/xlogreader.h"
+#include "nodes/execnodes.h"
 #include "replication/output_plugin.h"
 #include "replication/slot.h"
+#include "utils/relcache.h"
 
 struct LogicalDecodingContext;
 
@@ -130,5 +132,8 @@ extern bool filter_prepare_cb_wrapper(LogicalDecodingContext *ctx,
 extern bool filter_by_origin_cb_wrapper(LogicalDecodingContext *ctx, RepOriginId origin_id);
 extern void ResetLogicalStreamingState(void);
 extern void UpdateDecodingStats(LogicalDecodingContext *ctx);
+
+typedef void (*logicalrep_modify_slot_hook_type)(Relation rel, EState *estate, TupleTableSlot *slot);
+extern PGDLLIMPORT logicalrep_modify_slot_hook_type logicalrep_modify_slot_hook;
 
 #endif


### PR DESCRIPTION
# WARNING: DO NOT SQUASH COMMIT THIS PR!

### Description

Cherry-picked 2 Babelfish-related commits from `BABEL_1_X_DEV__PG_13_6`. During the cherry-pick, there was a merge conflict from the below commit.
```
48fcf4b965 Handle ROWVERSION/TIMESTAMP columns for Postgres Logical Replication
```
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
