### PR TITLE
Fix early string free to support GUC revert

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -5280,6 +5280,12 @@ string_field_used(struct config_string *conf, char *strval)
 			strval == stack->masked.val.stringval)
 			return true;
 	}
+	for (stack = conf->gen.session_stack; stack; stack = stack->prev)
+	{
+		if (strval == stack->prior.val.stringval ||
+			strval == stack->masked.val.stringval)
+			return true;
+	}
 	return false;
 }
 


### PR DESCRIPTION
### Description

The IDENTITY_INSERT setting uses strings to store if the setting is on or off and for which table. It is a babelfish GUC, so we store old values for revert in the session_stack field, as opposed to stack. The engine will check the stack to see if any string values are being used, and if not, will free the string. This causes issues as the string is improperly freed while used in session_stack. This change fixes the issues, checking session_stack as well as stack before freeing.

Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1017
 
### Issues Resolved

Task: BABEL-3092
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
