### PR TITLE
Remove restriction, input parameters after one with a default value must also have defaults, for all PL/tsql procedures/functions

### DIFF
--- a/src/backend/catalog/namespace.c
+++ b/src/backend/catalog/namespace.c
@@ -203,6 +203,7 @@ char	   *namespace_search_path = NULL;
 char *SYS_NAMESPACE_NAME = "sys";
 
 relname_lookup_hook_type relname_lookup_hook = NULL;
+match_pltsql_func_call_hook_type match_pltsql_func_call_hook = NULL;
 
 
 /* Local functions */
@@ -1044,6 +1045,7 @@ FuncnameGetCandidates(List *names, int nargs, List *argnames,
 		bool		use_defaults;
 		Oid			va_elem_type;
 		int		   *argnumbers = NULL;
+		List	   *defaults = NIL;
 		FuncCandidateList newResult;
 
 		if (OidIsValid(namespaceId))
@@ -1100,7 +1102,18 @@ FuncnameGetCandidates(List *names, int nargs, List *argnames,
 			}
 		}
 
-		if (argnames != NIL)
+		if (is_pltsql_language_oid(procform->prolang) &&
+			match_pltsql_func_call_hook)
+		{
+			if (!match_pltsql_func_call_hook(proctup, nargs, argnames,
+											 include_out_arguments,
+											 &argnumbers, &defaults,
+											 expand_defaults, expand_variadic,
+											 &use_defaults, &any_special,
+											 &variadic, &va_elem_type))
+				continue;
+		}
+		else if (argnames != NIL)
 		{
 			/*
 			 * Call uses named or mixed notation
@@ -1204,11 +1217,14 @@ FuncnameGetCandidates(List *names, int nargs, List *argnames,
 
 			for (i = 0; i < pronargs; i++)
 				newResult->args[i] = proargtypes[argnumbers[i]];
+
+			newResult->tsql_argdefaults = defaults;
 		}
 		else
 		{
 			/* Simple positional case, just copy proargtypes as-is */
 			memcpy(newResult->args, proargtypes, pronargs * sizeof(Oid));
+			newResult->tsql_argdefaults = NIL;
 		}
 		if (variadic)
 		{

--- a/src/backend/commands/functioncmds.c
+++ b/src/backend/commands/functioncmds.c
@@ -450,7 +450,7 @@ interpret_function_parameter_list(ParseState *pstate,
 		}
 		else
 		{
-			if (isinput && have_defaults)
+			if (isinput && have_defaults && !is_pltsql_language_oid(languageOid))
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_FUNCTION_DEFINITION),
 						 errmsg("input parameters after one with a default value must also have defaults")));
@@ -460,7 +460,7 @@ interpret_function_parameter_list(ParseState *pstate,
 			 * with a default, because the same sort of confusion arises in a
 			 * CALL statement.
 			 */
-			if (objtype == OBJECT_PROCEDURE && have_defaults)
+			if (objtype == OBJECT_PROCEDURE && have_defaults && !is_pltsql_language_oid(languageOid))
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_FUNCTION_DEFINITION),
 						 errmsg("procedure OUT parameters cannot appear after one with a default value")));

