### PR TITLE
Numeric testcase for precision overflow triggers known protocol violation

### DIFF
--- a/src/backend/utils/adt/numeric.c
+++ b/src/backend/utils/adt/numeric.c
@@ -596,7 +596,7 @@ static void accum_sum_final(NumericSumAccum *accum, NumericVar *result);
 static void accum_sum_copy(NumericSumAccum *dst, NumericSumAccum *src);
 static void accum_sum_combine(NumericSumAccum *accum, NumericSumAccum *accum2);
 
-
+detect_numeric_overflow_hook_type detect_numeric_overflow_hook = NULL;
 /* ----------------------------------------------------------------------
  *
  * Input-, output- and rounding-functions
@@ -2763,6 +2763,12 @@ numeric_add_opt_error(Numeric num1, Numeric num2, bool *have_error)
 
 	init_var(&result);
 	add_var(&arg1, &arg2, &result);
+
+	if (detect_numeric_overflow_hook &&
+	    (*detect_numeric_overflow_hook)(result.weight, result.dscale, result.digits[0], DEC_DIGITS))
+		ereport(ERROR,
+				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
+				errmsg("Arithmetic overflow error for data type numeric.")));
 
 	res = make_result_opt_error(&result, have_error);
 
@@ -5963,6 +5969,13 @@ numeric_avg(PG_FUNCTION_ARGS)
 
 	init_var(&sumX_var);
 	accum_sum_final(&state->sumX, &sumX_var);
+
+	if (detect_numeric_overflow_hook &&
+	    (*detect_numeric_overflow_hook)(sumX_var.weight, sumX_var.dscale, sumX_var.digits[0], DEC_DIGITS))
+		ereport(ERROR,
+				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
+				errmsg("Arithmetic overflow error for data type numeric.")));
+
 	sumX_datum = NumericGetDatum(make_result(&sumX_var));
 	free_var(&sumX_var);
 
@@ -5995,6 +6008,13 @@ numeric_sum(PG_FUNCTION_ARGS)
 
 	init_var(&sumX_var);
 	accum_sum_final(&state->sumX, &sumX_var);
+
+	if (detect_numeric_overflow_hook &&
+	    (*detect_numeric_overflow_hook)(sumX_var.weight, sumX_var.dscale, sumX_var.digits[0], DEC_DIGITS))
+		ereport(ERROR,
+				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
+				errmsg("Arithmetic overflow error for data type numeric.")));
+
 	result = make_result(&sumX_var);
 	free_var(&sumX_var);
 

--- a/src/include/utils/numeric.h
+++ b/src/include/utils/numeric.h
@@ -77,4 +77,8 @@ extern Numeric numeric_mod_opt_error(Numeric num1, Numeric num2,
 									 bool *have_error);
 extern int32 numeric_int4_opt_error(Numeric num, bool *error);
 
+/* Hook interface to calculate exact numeric digits before generating numeric overflow error in TSQL */
+typedef bool (*detect_numeric_overflow_hook_type) (int weight, int dscale, int first_block, int numeric_base);
+extern PGDLLIMPORT detect_numeric_overflow_hook_type detect_numeric_overflow_hook;
+
 #endif							/* _PG_NUMERIC_H_ */


### PR DESCRIPTION
### Description
Before Fix:
Numeric testcase for precision overflow triggers known protocol violation

After Fix:
Postgres can store numeric data upto 1000 digits but SQL server has a maximum limit of 38 digits. Since, adding the maximum numeric precision check on TDS sender side results into protocol violation, have addressed the issue on engine side by calculating exact numeric digits from Postgres numeric-blocks format and reporting error whenever #digits > TDS_MAX_NUMERIC_PRECISION(i.e. 38).

Task: BABEL-3179
Signed-off-by: Satarupa Biswas <satarupb@amazon.com>


- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
