### PR TITLE
Fix warnings which is occuring during compilation of babel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       - name: build-postgres
         run: |
           ./configure
-          make world-bin -j8
+          make world-bin -j8 COPT='-Werror'
       - name: run-tests
         run: |
           make check -j8

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -429,6 +429,8 @@ SPI_rollback_and_chain(void)
 void
 AtEOXact_SPI(bool isCommit)
 {
+	bool		found = false;
+	
 	if (!isCommit)
 	{
 		while (_SPI_current && !_SPI_current->internal_xact)
@@ -441,7 +443,6 @@ AtEOXact_SPI(bool isCommit)
 		}
 	}
 
-	bool		found = false;
 
 	/*
 	 * Pop stack entries, stopping if we find one marked internal_xact (that


### PR DESCRIPTION


### Description
So far we were getting lots of warning during compilation of babel. This commit fix warnings which were occurring during compilation of babel and adds flag in github workflow so that warnings will be treated as errors.

Extension PR : https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/943
 
Signed-off-by: Sumit Jaiswal <sumiji@amazon.com>
### Issues Resolved

[BABEL-3666]
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
