### PR TITLE
Fix issue with using strict/lax jsonpath with arrays

### DIFF
--- a/src/backend/utils/adt/jsonpath_exec.c
+++ b/src/backend/utils/adt/jsonpath_exec.c
@@ -550,16 +550,6 @@ tsql_openjson_with_columnize(Jsonb *jb, char *col_info)
 		}
 	}
 
-	if (strict)
-	{
-		char *tmp;
-		int len;
-		/* Since jsonb_path_query already can interpret strict/lax keywords, just put 'strict' back into the path */
-		len = 7 + strlen(col_path) + 1;
-		tmp = palloc0(len);
-		snprintf(tmp, len, "strict %s", col_path);
-		col_path = tmp;
-	}
 	if (JB_ROOT_IS_ARRAY(jb))
 	{
 		char *tmp;
@@ -568,6 +558,16 @@ tsql_openjson_with_columnize(Jsonb *jb, char *col_info)
 		len = 4 + strlen(col_path) + 1;
 		tmp = palloc0(len);
 		snprintf(tmp, len, "$[*]%s", &(col_path[1]));
+		col_path = tmp;
+	}
+	if (strict)
+	{
+		char *tmp;
+		int len;
+		/* Since jsonb_path_query already can interpret strict/lax keywords, just put 'strict' back into the path */
+		len = 7 + strlen(col_path) + 1;
+		tmp = palloc0(len);
+		snprintf(tmp, len, "strict %s", col_path);
 		col_path = tmp;
 	}
 


### PR DESCRIPTION
Signed-off-by: Jason Teng <jasonten@amazon.com>

### Description

Previously, tsql_openjson_with_columnize would first process the lax/strict keyword, and then check if the top-level object was an array. This would lead to a syntax error being reported when trying to use strict mode on an array. This commit reverses the order of the checks to prevent this issue from occurring.
 
### Issues Resolved

BABEL-3554
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
