### PR TITLE
Collatable constant expressions need to use CLUSTER_COLLATION_OID

### DIFF
--- a/src/backend/nodes/nodeFuncs.c
+++ b/src/backend/nodes/nodeFuncs.c
@@ -20,6 +20,7 @@
 #include "nodes/execnodes.h"
 #include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
+#include "parser/parser.h"
 #include "nodes/pathnodes.h"
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
@@ -961,6 +962,12 @@ exprCollation(const Node *expr)
 			coll = InvalidOid;	/* keep compiler quiet */
 			break;
 	}
+
+	if (sql_dialect == SQL_DIALECT_TSQL &&
+		coll == DEFAULT_COLLATION_OID &&
+		(nodeTag(expr) == T_Const || nodeTag(expr) == T_Param) )
+		coll = CLUSTER_COLLATION_OID();
+
 	return coll;
 }
 

--- a/src/backend/parser/parse_collate.c
+++ b/src/backend/parser/parse_collate.c
@@ -400,6 +400,9 @@ assign_collations_walker(Node *node, assign_collations_context *context)
 				CoerceToDomain *expr = (CoerceToDomain *) node;
 				Oid			typcollation = get_typcollation(expr->resulttype);
 
+				if (typcollation == DEFAULT_COLLATION_OID)
+					typcollation = CLUSTER_COLLATION_OID();
+
 				/* ... but first, recurse */
 				(void) expression_tree_walker(node,
 											  assign_collations_walker,
@@ -408,7 +411,7 @@ assign_collations_walker(Node *node, assign_collations_context *context)
 				if (OidIsValid(typcollation))
 				{
 					/* Node's result type is collatable. */
-					if (typcollation == DEFAULT_COLLATION_OID)
+					if (typcollation == CLUSTER_COLLATION_OID())
 					{
 						/* Collation state bubbles up from child. */
 						collation = loccontext.collation;
@@ -706,6 +709,7 @@ assign_collations_walker(Node *node, assign_collations_context *context)
 				 * Now figure out what collation to assign to this node.
 				 */
 				typcollation = get_typcollation(exprType(node));
+
 				if (OidIsValid(typcollation))
 				{
 					/* Node's result is collatable; what about its input? */
@@ -721,7 +725,7 @@ assign_collations_walker(Node *node, assign_collations_context *context)
 						/*
 						 * Collatable output produced without any collatable
 						 * input.  Use the type's collation (which is usually
-						 * DEFAULT_COLLATION_OID, but might be different for a
+						 * CLUSTER_COLLATION_OID(), but might be different for a
 						 * domain).
 						 */
 						collation = typcollation;
@@ -815,14 +819,14 @@ merge_collation_state(Oid collation,
 					/*
 					 * Non-default implicit collation always beats default.
 					 */
-					if (context->collation == DEFAULT_COLLATION_OID)
+					if (context->collation == CLUSTER_COLLATION_OID())
 					{
 						/* Override previous parent state */
 						context->collation = collation;
 						context->strength = strength;
 						context->location = location;
 					}
-					else if (collation != DEFAULT_COLLATION_OID)
+					else if (collation != CLUSTER_COLLATION_OID())
 					{
 						/*
 						 * Oops, we have a conflict.  We cannot throw error

--- a/src/backend/utils/cache/lsyscache.c
+++ b/src/backend/utils/cache/lsyscache.c
@@ -3026,6 +3026,10 @@ get_typcollation(Oid typid)
 
 		result = typtup->typcollation;
 		ReleaseSysCache(tp);
+
+		if (result == DEFAULT_COLLATION_OID)
+			result = CLUSTER_COLLATION_OID();
+
 		return result;
 	}
 	else


### PR DESCRIPTION
### Description

SELECT CASE WHEN 'a' = 'A' THEN 'case-insensitive' ELSE 'case-sensitive' END;
returns 'case-sensitive' when it should return 'case-insensitive'.

More generally, constant expressions are not getting the proper default collation,
and so collation inference fails when an expression has only constant expressions.
This was specified in the design document, but was not implemented. In addition,
two other locations in the code were found to be referring to DEFAULT_COLLATION_OID
when they should have been referring to CLUSTER_COLLATION_OID.

The core functional changes applies the CLUSTER_COLLATION_OID instead of the
DEFAULT_COLLATION_OID. The change was made at a low level so that it also applies
to collated parameters.

This change had widespread consequences because constants and parameters that were
previously collated with a deterministic collation (like the "C" collation) were
for the first time needing to cope with the nondeterministic database collation
(which currently is always case-insensitive and accent-sensitive). Regular expressions
and several core string functions don't work for nondeterministic collations, but
fortunately in nearly all cases regular expressions were being used to find delimiters
or separators such as comma that were not case-sensitive, and so the code be corrected
by explicitly collating with the deterministic "C" collation, which always exists.

This change also implements the missing string functions CHARINDEX and PATINDEX,
and corrects the behavior of STRING_SPLIT so that it is case-insensitive.

Task: BABEL-2851
Author: Jim Finnerty <jfinnert@amazon.com>
Signed-off-by: Jungkook Lee <jungkook@amazon.com>
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
