### PR TITLE
Support and re-design UPDATE/DELETE (3x)

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -76,6 +76,9 @@ pre_output_clause_transformation_hook_type pre_output_clause_transformation_hook
 /* Hook for plugins to get control after an insert row transform */
 post_transform_insert_row_hook_type post_transform_insert_row_hook = NULL;
 
+/* Hook for handle target table before transforming from clause */
+set_target_table_alternative_hook_type set_target_table_alternative_hook = NULL;
+
 static Query *transformOptionalSelectInto(ParseState *pstate, Node *parseTree);
 static Query *transformDeleteStmt(ParseState *pstate, DeleteStmt *stmt);
 static Query *transformInsertStmt(ParseState *pstate, InsertStmt *stmt);
@@ -513,10 +516,15 @@ transformDeleteStmt(ParseState *pstate, DeleteStmt *stmt)
 	}
 
 	/* set up range table with just the result rel */
-	qry->resultRelation = setTargetTable(pstate, stmt->relation,
-										 stmt->relation->inh,
-										 true,
-										 ACL_DELETE);
+	if (set_target_table_alternative_hook)
+		qry->resultRelation = (*set_target_table_alternative_hook) (pstate, 
+											(Node *) stmt, qry->commandType);
+	else
+		qry->resultRelation = setTargetTable(pstate, stmt->relation,
+											 stmt->relation->inh,
+											 true,
+											 ACL_DELETE);
+
 	nsitem = pstate->p_target_nsitem;
 
 	/* there's no DISTINCT in DELETE */
@@ -542,7 +550,7 @@ transformDeleteStmt(ParseState *pstate, DeleteStmt *stmt)
 								EXPR_KIND_WHERE, "WHERE");
 
 	if (pre_transform_returning_hook)
-			(*pre_transform_returning_hook) (qry->commandType, stmt->returningList, pstate);
+		(*pre_transform_returning_hook) (qry, stmt->returningList, pstate);
 	
 	qry->returningList = transformReturningList(pstate, stmt->returningList);
 
@@ -1005,7 +1013,7 @@ transformInsertStmt(ParseState *pstate, InsertStmt *stmt)
 	if (stmt->returningList)
 	{
 		if (pre_transform_returning_hook)
-			(*pre_transform_returning_hook) (qry->commandType, stmt->returningList, pstate);
+			(*pre_transform_returning_hook) (qry, stmt->returningList, pstate);
 		
 		qry->returningList = transformReturningList(pstate,
 													stmt->returningList);
@@ -2448,10 +2456,15 @@ transformUpdateStmt(ParseState *pstate, UpdateStmt *stmt)
 		qry->hasModifyingCTE = pstate->p_hasModifyingCTE;
 	}
 
-	qry->resultRelation = setTargetTable(pstate, stmt->relation,
-										 stmt->relation->inh,
-										 true,
-										 ACL_UPDATE);
+	if (set_target_table_alternative_hook)
+		qry->resultRelation = (*set_target_table_alternative_hook) (pstate, 
+											(Node *) stmt, qry->commandType);
+	else
+		qry->resultRelation = setTargetTable(pstate, stmt->relation,
+											 stmt->relation->inh,
+											 true,
+											 ACL_UPDATE);
+
 	nsitem = pstate->p_target_nsitem;
 
 	/* subqueries in FROM cannot access the result relation */
@@ -2470,7 +2483,7 @@ transformUpdateStmt(ParseState *pstate, UpdateStmt *stmt)
 
 	/* Check if self-join transformation is needed for update satatement with output clause */
 	if (pre_output_clause_transformation_hook)
-		qual = (*pre_output_clause_transformation_hook) (pstate, stmt, qry->commandType);
+		qual = (*pre_output_clause_transformation_hook) (pstate, stmt, qry);
 	else
 		qual = transformWhereClause(pstate, stmt->whereClause,
 								EXPR_KIND_WHERE, "WHERE");

--- a/src/include/parser/analyze.h
+++ b/src/include/parser/analyze.h
@@ -30,9 +30,7 @@ typedef void (*pre_parse_analyze_hook_type) (ParseState *pstate, RawStmt *parseT
 extern PGDLLIMPORT pre_parse_analyze_hook_type pre_parse_analyze_hook;
 
 /* Hook to handle qualifiers in returning list for output clause */
-typedef void (*pre_transform_returning_hook_type) (CmdType command, 
-										List *returningList, ParseState *pstate);
-
+typedef void (*pre_transform_returning_hook_type) (Query *query, List *returningList, ParseState *pstate);
 extern PGDLLIMPORT pre_transform_returning_hook_type pre_transform_returning_hook;
 
 /* Hook to modify insert statement in output clause */
@@ -41,7 +39,7 @@ typedef void (*pre_transform_insert_hook_type) (InsertStmt *stmt, Oid relid);
 extern PGDLLIMPORT pre_transform_insert_hook_type pre_transform_insert_hook;
 
 /* Hook to perform self-join transformation on UpdateStmt in output clause */
-typedef Node* (*pre_output_clause_transformation_hook_type) (ParseState *pstate, UpdateStmt *stmt, CmdType command);
+typedef Node* (*pre_output_clause_transformation_hook_type) (ParseState *pstate, UpdateStmt *stmt, Query *query);
 extern PGDLLIMPORT pre_output_clause_transformation_hook_type pre_output_clause_transformation_hook;
 
 /* Hook to read a global variable with info on output clause */
@@ -52,8 +50,14 @@ extern PGDLLIMPORT get_output_clause_status_hook_type get_output_clause_status_h
 typedef void (*post_transform_insert_row_hook_type) (List *icolumns, List *exprList, Oid relid);
 extern PGDLLIMPORT post_transform_insert_row_hook_type post_transform_insert_row_hook;
 
+/* Hook for handle target table before transforming from clause */
+typedef int (*set_target_table_alternative_hook_type) (ParseState *pstate, Node *stmt, CmdType command);
+extern PGDLLIMPORT set_target_table_alternative_hook_type set_target_table_alternative_hook;
+
 extern Query *parse_analyze_fixedparams(RawStmt *parseTree, const char *sourceText,
 										const Oid *paramTypes, int numParams, QueryEnvironment *queryEnv);
+extern Query *parse_analyze(RawStmt *parseTree, const char *sourceText,
+							Oid *paramTypes, int numParams, QueryEnvironment *queryEnv);
 extern Query *parse_analyze_varparams(RawStmt *parseTree, const char *sourceText,
 									  Oid **paramTypes, int *numParams, QueryEnvironment *queryEnv);
 extern Query *parse_analyze_withcb(RawStmt *parseTree, const char *sourceText,


### PR DESCRIPTION
This commit adds a required engine hook for the re-design of UPDATE/DELETE DML statemenet.

Hook name: post_set_target_table_hook
Input argument: (ParseState *pstate, Node *stmt, CmdType command) Location: In parse analyzing process of UPDATE/DELETE, after setting target table and before analyzing FROM clause
Usage: This hook is used to clean up duplicate table references

This commit also modifies the input arguments of other two engine hooks, pre_output_clause_transformation_hook and pre_transform_returning_hook, in order to extend their functionalities.

Task: BABEL-1330/1875/2675/3091/3684/3685/3775
Signed-off-by: Xiaohui Fanhe <hexiaohu@amazon.com>
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
