### PR TITLE
Fix crash in numeric_add_opt_error for TSQL hook

### DIFF
--- a/src/backend/utils/adt/numeric.c
+++ b/src/backend/utils/adt/numeric.c
@@ -2764,7 +2764,7 @@ numeric_add_opt_error(Numeric num1, Numeric num2, bool *have_error)
 	init_var(&result);
 	add_var(&arg1, &arg2, &result);
 
-	if (detect_numeric_overflow_hook &&
+	if (detect_numeric_overflow_hook && result.digits &&
 	    (*detect_numeric_overflow_hook)(result.weight, result.dscale, result.digits[0], DEC_DIGITS))
 		ereport(ERROR,
 				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
@@ -5970,7 +5970,7 @@ numeric_avg(PG_FUNCTION_ARGS)
 	init_var(&sumX_var);
 	accum_sum_final(&state->sumX, &sumX_var);
 
-	if (detect_numeric_overflow_hook &&
+	if (detect_numeric_overflow_hook && sumX_var.digits &&
 	    (*detect_numeric_overflow_hook)(sumX_var.weight, sumX_var.dscale, sumX_var.digits[0], DEC_DIGITS))
 		ereport(ERROR,
 				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
@@ -6009,7 +6009,7 @@ numeric_sum(PG_FUNCTION_ARGS)
 	init_var(&sumX_var);
 	accum_sum_final(&state->sumX, &sumX_var);
 
-	if (detect_numeric_overflow_hook &&
+	if (detect_numeric_overflow_hook && sumX_var.digits &&
 	    (*detect_numeric_overflow_hook)(sumX_var.weight, sumX_var.dscale, sumX_var.digits[0], DEC_DIGITS))
 		ereport(ERROR,
 				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),


### PR DESCRIPTION
### Description

Fix includes adding NULL check on NumericVar.digits before calling
numeric overflow detection function

Task: BABEL-3450
Signed-off-by: Satarupa Biswas <satarupb@amazon.com>

 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
