### PR TITLE
Create table or proc should throw error for declaring non-permissible…

### DIFF
--- a/src/backend/parser/parse_type.c
+++ b/src/backend/parser/parse_type.c
@@ -31,6 +31,7 @@ static int32 typenameTypeMod(ParseState *pstate, const TypeName *typeName,
 							 Type typ);
 
 check_or_set_default_typmod_hook_type check_or_set_default_typmod_hook = NULL;
+validate_var_datatype_scale_hook_type validate_var_datatype_scale_hook = NULL;
 
 /*
  * LookupTypeName
@@ -408,6 +409,13 @@ typenameTypeMod(ParseState *pstate, const TypeName *typeName, Type typ)
 					 parser_errposition(pstate, typeName->location)));
 		datums[n++] = CStringGetDatum(cstr);
 	}
+
+	/*
+	 * Checks whether variable length datatypes like numeric, decimal, time, datetime2, datetimeoffset
+	 * are declared with permissible datalength at the time of table or stored procedure creation
+	 */
+	if (validate_var_datatype_scale_hook)
+			(*validate_var_datatype_scale_hook)(typeName, typ);
 
 	/* hardwired knowledge about cstring's representation details here */
 	arrtypmod = construct_array(datums, n, CSTRINGOID,

--- a/src/include/parser/parse_type.h
+++ b/src/include/parser/parse_type.h
@@ -61,4 +61,11 @@ extern void parseTypeString(const char *str, Oid *typeid_p, int32 *typmod_p, boo
 typedef void (*check_or_set_default_typmod_hook_type)(TypeName * typeName, int32 *typmod, bool is_cast);
 extern PGDLLIMPORT check_or_set_default_typmod_hook_type check_or_set_default_typmod_hook;
 
+/*
+ * Hook to check whether variable length datatypes like numeric, decimal, time, datetime2, datetimeoffset
+ * are declared with permissible datalength at the time of table or stored procedure creation
+ */
+typedef void (*validate_var_datatype_scale_hook_type)(const TypeName *typeName, Type typ);
+extern PGDLLIMPORT validate_var_datatype_scale_hook_type validate_var_datatype_scale_hook;
+
 #endif							/* PARSE_TYPE_H */


### PR DESCRIPTION
### Description

It is found that all variable length datatypes like numeric, decimal, time, datetime2, datetimeoffset need explicit checking on their permissible datalength at the time of table or stored procedure creation and generate error if required. Before fix, Babelfish was not complaining for the above behaviour.

Task: BABEL-3793
Co-authored-by: Satarupa Biswas satarupb@amazon.com
Signed-off-by: Shalini Lohia <lshalini@amazon.com>

 
### Issues Resolved
BABEL-3793
 