### PR TITLE
Support UDTS for sequences and ISC-sequences view

### DIFF
--- a/src/backend/commands/sequence.c
+++ b/src/backend/commands/sequence.c
@@ -1393,7 +1393,13 @@ init_params(ParseState *pstate, List *options, bool for_identity,
 	/* AS type */
 	if (as_type != NULL)
 	{
-		Oid			newtypid = typenameTypeId(pstate, defGetTypeName(as_type));
+		/*
+		 * typenameTypeID is called after the hook to modify the schema name
+		 * internally used within the function when sequence is defined using a
+		 * user-defined data type
+		 */
+
+		Oid			newtypid = 0;
 
 		if (pltsql_sequence_datatype_hook)
 			(* pltsql_sequence_datatype_hook) (pstate,
@@ -1402,6 +1408,8 @@ init_params(ParseState *pstate, List *options, bool for_identity,
 											   as_type,
 											   &max_value,
 											   &min_value);
+
+		if(!newtypid) newtypid = typenameTypeId(pstate,defGetTypeName(as_type));
 
 		if (newtypid != INT2OID &&
 			newtypid != INT4OID &&


### PR DESCRIPTION
### Description

Creation of view information_schema_tsql.sequences to support for T-SQL INFORMATION_SCHEMA.SEQUENCES. Provide support for creation of a sequence using user-defined data types which is currently not supported in Babelfish. Added support for cross-schema UDTs

Task: BABEL-3504, BABEL-3452
Signed-off-by: Aditya Verma adiityav@amazon.com
 
### Check List

- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
