### PR TITLE
[BABEL-3315] Correct the default collation of Babelfish data types except text and ntext data types

### DIFF
--- a/src/backend/commands/typecmds.c
+++ b/src/backend/commands/typecmds.c
@@ -78,6 +78,8 @@
 
 bool enable_domain_typmod = false;
 
+define_type_default_collation_hook_type define_type_default_collation_hook = NULL;
+
 /* result structure for get_rels_with_domain() */
 typedef struct
 {
@@ -452,8 +454,16 @@ DefineType(ParseState *pstate, List *names, List *parameters)
 					(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 					 errmsg("storage \"%s\" not recognized", a)));
 	}
+
 	if (collatableEl)
 		collation = defGetBoolean(collatableEl) ? DEFAULT_COLLATION_OID : InvalidOid;
+
+	/*
+	 * For Babelfish, we are creating new types during create extension time under sys schema,
+	 * We want these data types being created under sys schema to have the correct default tsql collation.
+	 */
+	if (collatableEl && defGetBoolean(collatableEl) && define_type_default_collation_hook)
+		collation = (*define_type_default_collation_hook)(typeNamespace);
 
 	/*
 	 * make sure we have our required definitions

--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -31,5 +31,6 @@ extern bool isTsqlTableType(Archive *fout, const TableInfo *tbinfo);
 extern int getTsqlTvfType(Archive *fout, const FuncInfo *finfo, char prokind, bool proretset);
 extern void fixAttoptionsBbfOriginalName(Archive *fout, Oid relOid, const TableInfo *tbinfo, int idx);
 extern void setOrResetPltsqlFuncRestoreGUCs(Archive *fout, PQExpBuffer q, const FuncInfo *finfo, char prokind, bool proretset, bool is_set);
+extern void dumpBabelfishSpecificConfig(Archive *AH, const char *dbname, PQExpBuffer outbuf);
 
 #endif

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -3248,6 +3248,10 @@ dumpDatabaseConfig(Archive *AH, PQExpBuffer outbuf,
 
 	PQclear(res);
 
+	/* Dump babelfish specific GUCs for which the user defined value should be persisted during upgrade */
+	if (isBabelfishDatabase(AH))
+		dumpBabelfishSpecificConfig(AH, dbname, outbuf);
+
 	/* Now look for role-and-database-specific options */
 	printfPQExpBuffer(buf, "SELECT rolname, unnest(setconfig) "
 					  "FROM pg_db_role_setting s, pg_roles r "

--- a/src/include/commands/typecmds.h
+++ b/src/include/commands/typecmds.h
@@ -59,4 +59,8 @@ extern Oid	AlterTypeNamespaceInternal(Oid typeOid, Oid nspOid,
 extern ObjectAddress AlterType(AlterTypeStmt *stmt);
 
 extern bool enable_domain_typmod;
+
+typedef Oid (*define_type_default_collation_hook_type)(Oid);
+extern PGDLLIMPORT define_type_default_collation_hook_type define_type_default_collation_hook;
+
 #endif							/* TYPECMDS_H */


### PR DESCRIPTION
### Description

By default, Postgres does not allow us to specify collation for new data types being defined and it would pick PG's default collation (which is deterministic collation) as a default collation for new data type. This is not an ideal behaviour for Babelfish data types as non-deterministic collation behaviour is expected for Babelfish data types. So we altered the logic of  DefineDomain() to pick the correct default tsql collation for Babelfish data types. To achieve this, we have exposed new hook called define_type_default_collation_hook which is implemented inside babelfishpg_common extension and would update the default collation for the sys data types.

The user defined setting for the GUCs like babelfishpg_tsql.server_collation_name and babelfishpg_tsql.default_locale should be persisted during major version upgrade to version 2.3.0. The value of these GUC would be used to set the correct default collation for Babelfish data types. To preserve the setting, we have created two new GUCs namely babelfishpg_tsql.restored_server_collation_name and babelfishpg_tsql.restored_default_locale to restore the user defined value of babelfishpg_tsql.server_collation_name and babelfishpg_tsql.default_locale GUCs. And we have to dump these new GUCs and restore it during upgrade. So, made some tweak in dumpDatabaseConfig() to dump these new GUCs with user defined value of babelfishpg_tsql.server_collation_name and babelfishpg_tsql.default_locale GUCs forcefully if given database is Babelfish enabled.
 
Extensions PR - https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/912
Task: BABEL-3315
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
