### PR TITLE
Support duplicate trigger name in different database

### DIFF
--- a/src/backend/catalog/objectaddress.c
+++ b/src/backend/catalog/objectaddress.c
@@ -981,7 +981,7 @@ get_object_address(ObjectType objtype, Node *object,
 			case OBJECT_TRIGGER:
 				if(get_trigger_object_address_hook){
 						address = (*get_trigger_object_address_hook)(castNode(List, object),
-															&relation, missing_ok);
+															&relation, missing_ok,false);
 				}
 				else
 					address = get_object_address_relobject(objtype, castNode(List, object),

--- a/src/backend/catalog/objectaddress.c
+++ b/src/backend/catalog/objectaddress.c
@@ -979,9 +979,10 @@ get_object_address(ObjectType objtype, Node *object,
 													   &relation, missing_ok);
 				break;
 			case OBJECT_TRIGGER:
-				if(sql_dialect == SQL_DIALECT_TSQL && get_trigger_object_address_hook)
-					address = (*get_trigger_object_address_hook)(castNode(List, object),
+				if(get_trigger_object_address_hook){
+						address = (*get_trigger_object_address_hook)(castNode(List, object),
 															&relation, missing_ok);
+				}
 				else
 					address = get_object_address_relobject(objtype, castNode(List, object),
 													   &relation, missing_ok);

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -930,7 +930,7 @@ CreateTriggerFiringOn(CreateTrigStmt *stmt, const char *queryString,
 				newtrigger_schema_name = get_namespace_name(get_rel_namespace(RelationGetRelid(rel)));
 				
 				if (namestrcmp(&(pg_trigger->tgname), trigname) == 0
-							&& namestrcmp(newtrigger_schema_name, pg_trigger_schema_name) == 0)
+							&& strcasecmp(newtrigger_schema_name, pg_trigger_schema_name) == 0)
 					ereport(ERROR,
 							(errcode(ERRCODE_DUPLICATE_OBJECT),
 							errmsg("trigger \"%s\" already exists in the database",

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -220,6 +220,8 @@ CreateTriggerFiringOn(CreateTrigStmt *stmt, const char *queryString,
 	Oid			existing_constraint_oid = InvalidOid;
 	bool		existing_isInternal = false;
 	bool		is_composite_trigger = false;
+	char		*pg_trigger_schema_name;
+	char		*newtrigger_schema_name;
 
 	is_composite_trigger = IsCompositeTrigger(funcoid, stmt->funcname);
 
@@ -924,8 +926,11 @@ CreateTriggerFiringOn(CreateTrigStmt *stmt, const char *queryString,
 			while (HeapTupleIsValid(tuple = systable_getnext(tgscan)))
 			{
 				Form_pg_trigger pg_trigger = (Form_pg_trigger) GETSTRUCT(tuple);
-
-				if (namestrcmp(&(pg_trigger->tgname), trigname) == 0)
+				pg_trigger_schema_name = get_namespace_name(get_rel_namespace(pg_trigger->tgrelid));
+				newtrigger_schema_name = get_namespace_name(get_rel_namespace(RelationGetRelid(rel)));
+				
+				if (namestrcmp(&(pg_trigger->tgname), trigname) == 0
+							&& namestrcmp(newtrigger_schema_name, pg_trigger_schema_name) == 0)
 					ereport(ERROR,
 							(errcode(ERRCODE_DUPLICATE_OBJECT),
 							errmsg("trigger \"%s\" already exists in the database",

--- a/src/include/catalog/objectaddress.h
+++ b/src/include/catalog/objectaddress.h
@@ -86,7 +86,7 @@ extern struct ArrayType *strlist_to_textarray(List *list);
 
 extern ObjectType get_relkind_objtype(char relkind);
 
-typedef ObjectAddress (*get_trigger_object_address_hook_type)(List *object, Relation *relp, bool missing_ok);
+typedef ObjectAddress (*get_trigger_object_address_hook_type)(List *object, Relation *relp, bool missing_ok,bool object_from_input);
 extern PGDLLIMPORT get_trigger_object_address_hook_type get_trigger_object_address_hook;
 
 #endif							/* OBJECTADDRESS_H */

--- a/src/include/catalog/objectaddress.h
+++ b/src/include/catalog/objectaddress.h
@@ -86,7 +86,7 @@ extern struct ArrayType *strlist_to_textarray(List *list);
 
 extern ObjectType get_relkind_objtype(char relkind);
 
-extern ObjectAddress get_object_address_trigger_tsql(List *object,
-							Relation *relp, bool missing_ok);
+typedef ObjectAddress (*get_trigger_object_address_hook_type)(List *object, Relation *relp, bool missing_ok);
+extern PGDLLIMPORT get_trigger_object_address_hook_type get_trigger_object_address_hook;
 
 #endif							/* OBJECTADDRESS_H */


### PR DESCRIPTION
Support duplicate trigger name in different database

PR in BABEL extension : https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/680

Task:BABEL-3117
Signed-off-by: Zhenye Li <zhenye@amazon.com>

### Description
Previously, duplicate trigger name is not allowed in different database. But in sql server, different database can have the same trigger name. In this PR, we check if the trigger with the same trigger is not in current database, then the trigger can be created. And when drop trigger, we modified the pre check trigger in parsing stage to not throw error, and find the correct trigger to drop with trigger and database name. In this PR, we make `get_object_address_trigger_tsql` a hook type and move the function to hook.c file.
 
### Issues Resolved

BABEL-3117
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
