### PR TITLE
Allow func_select_candidate_hook call during restore

### DIFF
--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -1269,7 +1269,8 @@ func_select_candidate(int nargs,
 	 * let's try to choose the best candidate by T-SQL precedence rule with setting resolved_unknowns.
 	 */
 	if (resolved_unknowns &&
-		sql_dialect == SQL_DIALECT_TSQL &&
+		(sql_dialect == SQL_DIALECT_TSQL ||
+		(dump_restore && strcmp(dump_restore, "on") == 0)) && /* execute hook if dialect is T-SQL or while restoring babelfish database */
 		func_select_candidate_hook != NULL)
 	{
 		last_candidate = func_select_candidate_hook(nargs, input_typeids, candidates, true);


### PR DESCRIPTION
### Description
During restore certain function calls get failed since `func_select_candidate_hook`
is allowed only in `TSQL` dialect.
To fix this, added a check for dump_restore GUC along with `sql_dialect` check.

### Example:
Original table:
```
> CREATE TABLE BABEL_1475_vu_prepare_day (dt1 datetime2, dt2 datetimeoffset(6), day1 as DAY(dt1), day2 as DAY(dt2));

> INSERT INTO BABEL_1475_vu_prepare_day (dt1, dt2) values ('2007-01-01 13:10:10.1111111', '1912-10-25 12:24:32 +10:0');
 
```
Dumped SQL and error:
```
INSERT INTO "master_dbo"."babel_1475_vu_prepare_day" ("dt1", "dt2") VALUES ('2007-01-01 13:10:10.111111', '1912-10-25 12:24:32 +10:00');

psql:pg_upgrade_dump1.sql:38396: ERROR:  function sys.datepart(unknown, sys.datetime2) is not unique
LINE 2: SELECT sys.datepart('day', date);
               ^
HINT:  Could not choose a best candidate function. You might need to add explicit type casts.
QUERY:  
SELECT sys.datepart('day', date);CONTEXT:  SQL function "day" during inlining
```

Task: BABEL-3826
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>
 
### Check List

- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
