### PR TITLE
Avoid dumping COLLATE default for const clause

### DIFF
--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -319,6 +319,7 @@ static const char *query_getviewrule = "SELECT * FROM pg_catalog.pg_rewrite WHER
 bool		quote_all_identifiers = false;
 
 print_pltsql_function_arguments_hook_type print_pltsql_function_arguments_hook = NULL;
+get_tsql_const_collation_hook_type get_tsql_const_collation_hook = NULL;
 
 
 /* ----------
@@ -10453,6 +10454,9 @@ get_const_collation(Const *constval, deparse_context *context)
 
 		if (constval->constcollid != typcollation)
 		{
+			if (get_tsql_const_collation_hook && !get_tsql_const_collation_hook(constval))
+				return;
+
 			appendStringInfo(buf, " COLLATE %s",
 							 generate_collation_name(constval->constcollid));
 		}

--- a/src/include/utils/ruleutils.h
+++ b/src/include/utils/ruleutils.h
@@ -49,4 +49,7 @@ typedef int (*print_pltsql_function_arguments_hook_type) (StringInfo buf,
 														  bool print_defaults);
 extern PGDLLIMPORT print_pltsql_function_arguments_hook_type print_pltsql_function_arguments_hook;
 
+typedef bool (*get_tsql_const_collation_hook_type) (Const *constval);
+extern PGDLLIMPORT get_tsql_const_collation_hook_type get_tsql_const_collation_hook;
+
 #endif							/* RULEUTILS_H */


### PR DESCRIPTION
Previously, During v2.3.0 release, we fixed the most of collatable data types such as varchar to have the correct default collation same as server_collation_name. This fix may lead to dump extra COLLATE "default" clause for const clause during upgrade from 14.x to 15.1 if server is upgrade to 14.6 via minor version upgrade first. 

This commit fixes that issue by determining whether COLLATE needs to be dumped or not via newly introduced hook  handle_const_collation_hook_type which would be initialised by babelfishpg_common extension. 

Task: BABEL-3895
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
