### PR TITLE
[DO NOT MERGE] Remove restriction, input parameters after one with a default value must also have defaults, for all PL/tsql functions

### DIFF
--- a/src/backend/catalog/namespace.c
+++ b/src/backend/catalog/namespace.c
@@ -1247,13 +1247,13 @@ FuncnameGetCandidates(List *names, int nargs, List *argnames,
 			for (i = 0; i < pronargs; i++)
 				newResult->args[i] = proargtypes[argnumbers[i]];
 
-			newResult->argdefaults = defaults;
+			newResult->tsql_argdefaults = defaults;
 		}
 		else
 		{
 			/* Simple positional case, just copy proargtypes as-is */
 			memcpy(newResult->args, proargtypes, pronargs * sizeof(Oid));
-			newResult->argdefaults = NIL;
+			newResult->tsql_argdefaults = NIL;
 		}
 		if (variadic)
 		{
@@ -1531,7 +1531,7 @@ MatchNamedCall(HeapTuple proctup, int nargs, List *argnames,
 		char		*str;
 		List		*argdefaults = NIL;
 		bool		isnull;
-		bool		special = false;
+		bool		tsql_funcdefault_node = false;
 		ListCell	*def_item = NULL;
 
 		proargdefaults = SysCacheGetAttr(PROCOID, proctup,
@@ -1543,7 +1543,7 @@ MatchNamedCall(HeapTuple proctup, int nargs, List *argnames,
 			str = TextDatumGetCString(proargdefaults);
 			argdefaults = castNode(List, stringToNode(str));
 			def_item = list_head(argdefaults);
-			special = IsA(lfirst(def_item), FuncDefault) ? true : false;
+			tsql_funcdefault_node = IsA(lfirst(def_item), FuncDefault) ? true : false;
 			pfree(str);
 		}
 		for (pp = numposargs; pp < pronargs; pp++)
@@ -1556,7 +1556,7 @@ MatchNamedCall(HeapTuple proctup, int nargs, List *argnames,
 			 * special handling. Look into FuncDefault into node to find out
 			 * the default expression for pp'th argument.
 			 */
-			if (special)
+			if (tsql_funcdefault_node)
 			{
 				bool found = false;
 

--- a/src/backend/commands/functioncmds.c
+++ b/src/backend/commands/functioncmds.c
@@ -449,6 +449,10 @@ interpret_function_parameter_list(ParseState *pstate,
 
 			if (is_pltsql_func)
 			{
+				/*
+				 * If it is a PL/tsql function, store the default argument index
+				 * as well (FuncDefault node).
+				 */
 				FuncDefault *node = makeNode(FuncDefault);
 				node->position = i;
 				node->actualexpr = def;

--- a/src/backend/nodes/nodeFuncs.c
+++ b/src/backend/nodes/nodeFuncs.c
@@ -251,6 +251,9 @@ exprType(const Node *expr)
 		case T_PlaceHolderVar:
 			type = exprType((Node *) ((const PlaceHolderVar *) expr)->phexpr);
 			break;
+		case T_FuncDefault:
+			type = exprType((Node *) ((const FuncDefault *) expr)->actualexpr);
+			break;
 		default:
 			elog(ERROR, "unrecognized node type: %d", (int) nodeTag(expr));
 			type = InvalidOid;	/* keep compiler quiet */
@@ -483,6 +486,8 @@ exprTypmod(const Node *expr)
 			return ((const SetToDefault *) expr)->typeMod;
 		case T_PlaceHolderVar:
 			return exprTypmod((Node *) ((const PlaceHolderVar *) expr)->phexpr);
+		case T_FuncDefault:
+			return exprTypmod((Node *) ((const FuncDefault *) expr)->actualexpr);
 		default:
 			break;
 	}
@@ -958,6 +963,9 @@ exprCollation(const Node *expr)
 			break;
 		case T_PlaceHolderVar:
 			coll = exprCollation((Node *) ((const PlaceHolderVar *) expr)->phexpr);
+			break;
+		case T_FuncDefault:
+			coll = exprCollation((Node *) ((const FuncDefault *) expr)->actualexpr);
 			break;
 		default:
 			elog(ERROR, "unrecognized node type: %d", (int) nodeTag(expr));
@@ -2014,6 +2022,15 @@ expression_tree_walker(Node *node,
 				FuncExpr   *expr = (FuncExpr *) node;
 
 				if (expression_tree_walker((Node *) expr->args,
+										   walker, context))
+					return true;
+			}
+			break;
+		case T_FuncDefault:
+			{
+				FuncDefault		*expr = (FuncDefault *)node;
+
+				if (expression_tree_walker((Node *) expr->actualexpr,
 										   walker, context))
 					return true;
 			}

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -1251,6 +1251,15 @@ _outFuncExpr(StringInfo str, const FuncExpr *node)
 }
 
 static void
+_outFuncDefault(StringInfo str, const FuncDefault *node)
+{
+	WRITE_NODE_TYPE("FUNCDEFAULT");
+
+	WRITE_INT_FIELD(position);
+	WRITE_NODE_FIELD(actualexpr);
+}
+
+static void
 _outNamedArgExpr(StringInfo str, const NamedArgExpr *node)
 {
 	WRITE_NODE_TYPE("NAMEDARGEXPR");
@@ -4050,6 +4059,9 @@ outNode(StringInfo str, const void *obj)
 				break;
 			case T_FuncExpr:
 				_outFuncExpr(str, obj);
+				break;
+			case T_FuncDefault:
+				_outFuncDefault(str, obj);
 				break;
 			case T_NamedArgExpr:
 				_outNamedArgExpr(str, obj);

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -745,6 +745,17 @@ _readFuncExpr(void)
 	READ_DONE();
 }
 
+static FuncDefault *
+_readFuncDefault(void)
+{
+	READ_LOCALS(FuncDefault);
+
+	READ_INT_FIELD(position);
+	READ_NODE_FIELD(actualexpr);
+
+	READ_DONE();
+}
+
 /*
  * _readNamedArgExpr
  */
@@ -2771,6 +2782,8 @@ parseNodeString(void)
 		return_value = _readSubscriptingRef();
 	else if (MATCH("FUNCEXPR", 8))
 		return_value = _readFuncExpr();
+	else if (MATCH("FUNCDEFAULT", 11))
+		return_value = _readFuncDefault();
 	else if (MATCH("NAMEDARGEXPR", 12))
 		return_value = _readNamedArgExpr();
 	else if (MATCH("OPEXPR", 6))

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -4052,6 +4052,7 @@ reorder_function_arguments(List *args, int pronargs, HeapTuple func_tuple)
 	{
 		List	   *defaults = fetch_function_defaults(func_tuple);
 
+		/* If defaults consist of FuncDefault nodes, then fetch the actaul default expr. */
 		if (IsA(lfirst(list_head(defaults)), FuncDefault))
 		{
 			FuncDefault *node;
@@ -4111,6 +4112,7 @@ add_function_defaults(List *args, int pronargs, HeapTuple func_tuple)
 	if (ndelete > 0)
 		defaults = list_delete_first_n(defaults, ndelete);
 
+	/* If defaults consist of FuncDefault nodes, then fetch the actaul default expr. */
 	if (defaults != NIL && IsA(lfirst(list_head(defaults)), FuncDefault))
 	{
 		FuncDefault *node;

--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -1688,8 +1688,8 @@ func_get_detail(List *funcname,
 			pfree(str);
 
 			/* Delete any unused defaults from the returned list */
-			if (best_candidate->argnumbers != NULL && best_candidate->argdefaults != NIL)
-				*argdefaults = best_candidate->argdefaults;
+			if (best_candidate->argnumbers != NULL && best_candidate->tsql_argdefaults != NIL)
+				*argdefaults = best_candidate->tsql_argdefaults;
 			else if (best_candidate->argnumbers != NULL)
 			{
 				/*

--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -1688,7 +1688,9 @@ func_get_detail(List *funcname,
 			pfree(str);
 
 			/* Delete any unused defaults from the returned list */
-			if (best_candidate->argnumbers != NULL)
+			if (best_candidate->argnumbers != NULL && best_candidate->argdefaults != NIL)
+				*argdefaults = best_candidate->argdefaults;
+			else if (best_candidate->argnumbers != NULL)
 			{
 				/*
 				 * This is a bit tricky in named notation, since the supplied

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -3273,18 +3273,7 @@ print_function_arguments(StringInfo buf, HeapTuple proctup,
 		if (argname && argname[0])
 			appendStringInfo(buf, "%s ", quote_identifier(argname));
 		appendStringInfoString(buf, format_type_be(argtype));
-
-		if (nextargdefault != NULL && IsA(lfirst(nextargdefault), FuncDefault))
-		{
-			FuncDefault *fd = (FuncDefault *) lfirst(nextargdefault);
-			if (print_defaults && isinput && fd->position == (inputargno - 1))
-			{
-				nextargdefault = lnext(argdefaults, nextargdefault);
-				appendStringInfo(buf, " DEFAULT %s",
-								 deparse_expression(fd->actualexpr, NIL, false, false));
-			}
-		}
-		else if (print_defaults && isinput && inputargno > nlackdefaults)
+		if (print_defaults && isinput && inputargno > nlackdefaults)
 		{
 			Node	   *expr;
 

--- a/src/include/catalog/namespace.h
+++ b/src/include/catalog/namespace.h
@@ -35,6 +35,7 @@ typedef struct _FuncCandidateList
 	int			nvargs;			/* number of args to become variadic array */
 	int			ndargs;			/* number of defaulted args */
 	int		   *argnumbers;		/* args' positional indexes, if named call */
+	List	   *argdefaults;    /* list of default args, only set for PL/tsql function */
 	Oid			args[FLEXIBLE_ARRAY_MEMBER];	/* arg types */
 }		   *FuncCandidateList;
 

--- a/src/include/catalog/namespace.h
+++ b/src/include/catalog/namespace.h
@@ -35,7 +35,7 @@ typedef struct _FuncCandidateList
 	int			nvargs;			/* number of args to become variadic array */
 	int			ndargs;			/* number of defaulted args */
 	int		   *argnumbers;		/* args' positional indexes, if named call */
-	List	   *argdefaults;    /* list of default args, only set for PL/tsql function */
+	List	   *tsql_argdefaults;    /* list of default args, only set for PL/tsql function */
 	Oid			args[FLEXIBLE_ARRAY_MEMBER];	/* arg types */
 }		   *FuncCandidateList;
 

--- a/src/include/nodes/nodes.h
+++ b/src/include/nodes/nodes.h
@@ -162,6 +162,7 @@ typedef enum NodeTag
 	T_WindowFunc,
 	T_SubscriptingRef,
 	T_FuncExpr,
+	T_FuncDefault,
 	T_NamedArgExpr,
 	T_OpExpr,
 	T_DistinctExpr,

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -504,6 +504,13 @@ typedef struct FuncExpr
 	int			location;		/* token location, or -1 if unknown */
 } FuncExpr;
 
+typedef struct FuncDefault
+{
+	Expr		xpr;
+	int			position;
+	Node		*actualexpr;
+} FuncDefault;
+
 /*
  * NamedArgExpr - a named argument of a function
  *

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -504,11 +504,15 @@ typedef struct FuncExpr
 	int			location;		/* token location, or -1 if unknown */
 } FuncExpr;
 
+
+/*
+ * FuncDefault - expression node for a function's  default argument
+ */
 typedef struct FuncDefault
 {
 	Expr		xpr;
-	int			position;
-	Node		*actualexpr;
+	int			position;		/* Index or position of argument's default expression */
+	Node	   *actualexpr;	/* Actual default expression */
 } FuncDefault;
 
 /*


### PR DESCRIPTION
### Description
* PG has a restriction that input parameters after one with
a default value must also have defaults. Previously we
provided a workaround for this by letting user provide
default parameters anywhere but filling NULL as default
value for all parameters after first default parameter.  
* The commit removes this restriction for PL/tsql functions
by also storing the position of default parameters along
with the actual expression so that we can use the position
while looking for the parameter default expression. Introduced
a new structure `FuncDefault` for this purpose.

Task: BABEL-2877
signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>
 
### Check List

- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
