### PR TITLE
MVU fails while restoring table with unrecognized table options

### DIFF
--- a/src/backend/access/common/reloptions.c
+++ b/src/backend/access/common/reloptions.c
@@ -1452,8 +1452,8 @@ parseRelOptionsInternal(Datum options, bool validate,
 		}
 
 		/*
-		 * We are ignoring unrecognized parameters in TSQL
-		 * dialect without raising error
+		 * Ignore unrecognized parameters in TSQL dialect and as well
+		 * as while restoring babelfish database without raising error.
 		 */
 		if (j >= numoptions && validate)
 		{
@@ -1467,7 +1467,7 @@ parseRelOptionsInternal(Datum options, bool validate,
 				*p = '\0';
 
 			if (sql_dialect == SQL_DIALECT_TSQL ||
-				(dump_restore && strcmp(dump_restore, "on") == 0))
+				(dump_restore && strcmp(dump_restore, "on") == 0)) /* allow unrecognized parameters while restoring babelfish database */
 				continue;
 
 			if (strncmp(text_str, "bbf_original_rel_name", 21) == 0)

--- a/src/backend/access/common/reloptions.c
+++ b/src/backend/access/common/reloptions.c
@@ -1459,13 +1459,15 @@ parseRelOptionsInternal(Datum options, bool validate,
 		{
 			char	   *s;
 			char	   *p;
+			const char *dump_restore = GetConfigOption("babelfishpg_tsql.dump_restore", true, false);
 
 			s = TextDatumGetCString(optiondatums[i]);
 			p = strchr(s, '=');
 			if (p)
 				*p = '\0';
 
-			if (sql_dialect == SQL_DIALECT_TSQL)
+			if (sql_dialect == SQL_DIALECT_TSQL ||
+				(dump_restore && strcmp(dump_restore, "on") == 0))
 				continue;
 
 			if (strncmp(text_str, "bbf_original_rel_name", 21) == 0)


### PR DESCRIPTION
We ignore unrecognized reloptions in T-SQL dialect which is
fine since we have check for options in ANTLR parser but
MVU fails while restoring these unrecognized reloptions since
restore happens in PG dialect.

Fix this by also allowing unrecognized reloptions while we are
restoring Babelfish database.

Task: BABEL-3448
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>

### Check List

- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
