### PR TITLE
Improve security definer for procedures/functions by avoid Lookup for GUC values

### DIFF
--- a/src/backend/catalog/namespace.c
+++ b/src/backend/catalog/namespace.c
@@ -4480,7 +4480,10 @@ assign_search_path(const char *newval, void *extra)
 	baseSearchPathValid = false;
 }
 
-/* assign_hook: do extra actions as needed */
+/* assign_hook: do extra actions as needed when assigning the GUC. This function
+ * should also be invoked whenever changing the GUC value directly without
+ * set_config_option.
+ */
 void
 assign_sql_dialect(int newval, void *extra)
 {

--- a/src/backend/catalog/namespace.c
+++ b/src/backend/catalog/namespace.c
@@ -4480,7 +4480,8 @@ assign_search_path(const char *newval, void *extra)
 	baseSearchPathValid = false;
 }
 
-/* assign_hook: do extra actions as needed when assigning the GUC. This function
+/*
+ * assign_hook: do extra actions as needed when assigning the GUC. This function
  * should also be invoked whenever changing the GUC value directly without
  * set_config_option.
  */

--- a/src/backend/utils/fmgr/fmgr.c
+++ b/src/backend/utils/fmgr/fmgr.c
@@ -870,8 +870,10 @@ fmgr_security_definer(PG_FUNCTION_ARGS)
 		 * design for PG vs TSQL procedures.
 		 */
 		if (set_sql_dialect)
+		{
 			sql_dialect = sql_dialect_value_old;
 			assign_sql_dialect(sql_dialect_value_old, newextra);
+		}
 
 		PG_RE_THROW();
 	}

--- a/src/backend/utils/fmgr/fmgr.c
+++ b/src/backend/utils/fmgr/fmgr.c
@@ -710,10 +710,11 @@ fmgr_security_definer(PG_FUNCTION_ARGS)
 	bool		set_sql_dialect;
 	int			sql_dialect_value;
 	int			sql_dialect_value_old;
-	int			pg_dialect = 0;
-	int			tsql_dialect = 1;
+	int			pg_dialect = SQL_DIALECT_PG;
+	int			tsql_dialect = SQL_DIALECT_TSQL;
 	int			sys_func_count = 0;
 	int			non_tsql_proc_count = 0;
+	void	   *newextra = NULL;
 
 	if (!fcinfo->flinfo->fn_extra)
 	{
@@ -824,6 +825,7 @@ fmgr_security_definer(PG_FUNCTION_ARGS)
 		ReleaseSysCache(tuple);
 		sql_dialect_value_old = sql_dialect;
 		sql_dialect = sql_dialect_value;
+		assign_sql_dialect(sql_dialect_value, newextra);
 
 	}
 
@@ -869,6 +871,7 @@ fmgr_security_definer(PG_FUNCTION_ARGS)
 		 */
 		if (set_sql_dialect)
 			sql_dialect = sql_dialect_value_old;
+			assign_sql_dialect(sql_dialect_value_old, newextra);
 
 		PG_RE_THROW();
 	}
@@ -880,6 +883,8 @@ fmgr_security_definer(PG_FUNCTION_ARGS)
 	{
 
 		sql_dialect = sql_dialect_value_old;
+		assign_sql_dialect(sql_dialect_value_old, newextra);
+
 		if (sql_dialect_value == pg_dialect)
 			non_tsql_proc_entry_hook(non_tsql_proc_count * -1, sys_func_count * -1);
 	}

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -4990,6 +4990,9 @@ static struct config_enum ConfigureNamesEnum[] =
 		NULL, NULL, NULL
 	},
 
+/* When changing this guc value directly without set_config_option,The function 
+ * assign_sql_dialect() should also be invoked with the assignment. 
+ */
 	{
 		{"babelfishpg_tsql.sql_dialect", PGC_USERSET, COMPAT_OPTIONS_PREVIOUS,
 			gettext_noop("Sets the dialect for SQL commands."),

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -4990,7 +4990,8 @@ static struct config_enum ConfigureNamesEnum[] =
 		NULL, NULL, NULL
 	},
 
-/* When changing this guc value directly without set_config_option,The function 
+/*
+ * When changing this guc value directly without set_config_option,The function 
  * assign_sql_dialect() should also be invoked with the assignment. 
  */
 	{


### PR DESCRIPTION
### Description

Inside function `fmgr_security_definer` function there were frequent calls to `set_config_option/GetConfigOption` API's for `sql_dialect` GUC which would need Cache Lookup, which is unnecessary for the dialect. Changed the implementation to directly set/get the GUC value using the global variable.

Draft PR on Extension Repo: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/977
### Issues Resolved

BABEL-2994
 
### Check List

### Test Scenarios Covered ###
* **Use case based -**
Already Existing Test Cases

* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**
There would be a general performance for procedures,functions which use the FMGR framework
Here is one specific scenario
 A test database populated with 15k dummy procedures and executed the following query
`exec sp_sproc_columns  @procedure_name='sp_statistics' , @ODBCVer=3, @fUsePattern=0`
We had the following results
```
Without the change
Network packet size (bytes): 4096
50 xact[s]:
Clock Time (ms.): total     16516  avg   330.3 (3.0 xacts per sec.)

vs 

With the change
Network packet size (bytes): 4096
50 xact[s]:
Clock Time (ms.): total      9335  avg   186.7 (5.4 xacts per sec.)
```
Explanation:-For sp_sproc_columns, we he have created an internal view sp_sproc_columns_view for all procedures. The view itself has a lot of cast functions; mostly for each column  and each row for example if we cast to string types then varchar function is called using FMGR framework.
Later we select only one row for particular input based on procedure_name, but even there there’s a mismatch in datatype length so varchar function is called for one column, each row.

Attached the perf reports 
[perf-without](https://user-images.githubusercontent.com/44708230/210231957-03ceaee9-f0f5-413d-af37-27786f46b8f0.svg)
[perf-with-2994](https://user-images.githubusercontent.com/44708230/210231963-4c6bd6cf-5dd0-4726-a0d1-6516e285a086.svg)


* **Tooling impact -**


* **Client tests -**

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
