### PR TITLE
Fix Major-version-upgrade issue when column name has comma

### DIFF
--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -28,7 +28,7 @@ extern void fixOprRegProc(Archive *fout, const OprInfo *oprinfo, const char *opr
 extern void fixTsqlTableTypeDependency(Archive *fout, DumpableObject *func, DumpableObject *tabletype, char deptype);
 extern bool isTsqlTableType(Archive *fout, const TableInfo *tbinfo);
 extern int getTsqlTvfType(Archive *fout, const FuncInfo *finfo, char prokind, bool proretset);
-extern char *fixAttoptionsBbfOriginalName(Archive *fout, Oid relOid, char *attName);
+extern void fixAttoptionsBbfOriginalName(Archive *fout, Oid relOid, const TableInfo *tbinfo, int idx);
 extern void setOrResetPltsqlFuncRestoreGUCs(Archive *fout, PQExpBuffer q, const FuncInfo *finfo, char prokind, bool proretset, bool is_set);
 
 #endif

--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -28,7 +28,7 @@ extern void fixOprRegProc(Archive *fout, const OprInfo *oprinfo, const char *opr
 extern void fixTsqlTableTypeDependency(Archive *fout, DumpableObject *func, DumpableObject *tabletype, char deptype);
 extern bool isTsqlTableType(Archive *fout, const TableInfo *tbinfo);
 extern int getTsqlTvfType(Archive *fout, const FuncInfo *finfo, char prokind, bool proretset);
-extern void fixAttoptionsBbfOriginalName(Archive *fout, char **attoptions);
+extern char *fixAttoptionsBbfOriginalName(Archive *fout, Oid relOid, char *attName);
 extern void setOrResetPltsqlFuncRestoreGUCs(Archive *fout, PQExpBuffer q, const FuncInfo *finfo, char prokind, bool proretset, bool is_set);
 
 #endif

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -16544,12 +16544,15 @@ dumpTableSchema(Archive *fout, const TableInfo *tbinfo)
 			 */
 			if (tbinfo->attoptions[j][0] != '\0')
 			{
-				fixAttoptionsBbfOriginalName(fout, &tbinfo->attoptions[j]);
+				char *attoptions = fixAttoptionsBbfOriginalName(fout, tbinfo->dobj.catId.oid, tbinfo->attnames[j]);
 
 				appendPQExpBuffer(q, "ALTER %sTABLE ONLY %s ALTER COLUMN %s SET (%s);\n",
 								  foreign, qualrelname,
 								  fmtId(tbinfo->attnames[j]),
-								  tbinfo->attoptions[j]);
+								  attoptions ? attoptions : tbinfo->attoptions[j]);
+
+				if (attoptions)
+					PQfreemem(attoptions);
 			}
 
 			/*

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -16544,15 +16544,12 @@ dumpTableSchema(Archive *fout, const TableInfo *tbinfo)
 			 */
 			if (tbinfo->attoptions[j][0] != '\0')
 			{
-				char *attoptions = fixAttoptionsBbfOriginalName(fout, tbinfo->dobj.catId.oid, tbinfo->attnames[j]);
+				fixAttoptionsBbfOriginalName(fout, tbinfo->dobj.catId.oid, tbinfo, j);
 
 				appendPQExpBuffer(q, "ALTER %sTABLE ONLY %s ALTER COLUMN %s SET (%s);\n",
 								  foreign, qualrelname,
 								  fmtId(tbinfo->attnames[j]),
-								  attoptions ? attoptions : tbinfo->attoptions[j]);
-
-				if (attoptions)
-					PQfreemem(attoptions);
+								  tbinfo->attoptions[j]);
 			}
 
 			/*


### PR DESCRIPTION
If comma is included in column name, bbf_original_name attoptions is
parsed wrongly and it cause a failure of MVU. Before the fix,
attoptions is collpased into a string so it is hard to split into array
elements if comma is involved. This fix will access pg_attribute to get
attoption text[] so it will not cause a parse-issue.

Task: BABEL-3121
Authored-by: Sangil Song <sonsangi@amazon.com>
Signed-off-by: Sangil Song <sonsangi@amazon.com>

### Check List

- [v] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
