### PR TITLE
Improve identity value insert performance with IDENTITY_INSERT=on

### DIFF
--- a/src/include/commands/sequence.h
+++ b/src/include/commands/sequence.h
@@ -45,6 +45,10 @@ extern PGDLLIMPORT pltsql_nextval_hook_type pltsql_nextval_hook;
 typedef void (*pltsql_resetcache_hook_type) ();
 extern PGDLLIMPORT pltsql_resetcache_hook_type pltsql_resetcache_hook;
 
+/* Sequence setval hook */
+typedef int64 (*pltsql_setval_hook_type) (Oid seqid, int64 val, int64 last_val);
+extern pltsql_setval_hook_type pltsql_setval_hook;
+
 typedef struct FormData_pg_sequence_data
 {
 	int64		last_value;
@@ -89,6 +93,4 @@ extern void seq_desc(StringInfo buf, XLogReaderState *rptr);
 extern const char *seq_identify(uint8 info);
 extern void seq_mask(char *pagedata, BlockNumber blkno);
 
-/* BABELFISH */
-extern void do_setval_tsql(Oid relid, int64 next, bool iscalled);
 #endif							/* SEQUENCE_H */

--- a/src/include/commands/sequence.h
+++ b/src/include/commands/sequence.h
@@ -89,4 +89,6 @@ extern void seq_desc(StringInfo buf, XLogReaderState *rptr);
 extern const char *seq_identify(uint8 info);
 extern void seq_mask(char *pagedata, BlockNumber blkno);
 
+/* BABELFISH */
+extern void do_setval_tsql(Oid relid, int64 next, bool iscalled);
 #endif							/* SEQUENCE_H */


### PR DESCRIPTION
### Description
With IDENTITY_INSERT=on in a table, users are allowed to insert values in identity columns. We also need to update the last used identity for the table(seed) so that subsequent insertion with default identity can start from the same seed. As per the current approach, after inserting one row, we're doing a full scan of the table to find out the min/max identity value and updating these variables. This creates a huge performance bottleneck for data insertion and the performance degrades significantly as the number of rows increases in the table.

In T-SQL, the last used identity of a table is non-transactional. That means, it always increases (or decreases) irrespective of the underlying transaction commits/rollbacks. To implement this, we don't have to scan the entire table. We can just calculate the max(current seed, value to be inserted) and update the seed under the same lock.

Task: BABEL-3506
Signed-off-by: Kuntal Ghosh <kuntalgh@amazon.com>

### Functional Testing
Please check the extension PR for the same - https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/728

### Performance Testing
Please check the extension PR for the same - https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/728