### PR TITLE
Refactor utility function to be used by both SUM and AVG Aggregates

### DIFF
--- a/src/backend/utils/adt/numeric.c
+++ b/src/backend/utils/adt/numeric.c
@@ -5906,6 +5906,9 @@ numeric_poly_sum(PG_FUNCTION_ARGS)
 #endif
 }
 
+/*
+ *	Final function for BIGINT datatype for TSQL Aggregates (SUM,AVG)
+ */
 Datum
 bigint_utility(FunctionCallInfo fcinfo, bool isSum)
 {

--- a/src/backend/utils/adt/numeric.c
+++ b/src/backend/utils/adt/numeric.c
@@ -5910,7 +5910,7 @@ numeric_poly_sum(PG_FUNCTION_ARGS)
  *	Final function for BIGINT datatype for TSQL Aggregates (SUM,AVG)
  */
 Datum
-bigint_utility(FunctionCallInfo fcinfo, bool isSum)
+bigint_utility(FunctionCallInfo fcinfo, int tsqlAggType)
 {
 
 	PolyNumAggState		*state;
@@ -5938,8 +5938,9 @@ bigint_utility(FunctionCallInfo fcinfo, bool isSum)
 						errmsg("Arithmetic overflow error converting expression to data type bigint.")));
 		}
 		else {
-			if (isSum)
+			if (tsqlAggType == TSQL_SUM)
 				PG_RETURN_INT64((int64) result);
+			/* If the aggregate type is TSQL_AVG */
 			else
 			{
 				result /= state->N;
@@ -5947,8 +5948,9 @@ bigint_utility(FunctionCallInfo fcinfo, bool isSum)
 			}
 		}
 	#else
-		if (isSum)
+		if (tsqlAggType == TSQL_SUM)
 			temp = numeric_sum(fcinfo);
+		/* If the aggregate type is TSQL_AVG */
 		else
 			temp = numeric_avg(fcinfo);
 				

--- a/src/backend/utils/adt/numeric.c
+++ b/src/backend/utils/adt/numeric.c
@@ -5907,10 +5907,13 @@ numeric_poly_sum(PG_FUNCTION_ARGS)
 }
 
 /*
- *	Final function for BIGINT datatype for TSQL Aggregates (SUM,AVG)
+ *	Final function for BIGINT datatype for TSQL Aggregates (SUM,AVG).
+ *  The tsql aggregate return non-default return types when compared with 
+ *  Default aggregate for integer datatypes , this function takes the accumlated
+ *  State and tranform the result into return type expected by tsql.
  */
 Datum
-bigint_utility(FunctionCallInfo fcinfo, int tsqlAggType)
+bigint_poly_aggr_final(FunctionCallInfo fcinfo, int tsqlAggType)
 {
 
 	PolyNumAggState		*state;

--- a/src/backend/utils/adt/numeric.c
+++ b/src/backend/utils/adt/numeric.c
@@ -5907,7 +5907,7 @@ numeric_poly_sum(PG_FUNCTION_ARGS)
 }
 
 Datum
-bigint_poly_sum(PG_FUNCTION_ARGS)
+bigint_utility(FunctionCallInfo fcinfo, bool isSum)
 {
 
 	PolyNumAggState		*state;
@@ -5934,10 +5934,21 @@ bigint_poly_sum(PG_FUNCTION_ARGS)
 					(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),
 						errmsg("Arithmetic overflow error converting expression to data type bigint.")));
 		}
-		else
-			PG_RETURN_INT64((int64) result);
+		else {
+			if (isSum)
+				PG_RETURN_INT64((int64) result);
+			else
+			{
+				result /= state->N;
+				PG_RETURN_INT64((int64) result);
+			}
+		}
 	#else
-		temp = numeric_sum(fcinfo);
+		if (isSum)
+			temp = numeric_sum(fcinfo);
+		else
+			temp = numeric_avg(fcinfo);
+				
 		init_var(&nvar);
 		set_var_from_num(DatumGetNumeric(temp), &nvar);
 		is_overflow = !(numericvar_to_int64(&nvar, &result));

--- a/src/backend/utils/adt/numeric.c
+++ b/src/backend/utils/adt/numeric.c
@@ -5913,7 +5913,7 @@ numeric_poly_sum(PG_FUNCTION_ARGS)
  *  State and tranform the result into return type expected by tsql.
  */
 Datum
