### PR TITLE
BCP Related Bug-fixes

### DIFF
--- a/src/backend/commands/view.c
+++ b/src/backend/commands/view.c
@@ -37,6 +37,8 @@
 
 static void checkViewTupleDesc(TupleDesc newdesc, TupleDesc olddesc);
 
+inherit_view_constraints_from_table_hook_type inherit_view_constraints_from_table_hook = NULL;
+
 /*---------------------------------------------------------------------
  * DefineVirtualRelation
  *
@@ -71,6 +73,9 @@ DefineVirtualRelation(RangeVar *relation, List *tlist, bool replace,
 											exprType((Node *) tle->expr),
 											exprTypmod((Node *) tle->expr),
 											exprCollation((Node *) tle->expr));
+
+			if (inherit_view_constraints_from_table_hook)
+				(*inherit_view_constraints_from_table_hook) (def, tle->resorigtbl, tle->resorigcol);
 
 			/*
 			 * It's possible that the column is of a collatable type but the

--- a/src/include/commands/view.h
+++ b/src/include/commands/view.h
@@ -22,4 +22,6 @@ extern ObjectAddress DefineView(ViewStmt *stmt, const char *queryString,
 
 extern void StoreViewQuery(Oid viewOid, Query *viewParse, bool replace);
 
+typedef void (*inherit_view_constraints_from_table_hook_type) (ColumnDef  *col, Oid tableOid, AttrNumber colId);
+extern PGDLLIMPORT inherit_view_constraints_from_table_hook_type inherit_view_constraints_from_table_hook;
 #endif							/* VIEW_H */


### PR DESCRIPTION
Description
In this commit we fix 3 issues:

1. Bcp does not handle ‘db..table’ syntax. The issue was pertaining to
sp_describe_first_resultset where SPI API was not able to resolve the
DB..TABLE name. To fix this we are making use of ANTLR Parser to resolve
the full name, in addition it also provides syntax checks.

2. Bcp-in does not handle identity column. The issue was with views created
from select statement does not inherit the constraints from the base columns
which was the reason why sp_describe_first_resultset sent wrong values for
identity columns. To Fix this we lookup the catalog at the time of view
creation in TSQL Dialect to initialise the constraints for it.

3. We had restricted sp_describe_first_result_set to only work with SELECT
statements and for non-select statements we threw an error. With this commit
we return 0 rows for any valid non-select query.

Task: BABEL-3193, BABEL-3194, BABEL-3208
Signed-off-by: Kushaal Shroff ([kushaal@amazon.com](mailto:kushaal@amazon.com))
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
