### PR TITLE
PG15: Fix tests related to Numeric datatype in REL3_X_DEV branch

### DIFF
--- a/src/include/parser/parse_type.h
+++ b/src/include/parser/parse_type.h
@@ -61,4 +61,11 @@ extern void parseTypeString(const char *str, Oid *typeid_p, int32 *typmod_p, boo
 typedef void (*check_or_set_default_typmod_hook_type)(TypeName * typeName, int32 *typmod, bool is_cast);
 extern PGDLLIMPORT check_or_set_default_typmod_hook_type check_or_set_default_typmod_hook;
 
+/*
+ * Hook to check whether variable length datatypes like numeric, decimal, time, datetime2, datetimeoffset
+ * are declared with permissible datalength at the time of table or stored procedure creation
+ */
+typedef void (*verify_valid_scale_in_variable_length_datatypes_hook_type)(char *dataTypeName, int scale, int precision);
+extern PGDLLIMPORT verify_valid_scale_in_variable_length_datatypes_hook_type verify_valid_scale_in_variable_length_datatypes_hook;
+
 #endif							/* PARSE_TYPE_H */


### PR DESCRIPTION
### Description
PG15 has introduced a community change for numeric datatype as below:
Formerly, when specifying NUMERIC(precision, scale), the scale had to be in the range [0, precision], which was per SQL spec. This commit extends the range of allowed scales to [-1000, 1000], independent of
the precision (whose valid range remains [1, 1000]). A negative scale implies rounding before the decimal point. For
example, a column might be declared with a scale of -3 to round values to the nearest thousand. Note that the display scale remains non-negative, so in this case the display scale will be zero, and all digits before the decimal point will be displayed.
A scale greater than the precision supports fractional values with zeros immediately after the decimal point.

From SQL spec aspect which means checking explicitly whether 0 <= scale <= precision and 1 <= precision <= 38, which was earlier done by underlying PG code for any numeric/decimal input data.

Along with the above change, it is found that all variable length datatypes like numeric, decimal, time, datetime2, datetimeoffset need explicit checking on their permissible datalength at the time of table or stored procedure creation and generate error if required.
Before fix, Babelfish was not complaining for the above behaviour.

Task: BABEL-3720, BABEL-3793
Signed-off-by: Satarupa Biswas <satarupb@amazon.com>

 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
