### PR TITLE
Fix warnings which is occuring during compilation of babel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
       - name: build-postgres
         run: |
-          ./configure
+          ./configure CFLAGS="-Werror"
           make world-bin -j8
       - name: run-tests
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       - name: build-postgres
         run: |
           ./configure
-          make world-bin -j8 COPT='-Werror'
+          make world-bin -j8
       - name: run-tests
         run: |
           make check -j8

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       - name: build-postgres
         run: |
           ./configure
-          make world-bin -j8
+          make world-bin -j8 COPT='-Werror'
       - name: run-tests
         run: |
           make check -j8

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,8 +13,8 @@ jobs:
         uses: actions/checkout@v2
       - name: build-postgres
         run: |
-          ./configure CFLAGS="-Werror"
-          make world-bin -j8
+          ./configure
+          make world-bin -j8 COPT='-Werror'
       - name: run-tests
         run: |
           make check -j8

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,6 @@
 
 # AIX make defaults to building *every* target of the first rule.  Start with
 # a single-target, empty rule to make the other targets non-default.
-export COPT=$COPT" -Werror"  # all warnings being treated as errors
-
 all:
 
 all check install installdirs installcheck installcheck-parallel uninstall clean distclean maintainer-clean dist distcheck world check-world install-world installcheck-world:

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@
 
 # AIX make defaults to building *every* target of the first rule.  Start with
 # a single-target, empty rule to make the other targets non-default.
+export COPT=$COPT" -Werror"  # all warnings being treated as errors
+
 all:
 
 all check install installdirs installcheck installcheck-parallel uninstall clean distclean maintainer-clean dist distcheck world check-world install-world installcheck-world:

--- a/src/backend/utils/adt/encode.c
+++ b/src/backend/utils/adt/encode.c
@@ -223,43 +223,6 @@ hex_decode(const char *src, size_t len, char *dst)
 	return p - dst;
 }
 
