### PR TITLE
SELECT FOR JSON Move Enum declaration to extensions

### DIFF
--- a/src/include/parser/parser.h
+++ b/src/include/parser/parser.h
@@ -83,19 +83,6 @@ typedef enum
 	DATEFIRST_SUNDAY
 } DATEFIRST;
 
-/* Enum declaration to support FOR JSON clause */
-typedef enum
-{
-	TSQL_FORJSON_AUTO,
-	TSQL_FORJSON_PATH,
-} TSQLFORJSONMode;
-
-typedef enum
-{
-	TSQL_JSON_DIRECTIVE_INCLUDE_NULL_VALUES,
-	TSQL_JSON_DIRECTIVE_WITHOUT_ARRAY_WRAPPER
-} TSQLJSONDirective;
-
 /* GUC variables in scan.l (every one of these is a bad idea :-() */
 extern int	backslash_quote;
 extern bool escape_string_warning;


### PR DESCRIPTION
### Description

- Moving enum declaration for FOR JSON from engine's parser.h to extensions forjson.h
- This is not a complete fix for the issue

PR Extensions- https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/875

TASK: BABEL-3691
Signed-off-by: Anuj Sarda sardanuj@amazon.com
 
### Issues Resolved

BABEL-3691
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
