### PR TITLE
Avoid duplicate OBJECT_IDs after MVU

### DIFF
--- a/src/backend/access/transam/varsup.c
+++ b/src/backend/access/transam/varsup.c
@@ -33,6 +33,7 @@
 /* pointer to "variable cache" in shared memory (set up by shmem.c) */
 VariableCache ShmemVariableCache = NULL;
 
+GetNewObjectId_hook_type GetNewObjectId_hook = NULL;
 
 /*
  * Allocate the next FullTransactionId for a new transaction or
@@ -568,6 +569,9 @@ GetNewObjectId(void)
 			}
 		}
 	}
+
+	if (GetNewObjectId_hook)
+		GetNewObjectId_hook(ShmemVariableCache);
 
 	/* If we run out of logged for use oids then we must log more */
 	if (ShmemVariableCache->oidCount == 0)

--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -44,7 +44,7 @@ getMinOid(Archive *fout)
 					 "   union"
 					 "   select max(oid) oid from pg_class"
 					 "   union"
-					 "   select max(oid) from pg_type"
+					 "   select max(oid) oid from pg_type"
 					 "  ) t"
 					 );
 	res = ExecuteSqlQueryForSingleRow(fout, query->data);

--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -20,6 +20,24 @@
 #include "pg_dump.h"
 #include "pqexpbuffer.h"
 
+char *
+getMinOid(Archive *fout)
+{
+	PGresult *res;
+	PQExpBuffer query;
+	char *oid;
+
+	query = createPQExpBuffer();
+	appendPQExpBuffer(query, "SELECT next_oid FROM pg_control_checkpoint();");
+	res = ExecuteSqlQueryForSingleRow(fout, query->data);
+	oid = pg_strdup(PQgetvalue(res, 0, 0));
+
+	destroyPQExpBuffer(query);
+	PQclear(res);
+
+	return oid;
+}
+
 static char *
 getLanguageName(Archive *fout, Oid langid)
 {

--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -21,6 +21,7 @@
 #define PLTSQL_TVFTYPE_ITVF  2
 
 
+extern char *getMinOid(Archive *fout);
 extern void bbf_selectDumpableCast(CastInfo *cast);
 extern void fixTsqlDefaultExpr(Archive *fout, AttrDefInfo *attrDefInfo);
 extern bool isBabelfishDatabase(Archive *fout);

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -10581,7 +10581,12 @@ dumpExtension(Archive *fout, const ExtensionInfo *extinfo)
 	qextname = pg_strdup(fmtId(extinfo->dobj.name));
 
 	if (strstr(qextname, "babelfishpg_common") && isBabelfishDatabase(fout))
+	{
+		char *oid = getMinOid(fout);
 		appendPQExpBuffer(q, "SET babelfishpg_tsql.dump_restore = TRUE;\n");
+		appendPQExpBuffer(q, "SET babelfishpg_tsql.dump_restore_min_oid = %s;\n", oid);
+		free(oid);
+	}
 
 	appendPQExpBuffer(delq, "DROP EXTENSION %s;\n", qextname);
 

--- a/src/bin/pg_upgrade/pg_upgrade.c
+++ b/src/bin/pg_upgrade/pg_upgrade.c
@@ -162,12 +162,12 @@ main(int argc, char **argv)
 	 * the old system, but we do it anyway just in case.  We do it late here
 	 * because there is no need to have the schema load use new oids.
 	 */
-	prep_status("Setting next OID for new cluster");
-	exec_prog(UTILITY_LOG_FILE, NULL, true, true,
-			  "\"%s/pg_resetwal\" -o %u \"%s\"",
-			  new_cluster.bindir, old_cluster.controldata.chkpnt_nxtoid,
-			  new_cluster.pgdata);
-	check_ok();
+	// prep_status("Setting next OID for new cluster");
+	// exec_prog(UTILITY_LOG_FILE, NULL, true, true,
+	// 		  "\"%s/pg_resetwal\" -o %u \"%s\"",
+	// 		  new_cluster.bindir, old_cluster.controldata.chkpnt_nxtoid,
+	// 		  new_cluster.pgdata);
+	// check_ok();
 
 	prep_status("Sync data directory to disk");
 	exec_prog(UTILITY_LOG_FILE, NULL, true, true,

--- a/src/include/access/transam.h
+++ b/src/include/access/transam.h
@@ -290,6 +290,9 @@ extern void AdvanceOldestClogXid(TransactionId oldest_datfrozenxid);
 extern bool ForceTransactionIdLimitUpdate(void);
 extern Oid	GetNewObjectId(void);
 
+typedef void (*GetNewObjectId_hook_type) (VariableCache variableCache);
+extern PGDLLIMPORT GetNewObjectId_hook_type GetNewObjectId_hook;
+
 #ifdef USE_ASSERT_CHECKING
 extern void AssertTransactionIdInAllowableRange(TransactionId xid);
 #else


### PR DESCRIPTION
Signed-off-by: Jungkook Lee <jungkook@amazon.com>

### Description

PG allows duplicated OIDs in different catalog tables. However, in Babelfish, we use PG's OID as OBJECT_ID in all system catalog views and it should be unique within a logical database (https://github.com/MicrosoftDocs/sql-docs/blob/live/docs/relational-databases/system-catalog-views/sys-all-objects-transact-sql.md). Duplicate OIDs can break SQL server tools, e.g., SSMS, as well as customer applications.

In PG/Babelfish, duplicate OIDs can occur in the following two cases:
1. After MVU (Major Version Upgrade)
2. After hitting OID wraparound

This commit is to prevent duplicate OIDs during MVU and consists of two parts:

> First of all, from the old cluster, it finds the max OID in the 5 catalog tables: `pg_extension`, `pg_authid`, `pg_enum`, `pg_class` and `pg_type`. And then pass the max OID to the new cluster as a form of GUC, `babelfishpg_tsql.dump_restore_min_oid`. In the new cluster, set the nextOid greater than the max OID from the old cluster using `GetNewObjectId_hook`.

> Secondly, in `pg_upgrade.c`, it skips the step of transferring the next OID from the old cluster to the new cluster.

> Also note that the type of babelfishpg_tsql.dump_restore_min_oid is defined by `DefineCustomStringVariable()` to support UINT_MAX.

Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/693
 
### Issues Resolved

BABEL-3613

### Test Scenarios Covered ###
* **Use case based -** Yes
* **Boundary conditions -** Yes (babelfishpg_tsql.dump_restore_min_oid)
* **Arbitrary inputs -** N/A
* **Negative test cases -** N/A
* **Minor version upgrade tests -** Yes
* **Major version upgrade tests -** Yes
* **Performance tests -**N/A
* **Tooling impact -** N/A
* **Client tests -** N/A
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
