### PR TITLE
Support and re-design UPDATE/DELETE (3x)

### DIFF
--- a/src/include/parser/analyze.h
+++ b/src/include/parser/analyze.h
@@ -30,9 +30,7 @@ typedef void (*pre_parse_analyze_hook_type) (ParseState *pstate, RawStmt *parseT
 extern PGDLLIMPORT pre_parse_analyze_hook_type pre_parse_analyze_hook;
 
 /* Hook to handle qualifiers in returning list for output clause */
-typedef void (*pre_transform_returning_hook_type) (CmdType command, 
-										List *returningList, ParseState *pstate);
-
+typedef void (*pre_transform_returning_hook_type) (Query *query, List *returningList, ParseState *pstate);
 extern PGDLLIMPORT pre_transform_returning_hook_type pre_transform_returning_hook;
 
 /* Hook to modify insert statement in output clause */
@@ -41,7 +39,7 @@ typedef void (*pre_transform_insert_hook_type) (InsertStmt *stmt, Oid relid);
 extern PGDLLIMPORT pre_transform_insert_hook_type pre_transform_insert_hook;
 
 /* Hook to perform self-join transformation on UpdateStmt in output clause */
-typedef Node* (*pre_output_clause_transformation_hook_type) (ParseState *pstate, UpdateStmt *stmt, CmdType command);
+typedef Node* (*pre_output_clause_transformation_hook_type) (ParseState *pstate, UpdateStmt *stmt, Query *query);
 extern PGDLLIMPORT pre_output_clause_transformation_hook_type pre_output_clause_transformation_hook;
 
 /* Hook to read a global variable with info on output clause */
@@ -52,8 +50,14 @@ extern PGDLLIMPORT get_output_clause_status_hook_type get_output_clause_status_h
 typedef void (*post_transform_insert_row_hook_type) (List *icolumns, List *exprList, Oid relid);
 extern PGDLLIMPORT post_transform_insert_row_hook_type post_transform_insert_row_hook;
 
+/* Hook for handle target table before transforming from clause */
+typedef int (*pre_transform_from_clause_hook_type) (ParseState *pstate, Node *stmt, CmdType command);
+extern PGDLLIMPORT pre_transform_from_clause_hook_type pre_transform_from_clause_hook;
+
 extern Query *parse_analyze_fixedparams(RawStmt *parseTree, const char *sourceText,
 										const Oid *paramTypes, int numParams, QueryEnvironment *queryEnv);
+extern Query *parse_analyze(RawStmt *parseTree, const char *sourceText,
+							Oid *paramTypes, int numParams, QueryEnvironment *queryEnv);
 extern Query *parse_analyze_varparams(RawStmt *parseTree, const char *sourceText,
 									  Oid **paramTypes, int *numParams, QueryEnvironment *queryEnv);
 extern Query *parse_analyze_withcb(RawStmt *parseTree, const char *sourceText,


### PR DESCRIPTION
This commit adds a required engine hook for the re-design of UPDATE/DELETE DML statemenet.

Hook name: pre_transform_from_clause_hook
Location: In parse analyzing process of UPDATE/DELETE, before analyzing FROM clause
Usage: This hook is used to realize TSQL-style UPDATE/DELETE behavior

This commit also modifies the input arguments of other two engine hooks, pre_output_clause_transformation_hook and pre_transform_returning_hook, in order to extend their functionalities.

Signed-off-by: Xiaohui Fanhe <hexiaohu@amazon.com>

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
