### PR TITLE
Extending sp_babelfish_configure

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -7137,10 +7137,20 @@ parse_and_validate_value(struct config_generic *record,
 
 				if (!parse_bool(value, &newval->boolval))
 				{
-					ereport(elevel,
+					if (strstr(name, "babelfishpg_tsql") != NULL) {
+						ereport(elevel,
 							(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-							 errmsg("parameter \"%s\" requires a Boolean value",
-									name)));
+							 errmsg("Cannot set \"%s\" to \"%s\" - ignoring",
+									name, value)));
+
+					}
+					else{
+
+						ereport(elevel,
+								(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+								errmsg("parameter \"%s\" requires a Boolean value",
+										name)));
+					}
 					return false;
 				}
 
@@ -7157,11 +7167,22 @@ parse_and_validate_value(struct config_generic *record,
 				if (!parse_int(value, &newval->intval,
 							   conf->gen.flags, &hintmsg))
 				{
-					ereport(elevel,
+					if (strstr(name, "babelfishpg_tsql") != NULL) {
+						ereport(elevel,
 							(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-							 errmsg("invalid value for parameter \"%s\": \"%s\"",
+							 errmsg("Cannot set \"%s\" to \"%s\" - ignoring",
 									name, value),
 							 hintmsg ? errhint("%s", _(hintmsg)) : 0));
+
+					}
+					else
+					{
+						ereport(elevel,
+								(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+								errmsg("invalid value for parameter \"%s\": \"%s\"",
+										name, value),
+								hintmsg ? errhint("%s", _(hintmsg)) : 0));
+					}
 					return false;
 				}
 
@@ -7193,11 +7214,22 @@ parse_and_validate_value(struct config_generic *record,
 				if (!parse_real(value, &newval->realval,
 								conf->gen.flags, &hintmsg))
 				{
-					ereport(elevel,
+					if (strstr(name, "babelfishpg_tsql") != NULL) {
+						ereport(elevel,
 							(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-							 errmsg("invalid value for parameter \"%s\": \"%s\"",
+							 errmsg("Cannot set \"%s\" to \"%s\" - ignoring",
 									name, value),
 							 hintmsg ? errhint("%s", _(hintmsg)) : 0));
+
+					}
+					else
+					{
+						ereport(elevel,
+								(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+								errmsg("invalid value for parameter \"%s\": \"%s\"",
+										name, value),
+								hintmsg ? errhint("%s", _(hintmsg)) : 0));
+					}
 					return false;
 				}
 
@@ -7262,13 +7294,22 @@ parse_and_validate_value(struct config_generic *record,
 					hintmsg = config_enum_get_options(conf,
 													  "Available values: ",
 													  ".", ", ");
-
-					ereport(elevel,
+					if (strstr(name, "babelfishpg_tsql") != NULL) {
+						ereport(elevel,
 							(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-							 errmsg("invalid value for parameter \"%s\": \"%s\"",
+							 errmsg("Cannot set \"%s\" to \"%s\" - ignoring",
 									name, value),
 							 hintmsg ? errhint("%s", _(hintmsg)) : 0));
 
+					}
+					else
+					{
+						ereport(elevel,
+								(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+								errmsg("invalid value for parameter \"%s\": \"%s\"",
+										name, value),
+								hintmsg ? errhint("%s", _(hintmsg)) : 0));
+					}
 					if (hintmsg)
 						pfree(hintmsg);
 					return false;


### PR DESCRIPTION
Task:
Signed-off-by: Zhenye Li <zhenye@amazon.com>

### Description

This change allows user use sp_babelfish_configure to set all Gucs for EXPLAIN, except for babelfishpg_tsql.explain_format. The Guc name that can be specified with wildcars is extenped to all the babel gucs instead of just escape_hatch Gucs. When using '%' as input guc name, 'ingore' and 'strict' setting only applies to Gucs that allow these two options. When using '%' as input guc name, 'default' applies to all Gucs and set Gucs setting to their defult values.

PR in BABEL repo : https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/746
 
### Issues Resolved

BABEL-3588
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
