### PR TITLE
Add a check on the recursion depth for recursive CTE for T-SQL queries

### DIFF
--- a/src/include/executor/nodeRecursiveunion.h
+++ b/src/include/executor/nodeRecursiveunion.h
@@ -19,5 +19,6 @@
 extern RecursiveUnionState *ExecInitRecursiveUnion(RecursiveUnion *node, EState *estate, int eflags);
 extern void ExecEndRecursiveUnion(RecursiveUnionState *node);
 extern void ExecReScanRecursiveUnion(RecursiveUnionState *node);
+extern int num_of_tuples_processed_before_recursive_term;
 
 #endif							/* NODERECURSIVEUNION_H */


### PR DESCRIPTION
### Description

Currently, recursive CTE has no limit on the recursion depth. This can cause it to run infinitely. T-SQL on the other hand has a default limit of 100 on the recursion depth. The change is to honor the GUC max_recursion_depth for recursive CTE written in T-SQL dialect
 
### Issues Resolved

Task: BABEL-2202
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