--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -1687,8 +1687,11 @@ func_get_detail(List *funcname,
 			defaults = castNode(List, stringToNode(str));
 			pfree(str);
 
+			/* Use tsql_argdefaults directly if it is not NIL */
+			if (best_candidate->argnumbers != NULL && best_candidate->tsql_argdefaults != NIL)
+				*argdefaults = best_candidate->tsql_argdefaults;
 			/* Delete any unused defaults from the returned list */
-			if (best_candidate->argnumbers != NULL)
+			else if (best_candidate->argnumbers != NULL)
 			{
 				/*
 				 * This is a bit tricky in named notation, since the supplied

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -318,6 +318,8 @@ static const char *query_getviewrule = "SELECT * FROM pg_catalog.pg_rewrite WHER
 /* GUC parameters */
 bool		quote_all_identifiers = false;
 
+print_pltsql_function_arguments_hook_type print_pltsql_function_arguments_hook = NULL;
+
 
 /* ----------
  * Local functions
@@ -3170,6 +3172,11 @@ print_function_arguments(StringInfo buf, HeapTuple proctup,
 	List	   *argdefaults = NIL;
 	ListCell   *nextargdefault = NULL;
 	int			i;
+
+	if (is_pltsql_language_oid(proc->prolang) &&
+		print_pltsql_function_arguments_hook)
+		return print_pltsql_function_arguments_hook(buf, proctup,
+								print_table_args, print_defaults);
 
 	numargs = get_func_arg_info(proctup,
 								&argtypes, &argnames, &argmodes);

--- a/src/backend/utils/cache/lsyscache.c
+++ b/src/backend/utils/cache/lsyscache.c
@@ -1183,6 +1183,21 @@ get_language_name(Oid langoid, bool missing_ok)
 	return NULL;
 }
 
+bool
+is_pltsql_language_oid(Oid langoid)
+{
+	Oid		pltsql_lang_oid = InvalidOid;
+	Oid		pltsql_validator_oid = InvalidOid;
+
+	if (get_func_language_oids_hook)
+		get_func_language_oids_hook(&pltsql_lang_oid, &pltsql_validator_oid);
+
+	if (OidIsValid(pltsql_lang_oid) && langoid == pltsql_lang_oid)
+		return true;
+
+	return false;
+}
+
 /*				---------- OPCLASS CACHE ----------						 */
 
 /*

--- a/src/include/catalog/namespace.h
+++ b/src/include/catalog/namespace.h
@@ -14,6 +14,7 @@
 #ifndef NAMESPACE_H
 #define NAMESPACE_H
 
+#include "access/htup.h"
 #include "nodes/primnodes.h"
 #include "storage/lock.h"
 
@@ -35,6 +36,7 @@ typedef struct _FuncCandidateList
 	int			nvargs;			/* number of args to become variadic array */
 	int			ndargs;			/* number of defaulted args */
 	int		   *argnumbers;		/* args' positional indexes, if named call */
+	List	   *tsql_argdefaults;    /* list of default args, only set for PL/tsql function */
 	Oid			args[FLEXIBLE_ARRAY_MEMBER];	/* arg types */
 }		   *FuncCandidateList;
 
@@ -81,6 +83,12 @@ typedef void (*RangeVarGetRelidCallback) (const RangeVar *relation, Oid relId,
  */
 typedef Oid (*relname_lookup_hook_type) (const char *relname, Oid relnamespace);
 extern PGDLLIMPORT relname_lookup_hook_type relname_lookup_hook;
+typedef bool (*match_pltsql_func_call_hook_type) (HeapTuple proctup, int nargs, List *argnames,
+												  bool include_out_arguments, int **argnumbers,
+												  List **defaults, bool expand_defaults, bool expand_variadic,
+												  bool *use_defaults, bool *any_special,
+												  bool *variadic, Oid *va_elem_type);
+extern PGDLLIMPORT match_pltsql_func_call_hook_type match_pltsql_func_call_hook;
 
 #define RangeVarGetRelid(relation, lockmode, missing_ok) \
 	RangeVarGetRelidExtended(relation, lockmode, \

--- a/src/include/optimizer/clauses.h
+++ b/src/include/optimizer/clauses.h
@@ -14,6 +14,7 @@
 #ifndef CLAUSES_H
 #define CLAUSES_H
 
+#include "access/htup.h"
 #include "nodes/pathnodes.h"
 
 typedef struct
@@ -54,5 +55,8 @@ extern Query *inline_set_returning_function(PlannerInfo *root,
 											RangeTblEntry *rte);
 
 extern Bitmapset *pull_paramids(Expr *expr);
+
+typedef void (*insert_pltsql_function_defaults_hook_type)(HeapTuple func_tuple, List *defaults, Node **argarray);
+extern PGDLLIMPORT insert_pltsql_function_defaults_hook_type insert_pltsql_function_defaults_hook;
 
 #endif							/* CLAUSES_H */

--- a/src/include/utils/lsyscache.h
+++ b/src/include/utils/lsyscache.h
@@ -102,6 +102,7 @@ extern bool get_collation_isdeterministic(Oid colloid);
 extern char *get_constraint_name(Oid conoid);
 extern Oid	get_constraint_index(Oid conoid);
 extern char *get_language_name(Oid langoid, bool missing_ok);
+extern bool is_pltsql_language_oid(Oid langoid);
 extern Oid	get_opclass_family(Oid opclass);
 extern Oid	get_opclass_input_type(Oid opclass);
 extern bool get_opclass_opfamily_and_input_type(Oid opclass,

--- a/src/include/utils/ruleutils.h
+++ b/src/include/utils/ruleutils.h
@@ -43,4 +43,10 @@ extern char *get_range_partbound_string(List *bound_datums);
 
 extern char *pg_get_statisticsobjdef_string(Oid statextid);
 
+typedef int (*print_pltsql_function_arguments_hook_type) (StringInfo buf,
+														  HeapTuple proctup,
+														  bool print_table_args,
+														  bool print_defaults);
+extern PGDLLIMPORT print_pltsql_function_arguments_hook_type print_pltsql_function_arguments_hook;
+
 #endif							/* RULEUTILS_H */

--- a/src/include/utils/syscache.h
+++ b/src/include/utils/syscache.h
@@ -116,10 +116,11 @@ enum SysCacheIdentifier
 	 * the IDs to conflict.
 	 */
 	SYSDATABASEOID,
-	SYSDATABASENAME
+	SYSDATABASENAME,
+	PROCNSPSIGNATURE
 
 #define SysCacheNoExtensionSize (USERMAPPINGUSERSERVER+ 1)
-#define SysCacheSize (SYSDATABASENAME + 1)
+#define SysCacheSize (PROCNSPSIGNATURE + 1)
 };
 
 /*


### PR DESCRIPTION
[Engine]
* PG has a restriction that input parameters after one with a default value must also have defaults. Previously we provided a workaround for this by letting user provide default parameters anywhere but filling NULL as default value for all parameters after first default parameter.
* This commit removes this restriction for all PL/tsql functions. We will be storing the positions of default parameters in a separate babelfish catalog table (babelfish_function_ext) so that we can use these positions while looking for the parameter default expression. Introduced following hooks to achieve the functionality:
  1. `match_pltsql_func_call_hook`: Will help in parsing a PL/tsql function call.
  2. `insert_pltsql_function_defaults_hook`: Will be used to insert actual default values in a PL/tsql function call during execution phase.
  3. `print_pltsql_function_arguments_hook`: Will be used to print arguments for PL/tsql function depending upon default positions in catalog table.

  Additionally, introduced a syscache id `PROCNSPSIGNATURE`
  for new babelfish_function_ext catalog which takes sysdatabase oid,
  logical schema name and function signature as input keys.

[Extensions]
* Implemented all the hooks introduced on engine side.
* Added a sql definition of babelfish_function_ext catalog table in which all three columns dbid, schema_name and function_signature combined will be used as a primary key and default_positions column will hold the list of argument's default positions.

Task: BABEL-2877
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>

### Check List

- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
