### PR TITLE
Instead of trigger behaves incorrectly during recursive execution

### DIFF
--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -4861,7 +4861,7 @@ isTsqlInsteadofTriggerExecution(EState *estate, ResultRelInfo *relinfo, TriggerE
 	{
 		Trigger *trigger = &trigdesc->triggers[i];
 		if (TriggerEnabled(estate, relinfo, trigger, event, NULL, NULL, NULL)){
-			return true;
+			return !TsqlRecuresiveCheck(relinfo);
 		}
 	}
 	return false;
@@ -6559,6 +6559,12 @@ void BeginCompositeTriggers(MemoryContext curCxt)
 {
 	compositeTriggers.triggerLevel++;
 	compositeTriggers.curCxt = curCxt;
+}
+
+bool TsqlRecuresiveCheck(ResultRelInfo *resultRelInfo){
+	if (TriggerRecuresiveCheck_hook)
+		return TriggerRecuresiveCheck_hook(resultRelInfo);
+	else return false;
 }
 
 /*

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -73,6 +73,7 @@ ExecutorRun_hook_type ExecutorRun_hook = NULL;
 ExecutorFinish_hook_type ExecutorFinish_hook = NULL;
 ExecutorEnd_hook_type ExecutorEnd_hook = NULL;
 
+TriggerRecuresiveCheck_hook_type TriggerRecuresiveCheck_hook = NULL;
 /* Hook for plugin to get control in ExecCheckRTPerms() */
 ExecutorCheckPerms_hook_type ExecutorCheckPerms_hook = NULL;
 

--- a/src/include/commands/trigger.h
+++ b/src/include/commands/trigger.h
@@ -301,4 +301,6 @@ extern int	RI_FKey_trigger_type(Oid tgfoid);
 extern void BeginCompositeTriggers(MemoryContext curCxt);
 extern void EndCompositeTriggers(bool error);
 
+extern bool TsqlRecuresiveCheck(ResultRelInfo *resultRelInfo);
+
 #endif							/* TRIGGER_H */

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -84,6 +84,8 @@ extern PGDLLIMPORT ExecutorEnd_hook_type ExecutorEnd_hook;
 typedef bool (*ExecutorCheckPerms_hook_type) (List *, bool);
 extern PGDLLIMPORT ExecutorCheckPerms_hook_type ExecutorCheckPerms_hook;
 
+typedef bool (*TriggerRecuresiveCheck_hook_type) (ResultRelInfo *resultRelInfo);
+extern PGDLLIMPORT TriggerRecuresiveCheck_hook_type TriggerRecuresiveCheck_hook;
 
 /*
  * prototypes from functions in execAmi.c

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -261,6 +261,8 @@ extern double log_xact_sample_rate;
 extern char *backtrace_functions;
 extern char *backtrace_symbol_list;
 
+extern bool pltsql_recursive_triggers;
+
 extern int	temp_file_limit;
 
 extern int	num_temp_buffers;

--- a/src/tools/pgindent/typedefs.list
+++ b/src/tools/pgindent/typedefs.list
@@ -649,6 +649,7 @@ ExecStatus
 ExecStatusType
 ExecuteStmt
 ExecutorCheckPerms_hook_type
+TriggerRecuresiveCheck_hook_type
 ExecutorEnd_hook_type
 ExecutorFinish_hook_type
 ExecutorRun_hook_type


### PR DESCRIPTION
Recursively calling an instead of trigger will result in data loss for last DML on underlying trigger table

### Description

Row inserted by an INSTEAD-OF INSERT trigger is missing in the example below: 

```
-- repro in Babelfish:
1>
2> CREATE TABLE t
3> (
4> c1 int IDENTITY(1,1) PRIMARY KEY,
5> c2 varchar(20) UNIQUE,
6> );
7>
8> INSERT INTO t(c2)
9> VALUES ('Joe'), ('Steve');
10>
11>
12> SELECT * FROM t
13> GO
c1          c2
----------- --------------------
          1 Joe
          2 Steve
1>
2> CREATE TRIGGER TR_t ON t
3> INSTEAD OF INSERT
4> AS
5>  DECLARE @c1 int, @c2 varchar(20)
6> SELECT @c1 = c1, @c2 = c2 FROM inserted
7> INSERT INTO t (c2) VALUES(@c2 + '2') --BUG: This INSERT disappears
8> GO
1>
2> INSERT INTO t(c2) VALUES ('Joe')
3> GO
1>
2> --There should be 3 rows, but there are only 2 rows. The INSERT from the trigger is lost.
3> SELECT * FROM t
4> GO
c1          c2
----------- --------------------
          1 Joe
          2 Steve
```
Explanation: 
- Insert inside instead of trigger causes a recursive trigger execution
- A recursive trigger execution is capped at nesting level of one and should be a no-op.
- We skip both DML and trigger execution but we should execute the original DML as trigger is a no-op.

The same problem will happen for Delete/Update as well.

### Issues Resolved

The fix identifies a recursive instead of trigger and does not skip the DML execution
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
