### PR TITLE
Fix mismatch of target columns and expressions when table has default NULL column in OUTPUT clause

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -56,6 +56,9 @@ pre_parse_analyze_hook_type pre_parse_analyze_hook = NULL;
 /* Hook to handle qualifiers in returning list for output clause */
 pre_transform_returning_hook_type pre_transform_returning_hook = NULL;
 
+/* Hook to modify insert statement in output clause */
+pre_transform_insert_hook_type pre_transform_insert_hook = NULL;
+
 /* Hook to read a global variable with info on output clause */
 get_output_clause_status_hook_type get_output_clause_status_hook = NULL;
 
@@ -575,6 +578,9 @@ transformInsertStmt(ParseState *pstate, InsertStmt *stmt)
 	qry->resultRelation = setTargetTable(pstate, stmt->relation,
 										 false, false, targetPerms);
 
+	if (pre_transform_insert_hook && stmt->withClause)
+		(*pre_transform_insert_hook) (stmt, RelationGetRelid(pstate->p_target_relation));
+	
 	/* Validate stmt->cols list, or build default list if no list given */
 	icolumns = checkInsertTargets(pstate, stmt->cols, &attrnos);
 	Assert(list_length(icolumns) == list_length(attrnos));
@@ -874,7 +880,7 @@ transformInsertStmt(ParseState *pstate, InsertStmt *stmt)
 
 	if (post_transform_insert_row_hook)
 		(*post_transform_insert_row_hook) (icolumns, exprList, 
-						RelationGetRelid(pstate->p_target_relation));
+								RelationGetRelid(pstate->p_target_relation));
 
 	/*
 	 * Generate query's target list using the computed list of expressions.

--- a/src/include/parser/analyze.h
+++ b/src/include/parser/analyze.h
@@ -32,6 +32,11 @@ typedef void (*pre_transform_returning_hook_type) (CmdType command,
 
 extern PGDLLIMPORT pre_transform_returning_hook_type pre_transform_returning_hook;
 
+/* Hook to modify insert statement in output clause */
+typedef void (*pre_transform_insert_hook_type) (InsertStmt *stmt, Oid relid);
+
+extern PGDLLIMPORT pre_transform_insert_hook_type pre_transform_insert_hook;
+
 /* Hook to perform self-join transformation on UpdateStmt in output clause */
 typedef Node* (*pre_output_clause_transformation_hook_type) (ParseState *pstate, UpdateStmt *stmt, CmdType command);
 extern PGDLLIMPORT pre_output_clause_transformation_hook_type pre_output_clause_transformation_hook;


### PR DESCRIPTION

When target columns are not specified in the OUTPUT INTO target table,
add the column names as target columns to the parse tree during rewrite
to CTE.

This commit also reverts the catalog lookup introduced as a part of the
BABEL-2811 fix to check for default valued columns.

Task: BABEL-2928
Signed-off-by: Avantika Dasgupta <davantik@amazon.com>