### PR TITLE
Revert "Ignore extra COLLATE default which can come as part of default value of column and ignore explicit COLLATE default on view def in dump (#70)"

### DIFF
--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -24,7 +24,6 @@
 extern char *getMinOid(Archive *fout);
 extern void bbf_selectDumpableCast(CastInfo *cast);
 extern void fixTsqlDefaultExpr(Archive *fout, AttrDefInfo *attrDefInfo);
-extern void fixTsqlCheckConstraint(Archive *fout, ConstraintInfo *constrs);
 extern bool isBabelfishDatabase(Archive *fout);
 extern void fixOprRegProc(Archive *fout, const OprInfo *oprinfo, const char *oprleft, const char *oprright, char **oprregproc);
 extern void fixTsqlTableTypeDependency(Archive *fout, DumpableObject *func, DumpableObject *tabletype, char deptype);
@@ -33,6 +32,5 @@ extern int getTsqlTvfType(Archive *fout, const FuncInfo *finfo, char prokind, bo
 extern void fixAttoptionsBbfOriginalName(Archive *fout, Oid relOid, const TableInfo *tbinfo, int idx);
 extern void setOrResetPltsqlFuncRestoreGUCs(Archive *fout, PQExpBuffer q, const FuncInfo *finfo, char prokind, bool proretset, bool is_set);
 extern void dumpBabelfishSpecificConfig(Archive *AH, const char *dbname, PQExpBuffer outbuf);
-extern char *babelfish_handle_view_def(Archive *fout, char *view_def);
 
 #endif

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -8598,9 +8598,6 @@ getTableAttrs(Archive *fout, TableInfo *tblinfo, int numTables)
 				constrs[j].condeferred = false;
 				constrs[j].conislocal = (PQgetvalue(res, j, i_conislocal)[0] == 't');
 
-				/* Babelfish-specific logic for check constraint */
-				fixTsqlCheckConstraint(fout, &constrs[j]);
-
 				/*
 				 * An unvalidated constraint needs to be dumped separately, so
 				 * that potentially-violating existing data is loaded before
@@ -15075,8 +15072,7 @@ createViewAsClause(Archive *fout, const TableInfo *tbinfo)
 
 	/* Strip off the trailing semicolon so that other things may follow. */
 	Assert(PQgetvalue(res, 0, 0)[len - 1] == ';');
-
-	appendBinaryPQExpBuffer(result, babelfish_handle_view_def(fout, PQgetvalue(res, 0, 0)), len - 1);
+	appendBinaryPQExpBuffer(result, PQgetvalue(res, 0, 0), len - 1);
 
 	PQclear(res);
 	destroyPQExpBuffer(query);


### PR DESCRIPTION
### Description

This reverts commit e16b166a9c40cdac44ce9cbba685dacce0443e25. This commit reverts short term fix made for  BABEL-3801 via https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/70 except the change related to data  type _CI_SYSNAME as it would be required for long term fix. 

Long term fix for BABEL-3801 is introduced in BABEL_2_X_DEV__PG_14_X through engine PR: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/96 and extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1222

### Issues Resolved
Task: BABEL-3895
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>

### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