-/* A variant of the above hex_decode function, but allows odd number of hex digits */
-uint64
-hex_decode_allow_odd_digits(const char *src, unsigned len, char *dst)
-{
-	const char *s,
-			   *srcend;
-	char		v1,
-				v2,
-			   *p;
-
-	srcend = src + len;
-	s = src;
-	p = dst;
-
-	if (len % 2 == 1)
-	{
-		/* If input has odd number of hex digits, add a 0 to the front to make it even */
-		v1 = '\0';
-		v2 = get_hex(*s++);
-		*p++ = v1 | v2;
-	}
-	/* The rest of the input must have even number of digits*/
-	while (s < srcend)
-	{
-		if (*s == ' ' || *s == '\n' || *s == '\t' || *s == '\r')
-		{
-			s++;
-			continue;
-		}
-		v1 = get_hex(*s++) << 4;
-		v2 = get_hex(*s++);
-		*p++ = v1 | v2;
-	}
-
-	return p - dst;
-}
-
 static uint64
 hex_enc_len(const char *src, size_t srclen)
 {

--- a/src/backend/utils/adt/numeric.c
+++ b/src/backend/utils/adt/numeric.c
@@ -5915,14 +5915,7 @@ bigint_poly_sum(PG_FUNCTION_ARGS)
 {
 
 	PolyNumAggState		*state;
-	#ifdef HAVE_INT128
-		int128		result;
-	#else
-		Datum temp;
-		bool is_overflow;
-		int64 result;
-		NumericVar nvar;
-	#endif
+	
 
 	state = PG_ARGISNULL(0) ? NULL : (PolyNumAggState *) PG_GETARG_POINTER(0);
 	/* If there were no non-null inputs, return NULL */
@@ -5930,6 +5923,7 @@ bigint_poly_sum(PG_FUNCTION_ARGS)
 		PG_RETURN_NULL();
 
 	#ifdef HAVE_INT128
+		int128		result;
 		result = state->sumX;
 
 		if (unlikely(result < PG_INT64_MIN) || unlikely(result > PG_INT64_MAX))
@@ -5941,6 +5935,10 @@ bigint_poly_sum(PG_FUNCTION_ARGS)
 		else
 			PG_RETURN_INT64((int64) result);
 	#else
+		Datum temp;
+		bool is_overflow;
+		int64 result;
+		NumericVar nvar;
 		temp = numeric_sum(fcinfo);
 		init_var(&nvar);
 		set_var_from_num(DatumGetNumeric(temp), &nvar);

--- a/src/backend/utils/adt/numeric.c
+++ b/src/backend/utils/adt/numeric.c
@@ -5915,6 +5915,14 @@ bigint_poly_sum(PG_FUNCTION_ARGS)
 {
 
 	PolyNumAggState		*state;
+	#ifdef HAVE_INT128
+		int128		result;
+	#else
+		Datum temp;
+		bool is_overflow;
+		int64 result;
+		NumericVar nvar;
+	#endif
 
 	state = PG_ARGISNULL(0) ? NULL : (PolyNumAggState *) PG_GETARG_POINTER(0);
 	/* If there were no non-null inputs, return NULL */
@@ -5922,7 +5930,6 @@ bigint_poly_sum(PG_FUNCTION_ARGS)
 		PG_RETURN_NULL();
 
 	#ifdef HAVE_INT128
-		int128		result;
 		result = state->sumX;
 
 		if (unlikely(result < PG_INT64_MIN) || unlikely(result > PG_INT64_MAX))
@@ -5934,11 +5941,6 @@ bigint_poly_sum(PG_FUNCTION_ARGS)
 		else
 			PG_RETURN_INT64((int64) result);
 	#else
-		Datum temp;
-		bool is_overflow;
-		int64 result;
-		NumericVar nvar;
-
 		temp = numeric_sum(fcinfo);
 		init_var(&nvar);
 		set_var_from_num(DatumGetNumeric(temp), &nvar);

--- a/src/backend/utils/adt/numeric.c
+++ b/src/backend/utils/adt/numeric.c
@@ -5915,7 +5915,14 @@ bigint_poly_sum(PG_FUNCTION_ARGS)
 {
 
 	PolyNumAggState		*state;
-	
+	#ifdef HAVE_INT128
+		int128		result;
+	#else
+		Datum temp;
+		bool is_overflow;
+		int64 result;
+		NumericVar nvar;
+	#endif
 
 	state = PG_ARGISNULL(0) ? NULL : (PolyNumAggState *) PG_GETARG_POINTER(0);
 	/* If there were no non-null inputs, return NULL */
@@ -5923,7 +5930,6 @@ bigint_poly_sum(PG_FUNCTION_ARGS)
 		PG_RETURN_NULL();
 
 	#ifdef HAVE_INT128
-		int128		result;
 		result = state->sumX;
 
 		if (unlikely(result < PG_INT64_MIN) || unlikely(result > PG_INT64_MAX))
@@ -5935,10 +5941,6 @@ bigint_poly_sum(PG_FUNCTION_ARGS)
 		else
 			PG_RETURN_INT64((int64) result);
 	#else
-		Datum temp;
-		bool is_overflow;
-		int64 result;
-		NumericVar nvar;
 		temp = numeric_sum(fcinfo);
 		init_var(&nvar);
 		set_var_from_num(DatumGetNumeric(temp), &nvar);

--- a/src/include/nodes/nodeFuncs.h
+++ b/src/include/nodes/nodeFuncs.h
@@ -159,7 +159,7 @@ struct PlanState;
 extern bool planstate_tree_walker(struct PlanState *planstate, bool (*walker) (),
 								  void *context);
 
-typedef int32 (*coalesce_typmod_hook_type) (CoalesceExpr *cexpr);
+typedef int32 (*coalesce_typmod_hook_type) (const CoalesceExpr *cexpr);
 extern PGDLLIMPORT coalesce_typmod_hook_type coalesce_typmod_hook;
 
 #endif							/* NODEFUNCS_H */


### PR DESCRIPTION
Signed-off-by: Sumit Jaiswal <sumiji@amazon.com>

### Description
So far we were getting lots of warning during compilation of babel. This commit fix warnings which were occurring during compilation of babel and adds flag in github workflow so that warnings will be treated as errors.

Extension PR : https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/790
 
### Issues Resolved

[BABEL-3666]
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
