### PR TITLE
fixed the problem : create tmp table inside trigger will (#23) (#29)

### DIFF
--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -521,11 +521,14 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 						ListCell *type_lc;
         
 						tmp_enr = (EphemeralNamedRelation) lfirst(curlc);
-						type_lc = list_head(tmp_enr->md.cattups[ENR_CATTUP_TYPE]);
-						if (type_lc && ((Form_pg_type) GETSTRUCT((HeapTuple)lfirst(type_lc)))->oid 
-										== ((Form_pg_type) GETSTRUCT(tup))->typelem) {
-							enr = tmp_enr;
-							break;
+						if (tmp_enr->md.enrtype == ENR_TSQL_TEMP){
+							// inserted & delted are special tmp enr 
+							type_lc = list_head(tmp_enr->md.cattups[ENR_CATTUP_TYPE]);
+							if (type_lc && ((Form_pg_type) GETSTRUCT((HeapTuple)lfirst(type_lc)))->oid 
+											== ((Form_pg_type) GETSTRUCT(tup))->typelem) {
+								enr = tmp_enr;
+								break;
+							}
 						}
 					}
 					if (enr) {


### PR DESCRIPTION
cause the db crash

fixed the problem create tmp table inside after / instead of trigger
will cause the db server crash

Task: BABEL-3119
Signed-off-by: Zhibai Song szh@amazon.com

Co-authored-by: Zhibai Song <szh@amazon.com>

### Description

he following sequence crashes the BABEL server:

````
1> CREATE TABLE t(c1 int)
2> GO

1> CREATE TRIGGER trfjk ON t
2> INSTEAD OF INSERT
3> AS
4> DECLARE @a int
5> CREATE TABLE #t(c1 int) --This one is causing the problem
6> GO

1> INSERT INTO t(c1) VALUES(1) 
2> go
TCP Provider: An existing connection was forcibly closed by the remote host.
Communication link failure
```` 

### Issues Resolved

the specific sql won't crash server
[List any issues this PR will resolve]
 
### Check List

- Task : BABEL-3119
- Signed-off-by: Zhibai Song szh@amazon.com 

[List any issues this PR will resolve]
 
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
