### PR TITLE
Support UDTS for sequences and ISC-sequences view

### DIFF
--- a/src/backend/commands/sequence.c
+++ b/src/backend/commands/sequence.c
@@ -1405,7 +1405,7 @@ init_params(ParseState *pstate, List *options, bool for_identity,
 											   &max_value,
 											   &min_value);
 
-		else newtypid = typenameTypeId(pstate,defGetTypeName(as_type));
+		if(!newtypid) newtypid = typenameTypeId(pstate,defGetTypeName(as_type));
 
 		if (newtypid != INT2OID &&
 			newtypid != INT4OID &&

--- a/src/backend/commands/sequence.c
+++ b/src/backend/commands/sequence.c
@@ -46,7 +46,6 @@
 #include "utils/resowner.h"
 #include "utils/syscache.h"
 #include "utils/varlena.h"
-#include "parser/parser.h"
 
 
 /*

--- a/src/backend/commands/sequence.c
+++ b/src/backend/commands/sequence.c
@@ -1395,6 +1395,12 @@ init_params(ParseState *pstate, List *options, bool for_identity,
 	/* AS type */
 	if (as_type != NULL)
 	{
+		/*
+		 * typenameTypeID is called after the hook to modify the schema name
+		 * internally used within the function when sequence is defined using a
+		 * user-defined data type
+		 */
+
 		Oid			newtypid = 0;
 
 		if (pltsql_sequence_datatype_hook)

--- a/src/backend/commands/sequence.c
+++ b/src/backend/commands/sequence.c
@@ -46,6 +46,7 @@
 #include "utils/resowner.h"
 #include "utils/syscache.h"
 #include "utils/varlena.h"
+#include "parser/parser.h"
 
 
 /*
@@ -1395,7 +1396,7 @@ init_params(ParseState *pstate, List *options, bool for_identity,
 	/* AS type */
 	if (as_type != NULL)
 	{
-		Oid			newtypid = typenameTypeId(pstate, defGetTypeName(as_type));
+		Oid			newtypid;
 
 		if (pltsql_sequence_datatype_hook)
 			(* pltsql_sequence_datatype_hook) (pstate,
@@ -1404,6 +1405,8 @@ init_params(ParseState *pstate, List *options, bool for_identity,
 											   as_type,
 											   &max_value,
 											   &min_value);
+
+		else newtypid = typenameTypeId(pstate,defGetTypeName(as_type));
 
 		if (newtypid != INT2OID &&
 			newtypid != INT4OID &&

--- a/src/backend/commands/sequence.c
+++ b/src/backend/commands/sequence.c
@@ -1395,7 +1395,7 @@ init_params(ParseState *pstate, List *options, bool for_identity,
 	/* AS type */
 	if (as_type != NULL)
 	{
-		Oid			newtypid;
+		Oid			newtypid = 0;
 
 		if (pltsql_sequence_datatype_hook)
 			(* pltsql_sequence_datatype_hook) (pstate,


### PR DESCRIPTION
- Creation of view information_schema_tsql.sequences to support for T-SQL INFORMATION_SCHEMA.SEQUENCES. 
- Provide support for creation of a sequence using user-defined data types which is currently not supported in Babelfish.
- Added support for cross-schema UDTs

Pull request for changes in extensions repository:
https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/663

### Testing 
No testing required here as the changes are getting tested in the PR on the extensions repository. 

Task: BABEL-3504, BABEL-3452
Signed-off-by: Aditya Verma <adiityav@amazon.com>

### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
