### PR TITLE
 Make SELECT TOP (NULL) throw error instead of returning all rows (#96)

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -56,6 +56,7 @@
 #include "optimizer/tlist.h"
 #include "parser/analyze.h"
 #include "parser/parse_agg.h"
+#include "parser/parser.h"      /* only needed for GUC variables */
 #include "parser/parsetree.h"
 #include "partitioning/partdesc.h"
 #include "rewrite/rewriteManip.h"
@@ -3038,6 +3039,12 @@ limit_needed(Query *parse)
 			/* NULL indicates LIMIT ALL, ie, no limit */
 			if (!((Const *) node)->constisnull)
 				return true;	/* LIMIT with a constant value */
+
+			/* TOP (NULL) in TSQL mode should throw error */
+			if (sql_dialect == SQL_DIALECT_TSQL)
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_ROW_COUNT_IN_LIMIT_CLAUSE),
+						 errmsg("A TOP or FETCH clause contains an invalid value.")));
 		}
 		else
 			return true;		/* non-constant LIMIT */

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -1776,6 +1776,13 @@ transformLimitClause(ParseState *pstate, Node *clause,
 				(errcode(ERRCODE_INVALID_ROW_COUNT_IN_LIMIT_CLAUSE),
 				 errmsg("row count cannot be null in FETCH FIRST ... WITH TIES clause")));
 
+	/* TOP (NULL) in TSQL mode should throw error */
+	if (sql_dialect == SQL_DIALECT_TSQL && exprKind == EXPR_KIND_LIMIT &&
+		IsA(clause, A_Const) && ((A_Const *) clause)->val.type == T_Null)
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_ROW_COUNT_IN_LIMIT_CLAUSE),
+				 errmsg("A TOP or FETCH clause contains an invalid value.")));
+
 	return qual;
 }
 


### PR DESCRIPTION
### Extension PR
https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/298

### Description
Make SELECT TOP (NULL) throw error instead of returning all rows (#96)

Previously, SELECT TOP (NULL) returned all rows. This commit makes it throw an error instead by adding a NULL-check in the execution of LIMIT node, and also in the planner because the planner by default skips building a LIMIT node

Note: this was originally released as part of Aurora Babelfish 1.1 and was inadvertently missed as part of the move to GitHub.

Task: BABEL-1181
Author: Zitao Quan <qztao@amazon.com>
Signed-off-by: Sharu Goel <goelshar@amazon.com>

Co-authored-by: Sharu Goel <30777678+thephantomthief@users.noreply.github.com>

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
