### PR TITLE
OPENJSON() Raises an error mentioning nvarchar or join

### DIFF
--- a/src/backend/utils/adt/jsonpath_exec.c
+++ b/src/backend/utils/adt/jsonpath_exec.c
@@ -534,11 +534,6 @@ tsql_openjson_with_columnize(Jsonb *jb, char *col_info)
 		token = strtok(NULL, " ");
 	}
 
-	if (asjson)
-		if (pg_strcasecmp(col_type, "nvarchar") != 0) /* TODO: implement new error code for incorrect type for AS JSON */
-			ereport(ERROR, (errcode(ERRCODE_SYNTAX_ERROR),
-									errmsg("AS JSON in WITH clause can only be specified for column of type nvarchar(max)")));
-
 	if (strlen(col_type) >= 3) /* Get column size restriction, if it exists */
 	{
 		token = strtok(col_type, "(");

--- a/src/backend/utils/adt/jsonpath_exec.c
+++ b/src/backend/utils/adt/jsonpath_exec.c
@@ -465,6 +465,7 @@ tsql_openjson_with_get_subjsonb(PG_FUNCTION_ARGS)
 					*sub_jb,
 					*vars;
 	JsonPath		*jp;
+	JsonPathItem    jsp;
 	JsonValueList 	found = {0};
 	bool 			islax;
 
@@ -472,6 +473,13 @@ tsql_openjson_with_get_subjsonb(PG_FUNCTION_ARGS)
 	jb = (Jsonb *) DirectFunctionCall1(jsonb_in, CStringGetDatum(text_to_cstring(json_text)));
 	jsonpath_text = PG_GETARG_TEXT_PP(1);
 	jp = (JsonPath *) DirectFunctionCall1(jsonpath_in, CStringGetDatum(text_to_cstring(jsonpath_text)));
+
+	jspInit(&jsp, jp);
+	if (jsp.type != jpiRoot)
+	{
+		ereport(ERROR, (errcode(ERRCODE_SYNTAX_ERROR)),
+								errmsg("invalid json path"));
+	}
 
 	/* retrieve sub_jb */
 	vars = (Jsonb *) DirectFunctionCall1(jsonb_in, CStringGetDatum("{}"));


### PR DESCRIPTION
Task: Babel-3702
Signed-off-by: Jake Owen <owjco@amazon.com>

### Description

Moves an error message from the engine to the extension to support Babel-3702
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
