### PR TITLE
Revert "Support TSQL ownership chaining within same DB in procedure"

### DIFF
--- a/src/backend/catalog/aclchk.c
+++ b/src/backend/catalog/aclchk.c
@@ -100,11 +100,6 @@ typedef struct
  */
 bool		binary_upgrade_record_init_privs = false;
 
-pg_class_aclmask_hook_type pg_class_aclmask_hook = NULL;
-pg_proc_aclchk_hook_type pg_proc_aclchk_hook = NULL;
-pg_attribute_aclchk_hook_type pg_attribute_aclchk_hook = NULL;
-pg_attribute_aclchk_all_hook_type pg_attribute_aclchk_all_hook = NULL;
-
 static void ExecGrantStmt_oids(InternalGrant *istmt);
 static void ExecGrant_Relation(InternalGrant *grantStmt);
 static void ExecGrant_Database(InternalGrant *grantStmt);
@@ -3895,20 +3890,6 @@ pg_class_aclmask_ext(Oid table_oid, Oid roleid, AclMode mask,
 		return mask;
 	}
 
-	if (pg_class_aclmask_hook)
-	{
-		bool has_permission_via_hook = false;
-		bool read_write_all_data_safe = false;
-
-		(*pg_class_aclmask_hook) (classForm, table_oid, roleid, mask, &has_permission_via_hook, &read_write_all_data_safe);
-
-		if (has_permission_via_hook)
-		{
-			ReleaseSysCache(tuple);
-			return mask;
-		}
-	}
-
 	/*
 	 * Normal case: get the relation's ACL from pg_class
 	 */
@@ -4592,16 +4573,8 @@ pg_attribute_aclcheck_ext(Oid table_oid, AttrNumber attnum,
 	if (pg_attribute_aclmask_ext(table_oid, attnum, roleid, mode,
 								 ACLMASK_ANY, is_missing) != 0)
 		return ACLCHECK_OK;
-	if (pg_attribute_aclchk_hook)
-	{
-		bool has_access_via_hook = false;
-		(*pg_attribute_aclchk_hook) (table_oid, attnum, roleid, mode, &has_access_via_hook);
-
-		if (has_access_via_hook)
-			return ACLCHECK_OK;
-	}
-
-	return ACLCHECK_NO_PRIV;
+	else
+		return ACLCHECK_NO_PRIV;
 }
 
 /*
@@ -4698,15 +4671,6 @@ pg_attribute_aclcheck_all(Oid table_oid, Oid roleid, AclMode mode,
 		}
 	}
 
-	if (result == ACLCHECK_NO_PRIV && pg_attribute_aclchk_all_hook)
-	{
-		bool has_access_via_hook = false;
-		(*pg_attribute_aclchk_all_hook) (table_oid, roleid, mode, how, &has_access_via_hook);
-
-		if (has_access_via_hook)
-			return ACLCHECK_OK;
-	}
-
 	return result;
 }
 
@@ -4760,17 +4724,8 @@ pg_proc_aclcheck(Oid proc_oid, Oid roleid, AclMode mode)
 {
 	if (pg_proc_aclmask(proc_oid, roleid, mode, ACLMASK_ANY) != 0)
 		return ACLCHECK_OK;
-
-	if (pg_proc_aclchk_hook)
-	{
-		bool has_access_via_hook = false;
-		(*pg_proc_aclchk_hook) (proc_oid, roleid, mode, &has_access_via_hook);
-
-		if (has_access_via_hook)
-			return ACLCHECK_OK;
-	}
-
-	return ACLCHECK_NO_PRIV;
+	else
+		return ACLCHECK_NO_PRIV;
 }
 
 /*

--- a/src/include/utils/acl.h
+++ b/src/include/utils/acl.h
@@ -33,7 +33,6 @@
 #define ACL_H
 
 #include "access/htup.h"
-#include "catalog/pg_class.h"
 #include "nodes/parsenodes.h"
 #include "parser/parse_node.h"
 #include "utils/snapshot.h"
@@ -319,16 +318,5 @@ extern bool pg_subscription_ownercheck(Oid sub_oid, Oid roleid);
 extern bool pg_statistics_object_ownercheck(Oid stat_oid, Oid roleid);
 extern bool has_createrole_privilege(Oid roleid);
 extern bool has_bypassrls_privilege(Oid roleid);
-
-typedef void (*pg_class_aclmask_hook_type) (Form_pg_class classForm, Oid table_oid, Oid roleid, AclMode mask, bool *has_permission_via_hook, bool *read_write_all_data_safe);
-extern PGDLLIMPORT pg_class_aclmask_hook_type pg_class_aclmask_hook;
-
-typedef void (*pg_proc_aclchk_hook_type) (Oid proc_oid, Oid roleid, AclMode mode, bool *has_access);
-extern PGDLLIMPORT pg_proc_aclchk_hook_type pg_proc_aclchk_hook;
-
-typedef void (*pg_attribute_aclchk_hook_type) (Oid table_oid, AttrNumber attnum, Oid roleid, AclMode mode, bool *has_access);
-extern PGDLLIMPORT pg_attribute_aclchk_hook_type pg_attribute_aclchk_hook;
-typedef void (*pg_attribute_aclchk_all_hook_type) (Oid table_oid, Oid roleid, AclMode mode, AclMaskHow how, bool *has_access);
-extern PGDLLIMPORT pg_attribute_aclchk_all_hook_type pg_attribute_aclchk_all_hook;
 
 #endif							/* ACL_H */


### PR DESCRIPTION
### Description

Revert "Support TSQL ownership chaining within same DB in procedure"

This reverts commit 30d56a117d5dd121e029c35cfdf0a3a4364893ae.
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
