### PR TITLE
Support nondeterministic collations for LIKE in CHECK constraint clause

### DIFF
--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -3236,8 +3236,7 @@ cookConstraint(ParseState *pstate,
 	 * been invoked, but the invoked function must take care of preventing any
 	 * duplicated transformations.
 	 */
-	if(IsA(raw_constraint, A_Expr) && ((A_Expr*)raw_constraint)->kind == AEXPR_LIKE 
-			&& transform_check_constraint_expr_hook)
+	if(sql_dialect == SQL_DIALECT_TSQL && transform_check_constraint_expr_hook)
 		expr = transform_check_constraint_expr_hook(expr);
 
 	/*

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -68,7 +68,6 @@
 #include "executor/spi.h"
 #include "miscadmin.h"
 #include "nodes/nodeFuncs.h"
-#include "nodes/nodes.h"
 #include "optimizer/optimizer.h"
 #include "parser/parser.h"      /* only needed for GUC variables */
 #include "parser/parse_coerce.h"
@@ -3230,7 +3229,7 @@ cookConstraint(ParseState *pstate,
 	/* 
 	 * If there is a LIKE operation within CHECK constraint, then call the hook to 
 	 * transform like node into ilike node for tsql compatibility. Since utility 
-	 * statements do not get planned, we invoke a planner hook here to carry out the
+	 * statements do not get planned, we invoke a hook here to carry out the
 	 * transformation. 
 	 * Note that we cannot guarantee that this hook has not already
 	 * been invoked, but the invoked function must take care of preventing any

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -3236,7 +3236,7 @@ cookConstraint(ParseState *pstate,
 	 * been invoked, but the invoked function must take care of preventing any
 	 * duplicated transformations.
 	 */
-	if(sql_dialect == SQL_DIALECT_TSQL && transform_check_constraint_expr_hook)
+	if(transform_check_constraint_expr_hook)
 		expr = transform_check_constraint_expr_hook(expr);
 
 	/*

--- a/src/include/catalog/heap.h
+++ b/src/include/catalog/heap.h
@@ -162,4 +162,7 @@ extern void RemovePartitionKeyByRelId(Oid relid);
 extern void StorePartitionBound(Relation rel, Relation parent,
 								PartitionBoundSpec *bound);
 
+/* Hook for plugins to transform executable expressions in check constraint clause */
+typedef Node* (*transform_check_constraint_expr_hook_type) (Node *node);
+extern PGDLLIMPORT transform_check_constraint_expr_hook_type transform_check_constraint_expr_hook;
 #endif							/* HEAP_H */


### PR DESCRIPTION
Utility statements such as ALTER TABLE are not planned. Due to collation like to ilike transformation logic being called in a planner hook, CHECK constraint in utlity commands do not support LIKE for nondeterministic collations.

To solve this problem, we add a hook to invoke the like to ilike transformation function after the raw parsetree is transformed into an executable expression.

Task: BABEL-3319
Signed-off-by: Avantika Dasgupta <davantik@amazon.com>

Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/684