-bigint_poly_aggr_final(FunctionCallInfo fcinfo, int tsqlAggType)
+bigint_poly_aggr_final(FunctionCallInfo fcinfo, tsqlAggType aggType)
 {
 
 	PolyNumAggState		*state;
@@ -5941,7 +5941,7 @@ bigint_poly_aggr_final(FunctionCallInfo fcinfo, int tsqlAggType)
 						errmsg("Arithmetic overflow error converting expression to data type bigint.")));
 		}
 		else {
-			if (tsqlAggType == TSQL_SUM)
+			if (aggType == TSQL_SUM)
 				PG_RETURN_INT64((int64) result);
 			/* If the aggregate type is TSQL_AVG */
 			else

--- a/src/include/utils/numeric.h
+++ b/src/include/utils/numeric.h
@@ -93,7 +93,7 @@ extern Numeric numeric_mod_opt_error(Numeric num1, Numeric num2,
 									 bool *have_error);
 extern int32 numeric_int4_opt_error(Numeric num, bool *error);
 
-extern Datum bigint_utility(FunctionCallInfo fcinfo, int tsqlAggType);
+extern Datum bigint_poly_aggr_final(FunctionCallInfo fcinfo, int tsqlAggType);
 
 /* Hook interface to calculate exact numeric digits before generating numeric overflow error in TSQL */
 typedef bool (*detect_numeric_overflow_hook_type) (int weight, int dscale, int first_block, int numeric_base);

--- a/src/include/utils/numeric.h
+++ b/src/include/utils/numeric.h
@@ -93,7 +93,7 @@ extern Numeric numeric_mod_opt_error(Numeric num1, Numeric num2,
 									 bool *have_error);
 extern int32 numeric_int4_opt_error(Numeric num, bool *error);
 
-extern Datum bigint_poly_aggr_final(FunctionCallInfo fcinfo, int tsqlAggType);
+extern Datum bigint_poly_aggr_final(FunctionCallInfo fcinfo, tsqlAggType aggType);
 
 /* Hook interface to calculate exact numeric digits before generating numeric overflow error in TSQL */
 typedef bool (*detect_numeric_overflow_hook_type) (int weight, int dscale, int first_block, int numeric_base);

--- a/src/include/utils/numeric.h
+++ b/src/include/utils/numeric.h
@@ -52,6 +52,12 @@
 struct NumericData;
 typedef struct NumericData *Numeric;
 
+/* Enum type for bigint aggregates for tsql dialect */
+typedef enum tsqlAggType {
+	TSQL_SUM,
+	TSQL_AVG
+} tsqlAggType;
+
 /*
  * fmgr interface macros
  */
@@ -87,7 +93,7 @@ extern Numeric numeric_mod_opt_error(Numeric num1, Numeric num2,
 									 bool *have_error);
 extern int32 numeric_int4_opt_error(Numeric num, bool *error);
 
-extern Datum bigint_utility(FunctionCallInfo fcinfo, bool isSum);
+extern Datum bigint_utility(FunctionCallInfo fcinfo, int tsqlAggType);
 
 /* Hook interface to calculate exact numeric digits before generating numeric overflow error in TSQL */
 typedef bool (*detect_numeric_overflow_hook_type) (int weight, int dscale, int first_block, int numeric_base);

--- a/src/include/utils/numeric.h
+++ b/src/include/utils/numeric.h
@@ -87,7 +87,7 @@ extern Numeric numeric_mod_opt_error(Numeric num1, Numeric num2,
 									 bool *have_error);
 extern int32 numeric_int4_opt_error(Numeric num, bool *error);
 
-extern Datum bigint_poly_sum(PG_FUNCTION_ARGS);
+extern Datum bigint_utility(FunctionCallInfo fcinfo, bool isSum);
 
 /* Hook interface to calculate exact numeric digits before generating numeric overflow error in TSQL */
 typedef bool (*detect_numeric_overflow_hook_type) (int weight, int dscale, int first_block, int numeric_base);


### PR DESCRIPTION
### Description
Refactor the previously introduced helper function into a common utility (`bigint_utility`) function which can be used by both SUM and AVG  aggregates for BIGINT datatype
 
### Issues Resolved
BABEL-3507

#### Extension PR
https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1045

 Signed-off-by: Nirmit Shah <nirmisha@amazon.com>
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
