### PR TITLE
Fix scope_identity rewrite for other types

### DIFF
--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -952,7 +952,7 @@ rewrite_scope_identity_call(ParseState *pstate, Node **lexpr, Node **rexpr)
 	if (strcmp(func_name, "babelfish_get_last_identity_numeric") != 0 &&
 			strcmp(func_name, "scope_identity") != 0)
 		return;
-	if (col_expr->vartype != INT4OID)
+	if (col_expr->vartype != INT2OID && col_expr->vartype != INT4OID && col_expr->vartype != INT8OID)
 		return;
 
 	new_call = makeFuncCall(list_make1(makeString("babelfish_get_last_identity")), NULL, COERCE_EXPLICIT_CALL, -1);


### PR DESCRIPTION
### Description

A previous commit rewrites scope_identity to return an integer so that an index may be used for certain queries. This only applied to columns of type integer, but identity columns can be of type smallint and bigint as well. Now, if scope_identity is compared against columns of these types the call will be rewritten and the index will be used.
 
### Issues Resolved

BABEL-3384
 
### Check List

- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
