### PR TITLE
Fix incorrect argument passing in encode.c

### DIFF
--- a/src/backend/utils/adt/encode.c
+++ b/src/backend/utils/adt/encode.c
@@ -241,7 +241,7 @@ hex_decode_allow_odd_digits(const char *src, unsigned len, char *dst)
 	{
 		/* If input has odd number of hex digits, add a 0 to the front to make it even */
 		v1 = '\0';
-		v2 = get_hex(*s++);
+		v2 = get_hex(s++);
 		*p++ = v1 | v2;
 	}
 	/* The rest of the input must have even number of digits*/
@@ -252,8 +252,8 @@ hex_decode_allow_odd_digits(const char *src, unsigned len, char *dst)
 			s++;
 			continue;
 		}
-		v1 = get_hex(*s++) << 4;
-		v2 = get_hex(*s++);
+		v1 = get_hex(s++) << 4;
+		v2 = get_hex(s++);
 		*p++ = v1 | v2;
 	}
 


### PR DESCRIPTION
There was several incorrect usages of get_hex functions
in encode.c file, where char was passed in function
which expects const char * argument type

### Description
```
encode.c: In function ‘hex_decode_allow_odd_digits’:
encode.c:244:16: warning: passing argument 1 of ‘get_hex’ makes pointer from integer without a cast [-Wint-conversion]
  244 |   v2 = get_hex(*s++);
      |                ^~~~
      |                |
      |                char
encode.c:175:21: note: expected ‘const char *’ but argument is of type ‘char’
  175 | get_hex(const char *cp)
      |         ~~~~~~~~~~~~^~
encode.c:255:16: warning: passing argument 1 of ‘get_hex’ makes pointer from integer without a cast [-Wint-conversion]
  255 |   v1 = get_hex(*s++) << 4;
      |                ^~~~
      |                |
      |                char
encode.c:175:21: note: expected ‘const char *’ but argument is of type ‘char’
  175 | get_hex(const char *cp)
      |         ~~~~~~~~~~~~^~
encode.c:256:16: warning: passing argument 1 of ‘get_hex’ makes pointer from integer without a cast [-Wint-conversion]
  256 |   v2 = get_hex(*s++);
      |                ^~~~
      |                |
      |                char
encode.c:175:21: note: expected ‘const char *’ but argument is of type ‘char’
  175 | get_hex(const char *cp)
      |         ~~~~~~~~~~~~^~
```
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
