### PR TITLE
[WIP][POC] Support TSQL typename and typmod de-parsing

### DIFF
--- a/src/include/utils/builtins.h
+++ b/src/include/utils/builtins.h
@@ -123,6 +123,9 @@ extern char *format_type_with_typemod(Oid type_oid, int32 typemod);
 
 extern int32 type_maximum_size(Oid type_oid, int32 typemod);
 
+typedef char *(*tsql_format_type_extended_hook_type)(Oid type_oid, int32 typemod, bits16 flags);
+extern PGDLLIMPORT tsql_format_type_extended_hook_type tsql_format_type_extended_hook;
+
 /* quote.c */
 extern char *quote_literal_cstr(const char *rawstr);
 


### PR DESCRIPTION
Added tsql_format_type_extended() hook function call in
format_type_extended() when sql_dialect is TSQL. It will de-parse the
typename and typmod to TSQL compitible form.

Signed-off-by: Harsh Lunagariya <lunharsh@amazon.com>

### Description

[Describe what this change achieves]
 
### Issues Resolved

[List any issues this PR will resolve]
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
