### PR TITLE
Computed column ISNULL(CONVERT()) crashes PG server with segfault

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -2023,6 +2023,7 @@ _copyCoalesceExpr(const CoalesceExpr *from)
 	COPY_SCALAR_FIELD(coalescecollid);
 	COPY_NODE_FIELD(args);
 	COPY_LOCATION_FIELD(location);
+	COPY_SCALAR_FIELD(tsql_is_null);
 
 	return newnode;
 }

--- a/src/backend/nodes/nodeFuncs.c
+++ b/src/backend/nodes/nodeFuncs.c
@@ -33,6 +33,7 @@ static bool planstate_walk_subplans(List *plans, bool (*walker) (),
 static bool planstate_walk_members(PlanState **planstates, int nplans,
 								   bool (*walker) (), void *context);
 
+coalesce_typmod_hook_type coalesce_typmod_hook = NULL;
 
 /*
  *	exprType -
@@ -427,6 +428,9 @@ exprTypmod(const Node *expr)
 				Oid			coalescetype = cexpr->coalescetype;
 				int32		typmod;
 				ListCell   *arg;
+
+				if (coalesce_typmod_hook && cexpr->tsql_is_null)
+					return (*coalesce_typmod_hook)(cexpr);
 
 				if (exprType((Node *) linitial(cexpr->args)) != coalescetype)
 					return -1;

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -3099,6 +3099,7 @@ eval_const_expressions_mutator(Node *node,
 				newcoalesce->coalescecollid = coalesceexpr->coalescecollid;
 				newcoalesce->args = newargs;
 				newcoalesce->location = coalesceexpr->location;
+				newcoalesce->tsql_is_null = coalesceexpr->tsql_is_null;
 				return (Node *) newcoalesce;
 			}
 		case T_SQLValueFunction:

--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -2244,6 +2244,7 @@ transformCoalesceExpr(ParseState *pstate, CoalesceExpr *c)
 
 	newc->args = newcoercedargs;
 	newc->location = c->location;
+	newc->tsql_is_null = c->tsql_is_null;
 	return (Node *) newc;
 }
 

--- a/src/include/nodes/nodeFuncs.h
+++ b/src/include/nodes/nodeFuncs.h
@@ -159,4 +159,7 @@ struct PlanState;
 extern bool planstate_tree_walker(struct PlanState *planstate, bool (*walker) (),
 								  void *context);
 
+typedef int32 (*coalesce_typmod_hook_type) (CoalesceExpr *cexpr);
+extern PGDLLIMPORT coalesce_typmod_hook_type coalesce_typmod_hook;
+
 #endif							/* NODEFUNCS_H */

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -1121,6 +1121,7 @@ typedef struct CoalesceExpr
 	Oid			coalescecollid; /* OID of collation, or InvalidOid if none */
 	List	   *args;			/* the arguments */
 	int			location;		/* token location, or -1 if unknown */
+	bool			tsql_is_null;	/* whether the calling function is T-SQL ISNULL() */
 } CoalesceExpr;
 
 /*


### PR DESCRIPTION
### Description

In PG, the typmod of a CoalesceExpr is -1 if all the arguments of the
expression are unable to agree on type and typmod. This is not the case
for T-SQL ISNULL() (which is implemented using PG COALESCE() in
Babelfish and so uses CoalesceExpr internally). In case of T-SQL
ISNULL(), the type/typmod is determined by the first not null argument.

This commit introduces a hook namely "coalesce_typmod_hook" which is
called if we encounter a T-SQL ISNULL() function. This hook returns the
typmod of the first argument in a CoalesceExpr. If the coalesce type is
numeric, then instead of sending typmod of the first argument (which is
not entirely correct since we may not be able to fit other arguments in
that scale/precision), we use the "resolve_numeric_typmod_from_exp"
method to figure out the scale/precision for us.

Also added a boolean member variable "tsql_is_null" in the
CoalesceExpr struct which is true if we encounter a T-SQL
ISNULL(); false otherwise.

Signed-off-by: Sharu Goel <goelshar@amazon.com>
 
### Issues Resolved

https://github.com/babelfish-for-postgresql/babelfish_extensions/issues/117
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
