### PR TITLE
Adding support for SELECT FOR JSON

### DIFF
--- a/src/backend/utils/adt/json.c
+++ b/src/backend/utils/adt/json.c
@@ -1381,21 +1381,13 @@ json_typeof(PG_FUNCTION_ARGS)
  * 
  * Transform the input key,val into json key:val pair
  */
-StringInfo
-tsql_json_build_object(Datum colname, Datum colval, Oid collation, bool is_null)
-{
-	StringInfo	result;
-
-	result = makeStringInfo();
-	
+void
+tsql_json_build_object(StringInfo result,Datum colname, Datum colval, Oid collation, bool is_null)
+{	
 	add_json(colname, false, result, CSTRINGOID, true);
 
 	appendStringInfoString(result, ":");
-	if (is_null)
-		add_json(colval, true, result, collation, false);
-	else
-		add_json(colval, false, result, collation, false);
 	
-	return result;
+	add_json(colval, is_null, result, collation, false);
 }
 

--- a/src/backend/utils/adt/json.c
+++ b/src/backend/utils/adt/json.c
@@ -1374,3 +1374,28 @@ json_typeof(PG_FUNCTION_ARGS)
 
 	PG_RETURN_TEXT_P(cstring_to_text(type));
 }
+
+
+/*
+ * SQL function tsql_json_build_object()
+ * 
+ * Transform the input key,val into json key:val pair
+ */
+StringInfo
+tsql_json_build_object(Datum colname, Datum colval, Oid collation, bool is_null)
+{
+	StringInfo	result;
+
+	result = makeStringInfo();
+	
+	add_json(colname, false, result, CSTRINGOID, true);
+
+	appendStringInfoString(result, ":");
+	if (is_null)
+		add_json(colval, true, result, collation, false);
+	else
+		add_json(colval, false, result, collation, false);
+	
+	return result;
+}
+

--- a/src/include/parser/parser.h
+++ b/src/include/parser/parser.h
@@ -83,6 +83,19 @@ typedef enum
 	DATEFIRST_SUNDAY
 } DATEFIRST;
 
+/* Enum declaration to support FOR JSON clause */
+typedef enum
+{
+	TSQL_FORJSON_AUTO,
+	TSQL_FORJSON_PATH,
+} TSQLFORJSONMode;
+
+typedef enum
+{
+	TSQL_JSON_DIRECTIVE_INCLUDE_NULL_VALUES,
+	TSQL_JSON_DIRECTIVE_WITHOUT_ARRAY_WRAPPER
+} TSQLJSONDirective;
+
 /* GUC variables in scan.l (every one of these is a bad idea :-() */
 extern int	backslash_quote;
 extern bool escape_string_warning;

--- a/src/include/utils/json.h
+++ b/src/include/utils/json.h
@@ -20,6 +20,6 @@
 extern void escape_json(StringInfo buf, const char *str);
 extern char *JsonEncodeDateTime(char *buf, Datum value, Oid typid,
 								const int *tzp);
-extern StringInfo tsql_json_build_object(Datum colname, Datum colval, Oid collation, bool is_null);
+extern void tsql_json_build_object(StringInfo result,Datum colname, Datum colval, Oid collation, bool is_null);
 
 #endif							/* JSON_H */

--- a/src/include/utils/json.h
+++ b/src/include/utils/json.h
@@ -20,5 +20,6 @@
 extern void escape_json(StringInfo buf, const char *str);
 extern char *JsonEncodeDateTime(char *buf, Datum value, Oid typid,
 								const int *tzp);
+extern StringInfo tsql_json_build_object(Datum colname, Datum colval, Oid collation, bool is_null);
 
 #endif							/* JSON_H */


### PR DESCRIPTION
### Description

- Enum declaration of FOR JSON modes and directives
- function support for converting input key,val into json key, value pair

Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/769

TASK: BABEL-3669
Signed-off-by: Anuj Sarda <sardanuj@amazon.com>
 
### Issues Resolved

BABEL- 3669
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
