### PR TITLE
Fix issue with ORDER BY in set operation

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -1753,13 +1753,11 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 	List	   *targetvars,
 			   *targetnames,
 			   *sv_namespace;
-			//    *sv_targetList;
 	int			sv_rtable_length;
 	ParseNamespaceItem *jnsitem;
 	ParseNamespaceColumn *sortnscolumns;
 	int			sortcolindex;
 	int			tllen;
-	// NamespaceStack ns_stack_item = {.prev = NULL, .namespace = NIL};
 
 	qry->commandType = CMD_SELECT;
 
@@ -1820,14 +1818,7 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 
 	/* Push new stack item to save the leftmost SELECT's namespace */
 	if(push_namespace_stack_hook)
-	{
 		push_namespace_stack_hook();
-	}
-	// if (sql_dialect == SQL_DIALECT_TSQL)
-	// {
-	// 	ns_stack_item.prev = set_op_ns_stack;
-	// 	set_op_ns_stack = &ns_stack_item;
-	// }
 
 	/*
 	 * Recursively transform the components of the tree.
@@ -1937,17 +1928,7 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 	
 	/* tsql needs the leftmost query's targetlist and ns to handle ORDER BY */
 	if (pre_transform_sort_clause_hook)
-	{
 		pre_transform_sort_clause_hook(pstate, qry, leftmostQuery);
-	}
-	// sv_targetList = qry->targetList;
-	// if (sql_dialect == SQL_DIALECT_TSQL)
-	// {
-	// 	qry->targetList = leftmostQuery->targetList;
-	// 	pstate->p_namespace = set_op_ns_stack->namespace;
-	// 	set_op_ns_stack = set_op_ns_stack->prev;
-	// }
-	
 
 	/*
 	 * For now, we don't support resjunk sort clauses on the output of a
@@ -1968,19 +1949,8 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 	 * of -1. Reset the targetlist to the dummy tl, but fill in ressortgroupref
 	 */
 	if (post_transform_sort_clause_hook)
-	{
 		post_transform_sort_clause_hook(qry);
-	}
-	// if (sql_dialect == SQL_DIALECT_TSQL)
-	// {
-	// 	forboth(l, qry->targetList, lct, sv_targetList)
-	// 	{
-	// 		TargetEntry *tle = (TargetEntry *) lfirst(l);
-	// 		TargetEntry *sv_tle = (TargetEntry *) lfirst(lct);
-	// 		sv_tle->ressortgroupref = tle->ressortgroupref;
-	// 	}
-	// 	qry->targetList = sv_targetList;
-	// }
+
 	/* restore namespace, remove join RTE from rtable */
 	pstate->p_namespace = sv_namespace;
 	pstate->p_rtable = list_truncate(pstate->p_rtable, sv_rtable_length);

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -1749,7 +1749,7 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 	ParseNamespaceColumn *sortnscolumns;
 	int			sortcolindex;
 	int			tllen;
-	NamespaceStack ns_stack_item = {.prev = NULL, .namespace = NIL};
+	// NamespaceStack ns_stack_item = {.prev = NULL, .namespace = NIL};
 
 	qry->commandType = CMD_SELECT;
 

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -1813,8 +1813,8 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 	 */
 	if (sql_dialect == SQL_DIALECT_TSQL)
 	{
-		ns_stack_item.prev = ns_stack;
-		ns_stack = &ns_stack_item;
+		ns_stack_item.prev = set_op_ns_stack;
+		set_op_ns_stack = &ns_stack_item;
 	}
 
 	sostmt = castNode(SetOperationStmt,
@@ -1920,11 +1920,12 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 	/* add jnsitem to column namespace only */
 	addNSItemToQuery(pstate, jnsitem, false, false, true);
 	
+	/* tsql needs the leftmost query's targetlist and ns to handle ORDER BY */
 	if (sql_dialect == SQL_DIALECT_TSQL)
 	{
-		pstate->p_namespace = ns_stack->namespace;
 		qry->targetList = leftmostQuery->targetList;
-		ns_stack = ns_stack->prev;
+		pstate->p_namespace = set_op_ns_stack->namespace;
+		set_op_ns_stack = set_op_ns_stack->prev;
 	}
 	
 

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -1920,7 +1920,7 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 	if (sql_dialect == SQL_DIALECT_TSQL)
 	{
 		pstate->p_namespace = ns_stack->namespace;
-		qry->targetList = leftmostQuery->targetList;
+		// qry->targetList = leftmostQuery->targetList;
 	}
 	ns_stack = ns_stack->prev;
 	

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -1919,7 +1919,7 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 	
 	if (sql_dialect == SQL_DIALECT_TSQL)
 	{
-		pstate->p_namespace = ns_stack->namespace;
+		// pstate->p_namespace = ns_stack->namespace;
 		// qry->targetList = leftmostQuery->targetList;
 	}
 	ns_stack = ns_stack->prev;

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -1811,8 +1811,8 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 	/*
 	 * Recursively transform the components of the tree.
 	 */
-	ns_stack_item.prev = ns_stack;
-	ns_stack = &ns_stack_item;
+	// ns_stack_item.prev = ns_stack;
+	// ns_stack = &ns_stack_item;
 
 	sostmt = castNode(SetOperationStmt,
 					  transformSetOperationTree(pstate, stmt, true, NULL));
@@ -1917,12 +1917,12 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 	/* add jnsitem to column namespace only */
 	addNSItemToQuery(pstate, jnsitem, false, false, true);
 	
-	if (sql_dialect == SQL_DIALECT_TSQL)
-	{
+	// if (sql_dialect == SQL_DIALECT_TSQL)
+	// {
 		// pstate->p_namespace = ns_stack->namespace;
 		// qry->targetList = leftmostQuery->targetList;
-	}
-	ns_stack = ns_stack->prev;
+	// }
+	// ns_stack = ns_stack->prev;
 	
 
 	/*

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -79,6 +79,9 @@ post_transform_insert_row_hook_type post_transform_insert_row_hook = NULL;
 /* Hook for handle target table before transforming from clause */
 set_target_table_alternative_hook_type set_target_table_alternative_hook = NULL;
 
+/* Hook to handle target table in ORDER BY with set operation */
+pre_transform_sort_from_set_hook_type pre_transform_sort_from_set_hook = NULL;
+
 static Query *transformOptionalSelectInto(ParseState *pstate, Node *parseTree);
 static Query *transformDeleteStmt(ParseState *pstate, DeleteStmt *stmt);
 static Query *transformInsertStmt(ParseState *pstate, InsertStmt *stmt);
@@ -1911,6 +1914,9 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 
 	/* add jnsitem to column namespace only */
 	addNSItemToQuery(pstate, jnsitem, false, false, true);
+	
+	if (pre_transform_sort_from_set_hook)
+		(*pre_transform_sort_from_set_hook) (pstate, qry, leftmostQuery, leftmostSelect->fromClause);
 
 	/*
 	 * For now, we don't support resjunk sort clauses on the output of a

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -77,6 +77,9 @@ pre_output_clause_transformation_hook_type pre_output_clause_transformation_hook
 /* Hook for plugins to get control after an insert row transform */
 post_transform_insert_row_hook_type post_transform_insert_row_hook = NULL;
 
+/* Hook for handle target table before transforming from clause */
+set_target_table_alternative_hook_type set_target_table_alternative_hook = NULL;
+
 /* Hook to save to a namespace stack for handling statements with set ops */
 push_namespace_stack_hook_type push_namespace_stack_hook = NULL;
 
@@ -1935,7 +1938,7 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 	/* tsql needs the leftmost query's targetlist and ns to handle ORDER BY */
 	if (pre_transform_sort_clause_hook)
 	{
-		pre_transform_sort_clause_hook(qry, leftmostQuery);
+		pre_transform_sort_clause_hook(pstate, qry, leftmostQuery);
 	}
 	// sv_targetList = qry->targetList;
 	// if (sql_dialect == SQL_DIALECT_TSQL)

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -1752,11 +1752,7 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 	ParseNamespaceColumn *sortnscolumns;
 	int			sortcolindex;
 	int			tllen;
-<<<<<<< Updated upstream
-	List *sv_namespace_tsql = NIL;
-=======
 	NamespaceStack ns_stack_item = {.prev = NULL, .namespace = NIL};
->>>>>>> Stashed changes
 
 	qry->commandType = CMD_SELECT;
 
@@ -1818,9 +1814,6 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 	/*
 	 * Recursively transform the components of the tree.
 	 */
-<<<<<<< Updated upstream
-	sv_fromclause_ns = &sv_namespace_tsql;
-=======
 	// Manage Namespace Stack
 	if (!ns_stack)
 		ns_stack = &ns_stack_item;
@@ -1829,7 +1822,6 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 		ns_stack_item.prev = ns_stack;
 		ns_stack = &ns_stack_item;
 	}
->>>>>>> Stashed changes
 	sostmt = castNode(SetOperationStmt,
 					  transformSetOperationTree(pstate, stmt, true, NULL));
 	Assert(sostmt);

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -1811,14 +1811,9 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 	/*
 	 * Recursively transform the components of the tree.
 	 */
-	// Manage Namespace Stack
-	if (!ns_stack)
-		ns_stack = &ns_stack_item;
-	else
-	{
-		ns_stack_item.prev = ns_stack;
-		ns_stack = &ns_stack_item;
-	}
+	ns_stack_item.prev = ns_stack;
+	ns_stack = &ns_stack_item;
+
 	sostmt = castNode(SetOperationStmt,
 					  transformSetOperationTree(pstate, stmt, true, NULL));
 	Assert(sostmt);

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -80,9 +80,6 @@ post_transform_insert_row_hook_type post_transform_insert_row_hook = NULL;
 /* Hook for handle target table before transforming from clause */
 set_target_table_alternative_hook_type set_target_table_alternative_hook = NULL;
 
-/* Hook to handle target table in ORDER BY with set operation */
-pre_transform_sort_from_set_hook_type pre_transform_sort_from_set_hook = NULL;
-
 static Query *transformOptionalSelectInto(ParseState *pstate, Node *parseTree);
 static Query *transformDeleteStmt(ParseState *pstate, DeleteStmt *stmt);
 static Query *transformInsertStmt(ParseState *pstate, InsertStmt *stmt);

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -1811,11 +1811,11 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 	/*
 	 * Recursively transform the components of the tree.
 	 */
-	if (sql_dialect == SQL_DIALECT_TSQL)
-	{
+	// if (sql_dialect == SQL_DIALECT_TSQL)
+	// {
 		ns_stack_item.prev = set_op_ns_stack;
 		set_op_ns_stack = &ns_stack_item;
-	}
+	// }
 
 	sostmt = castNode(SetOperationStmt,
 					  transformSetOperationTree(pstate, stmt, true, NULL));
@@ -1925,8 +1925,8 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 	{
 		qry->targetList = leftmostQuery->targetList;
 		pstate->p_namespace = set_op_ns_stack->namespace;
-		set_op_ns_stack = set_op_ns_stack->prev;
 	}
+	set_op_ns_stack = set_op_ns_stack->prev;
 	
 
 	/*

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -1923,9 +1923,9 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 	addNSItemToQuery(pstate, jnsitem, false, false, true);
 	
 	/* tsql needs the leftmost query's targetlist and ns to handle ORDER BY */
+	sv_targetList = qry->targetList;
 	if (sql_dialect == SQL_DIALECT_TSQL)
 	{
-		sv_targetList = qry->targetList;
 		qry->targetList = leftmostQuery->targetList;
 		pstate->p_namespace = set_op_ns_stack->namespace;
 		set_op_ns_stack = set_op_ns_stack->prev;

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -1749,7 +1749,7 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 	ParseNamespaceColumn *sortnscolumns;
 	int			sortcolindex;
 	int			tllen;
-	// NamespaceStack ns_stack_item = {.prev = NULL, .namespace = NIL};
+	NamespaceStack ns_stack_item = {.prev = NULL, .namespace = NIL};
 
 	qry->commandType = CMD_SELECT;
 
@@ -1811,8 +1811,11 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 	/*
 	 * Recursively transform the components of the tree.
 	 */
-	// ns_stack_item.prev = ns_stack;
-	// ns_stack = &ns_stack_item;
+	if (sql_dialect == SQL_DIALECT_TSQL)
+	{
+		ns_stack_item.prev = ns_stack;
+		ns_stack = &ns_stack_item;
+	}
 
 	sostmt = castNode(SetOperationStmt,
 					  transformSetOperationTree(pstate, stmt, true, NULL));
@@ -1917,12 +1920,12 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 	/* add jnsitem to column namespace only */
 	addNSItemToQuery(pstate, jnsitem, false, false, true);
 	
-	// if (sql_dialect == SQL_DIALECT_TSQL)
-	// {
-		// pstate->p_namespace = ns_stack->namespace;
-		// qry->targetList = leftmostQuery->targetList;
-	// }
-	// ns_stack = ns_stack->prev;
+	if (sql_dialect == SQL_DIALECT_TSQL)
+	{
+		pstate->p_namespace = ns_stack->namespace;
+		qry->targetList = leftmostQuery->targetList;
+		ns_stack = ns_stack->prev;
+	}
 	
 
 	/*

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -1751,6 +1751,7 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 	ParseNamespaceColumn *sortnscolumns;
 	int			sortcolindex;
 	int			tllen;
+	List *sv_namespace_tsql = NIL;
 
 	qry->commandType = CMD_SELECT;
 
@@ -1812,6 +1813,7 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 	/*
 	 * Recursively transform the components of the tree.
 	 */
+	sv_fromclause_ns = &sv_namespace_tsql;
 	sostmt = castNode(SetOperationStmt,
 					  transformSetOperationTree(pstate, stmt, true, NULL));
 	Assert(sostmt);
@@ -1916,7 +1918,7 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 	addNSItemToQuery(pstate, jnsitem, false, false, true);
 	
 	if (pre_transform_sort_from_set_hook)
-		(*pre_transform_sort_from_set_hook) (pstate, qry, leftmostQuery, leftmostSelect->fromClause);
+		(*pre_transform_sort_from_set_hook) (pstate, qry, leftmostQuery, sv_namespace_tsql);
 
 	/*
 	 * For now, we don't support resjunk sort clauses on the output of a

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -53,11 +53,7 @@
 #include "utils/syscache.h"
 
 tle_name_comparison_hook_type  tle_name_comparison_hook = NULL;
-<<<<<<< Updated upstream
-List **sv_fromclause_ns;
-=======
 NamespaceStack *ns_stack = NULL;
->>>>>>> Stashed changes
 
 static int	extractRemainingColumns(ParseNamespaceColumn *src_nscolumns,
 									List *src_colnames,

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -153,7 +153,7 @@ transformFromClause(ParseState *pstate, List *frmList)
 	 */
 	setNamespaceLateralState(pstate->p_namespace, false, true);
 
-	// /* Save namespace */
+	/* Save namespace */
 	if (ns_stack && !ns_stack->namespace)
 		ns_stack->namespace = pstate->p_namespace;
 }

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -53,7 +53,8 @@
 #include "utils/syscache.h"
 
 tle_name_comparison_hook_type  tle_name_comparison_hook = NULL;
-NamespaceStack *set_op_ns_stack = NULL;
+post_transform_from_clause_hook_type  post_transform_from_clause_hook = NULL;
+// NamespaceStack *set_op_ns_stack = NULL;
 
 static int	extractRemainingColumns(ParseNamespaceColumn *src_nscolumns,
 									List *src_colnames,
@@ -157,8 +158,12 @@ transformFromClause(ParseState *pstate, List *frmList)
 	 * Save the namespace -- tsql needs the leftmost select's namespace to
 	 * resolve some ORDER BY clauses used with set operations (i.e. UNION) 
 	 */
-	if (sql_dialect == SQL_DIALECT_TSQL && set_op_ns_stack && !set_op_ns_stack->namespace)
-		set_op_ns_stack->namespace = pstate->p_namespace;
+	if (post_transform_from_clause_hook)
+	{
+		post_transform_from_clause_hook(pstate);
+	}
+	// if (sql_dialect == SQL_DIALECT_TSQL && set_op_ns_stack && !set_op_ns_stack->namespace)
+	// 	set_op_ns_stack->namespace = pstate->p_namespace;
 }
 
 /*

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -54,7 +54,6 @@
 
 tle_name_comparison_hook_type  tle_name_comparison_hook = NULL;
 post_transform_from_clause_hook_type  post_transform_from_clause_hook = NULL;
-// NamespaceStack *set_op_ns_stack = NULL;
 
 static int	extractRemainingColumns(ParseNamespaceColumn *src_nscolumns,
 									List *src_colnames,
@@ -159,11 +158,7 @@ transformFromClause(ParseState *pstate, List *frmList)
 	 * resolve some ORDER BY clauses used with set operations (i.e. UNION) 
 	 */
 	if (post_transform_from_clause_hook)
-	{
 		post_transform_from_clause_hook(pstate);
-	}
-	// if (sql_dialect == SQL_DIALECT_TSQL && set_op_ns_stack && !set_op_ns_stack->namespace)
-	// 	set_op_ns_stack->namespace = pstate->p_namespace;
 }
 
 /*

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -53,7 +53,11 @@
 #include "utils/syscache.h"
 
 tle_name_comparison_hook_type  tle_name_comparison_hook = NULL;
+<<<<<<< Updated upstream
 List **sv_fromclause_ns;
+=======
+NamespaceStack *ns_stack = NULL;
+>>>>>>> Stashed changes
 
 static int	extractRemainingColumns(ParseNamespaceColumn *src_nscolumns,
 									List *src_colnames,
@@ -153,9 +157,9 @@ transformFromClause(ParseState *pstate, List *frmList)
 	 */
 	setNamespaceLateralState(pstate->p_namespace, false, true);
 
-	/* Save namespace */
-	if (sv_fromclause_ns && !*sv_fromclause_ns)
-		*sv_fromclause_ns = pstate->p_namespace;
+	// /* Save namespace */
+	if (ns_stack && !ns_stack->namespace)
+		ns_stack->namespace = pstate->p_namespace;
 }
 
 /*

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -53,6 +53,7 @@
 #include "utils/syscache.h"
 
 tle_name_comparison_hook_type  tle_name_comparison_hook = NULL;
+List **sv_fromclause_ns;
 
 static int	extractRemainingColumns(ParseNamespaceColumn *src_nscolumns,
 									List *src_colnames,
@@ -151,6 +152,10 @@ transformFromClause(ParseState *pstate, List *frmList)
 	 * but those should have been that way already.
 	 */
 	setNamespaceLateralState(pstate->p_namespace, false, true);
+
+	/* Save namespace */
+	if (sv_fromclause_ns && !*sv_fromclause_ns)
+		*sv_fromclause_ns = pstate->p_namespace;
 }
 
 /*

--- a/src/include/parser/analyze.h
+++ b/src/include/parser/analyze.h
@@ -54,6 +54,10 @@ extern PGDLLIMPORT post_transform_insert_row_hook_type post_transform_insert_row
 typedef int (*set_target_table_alternative_hook_type) (ParseState *pstate, Node *stmt, CmdType command);
 extern PGDLLIMPORT set_target_table_alternative_hook_type set_target_table_alternative_hook;
 
+/* Hook to handle target table in ORDER BY with set operation */
+typedef void (*pre_transform_sort_from_set_hook_type) (ParseState *pstate, Query *qry, Query *leftmostQuery, List *fromClause);
+extern PGDLLIMPORT pre_transform_sort_from_set_hook_type pre_transform_sort_from_set_hook;
+
 extern Query *parse_analyze_fixedparams(RawStmt *parseTree, const char *sourceText,
 										const Oid *paramTypes, int numParams, QueryEnvironment *queryEnv);
 extern Query *parse_analyze(RawStmt *parseTree, const char *sourceText,

--- a/src/include/parser/analyze.h
+++ b/src/include/parser/analyze.h
@@ -54,6 +54,18 @@ extern PGDLLIMPORT post_transform_insert_row_hook_type post_transform_insert_row
 typedef int (*set_target_table_alternative_hook_type) (ParseState *pstate, Node *stmt, CmdType command);
 extern PGDLLIMPORT set_target_table_alternative_hook_type set_target_table_alternative_hook;
 
+/* Hook for handle target table before transforming from clause */
+typedef void (*push_namespace_stack_hook_type) ();
+extern PGDLLIMPORT push_namespace_stack_hook_type push_namespace_stack_hook;
+
+/* Hook for handle target table before transforming from clause */
+typedef void (*pre_transform_sort_clause_hook_type) (Query *qry, Query *leftmostQuery);
+extern PGDLLIMPORT pre_transform_sort_clause_hook_type pre_transform_sort_clause_hook;
+
+/* Hook for handle target table before transforming from clause */
+typedef void (*post_transform_sort_clause_hook_type) (Query *qry);
+extern PGDLLIMPORT post_transform_sort_clause_hook_type post_transform_sort_clause_hook;
+
 extern Query *parse_analyze_fixedparams(RawStmt *parseTree, const char *sourceText,
 										const Oid *paramTypes, int numParams, QueryEnvironment *queryEnv);
 extern Query *parse_analyze(RawStmt *parseTree, const char *sourceText,

--- a/src/include/parser/analyze.h
+++ b/src/include/parser/analyze.h
@@ -54,10 +54,6 @@ extern PGDLLIMPORT post_transform_insert_row_hook_type post_transform_insert_row
 typedef int (*set_target_table_alternative_hook_type) (ParseState *pstate, Node *stmt, CmdType command);
 extern PGDLLIMPORT set_target_table_alternative_hook_type set_target_table_alternative_hook;
 
-/* Hook to handle target table in ORDER BY with set operation */
-typedef void (*pre_transform_sort_from_set_hook_type) (ParseState *pstate, Query *qry, Query *leftmostQuery, List *fromClause);
-extern PGDLLIMPORT pre_transform_sort_from_set_hook_type pre_transform_sort_from_set_hook;
-
 extern Query *parse_analyze_fixedparams(RawStmt *parseTree, const char *sourceText,
 										const Oid *paramTypes, int numParams, QueryEnvironment *queryEnv);
 extern Query *parse_analyze(RawStmt *parseTree, const char *sourceText,

--- a/src/include/parser/analyze.h
+++ b/src/include/parser/analyze.h
@@ -59,7 +59,7 @@ typedef void (*push_namespace_stack_hook_type) ();
 extern PGDLLIMPORT push_namespace_stack_hook_type push_namespace_stack_hook;
 
 /* Hook for handle target table before transforming from clause */
-typedef void (*pre_transform_sort_clause_hook_type) (Query *qry, Query *leftmostQuery);
+typedef void (*pre_transform_sort_clause_hook_type) (ParseState *pstate, Query *qry, Query *leftmostQuery);
 extern PGDLLIMPORT pre_transform_sort_clause_hook_type pre_transform_sort_clause_hook;
 
 /* Hook for handle target table before transforming from clause */

--- a/src/include/parser/parse_clause.h
+++ b/src/include/parser/parse_clause.h
@@ -61,4 +61,7 @@ extern bool targetIsInSortList(TargetEntry *tle, Oid sortop, List *sortList);
 typedef bool (*tle_name_comparison_hook_type)(const char *tlename, const char *identifier);
 extern PGDLLIMPORT tle_name_comparison_hook_type tle_name_comparison_hook;
 
+typedef bool (*post_transform_from_clause_hook_type)(ParseState *pstate);
+extern PGDLLIMPORT post_transform_from_clause_hook_type post_transform_from_clause_hook;
+
 #endif							/* PARSE_CLAUSE_H */

--- a/src/include/parser/parse_clause.h
+++ b/src/include/parser/parse_clause.h
@@ -16,13 +16,6 @@
 
 #include "parser/parse_node.h"
 
-typedef struct namespace_stack {
-	struct namespace_stack *prev;
-	List *namespace;
-} NamespaceStack;
-
-extern NamespaceStack *set_op_ns_stack;
-
 extern void transformFromClause(ParseState *pstate, List *frmList);
 extern int	setTargetTable(ParseState *pstate, RangeVar *relation,
 						   bool inh, bool alsoSource, AclMode requiredPerms);
@@ -61,7 +54,7 @@ extern bool targetIsInSortList(TargetEntry *tle, Oid sortop, List *sortList);
 typedef bool (*tle_name_comparison_hook_type)(const char *tlename, const char *identifier);
 extern PGDLLIMPORT tle_name_comparison_hook_type tle_name_comparison_hook;
 
-typedef bool (*post_transform_from_clause_hook_type)(ParseState *pstate);
+typedef void (*post_transform_from_clause_hook_type)(ParseState *pstate);
 extern PGDLLIMPORT post_transform_from_clause_hook_type post_transform_from_clause_hook;
 
 #endif							/* PARSE_CLAUSE_H */

--- a/src/include/parser/parse_clause.h
+++ b/src/include/parser/parse_clause.h
@@ -16,6 +16,8 @@
 
 #include "parser/parse_node.h"
 
+extern List **sv_fromclause_ns;
+
 extern void transformFromClause(ParseState *pstate, List *frmList);
 extern int	setTargetTable(ParseState *pstate, RangeVar *relation,
 						   bool inh, bool alsoSource, AclMode requiredPerms);

--- a/src/include/parser/parse_clause.h
+++ b/src/include/parser/parse_clause.h
@@ -21,7 +21,7 @@ typedef struct namespace_stack {
 	List *namespace;
 } NamespaceStack;
 
-extern NamespaceStack *ns_stack;
+extern NamespaceStack *set_op_ns_stack;
 
 extern void transformFromClause(ParseState *pstate, List *frmList);
 extern int	setTargetTable(ParseState *pstate, RangeVar *relation,

--- a/src/include/parser/parse_clause.h
+++ b/src/include/parser/parse_clause.h
@@ -16,7 +16,12 @@
 
 #include "parser/parse_node.h"
 
-extern List **sv_fromclause_ns;
+typedef struct namespace_stack {
+	struct namespace_stack *prev;
+	List *namespace;
+} NamespaceStack;
+
+extern NamespaceStack *ns_stack;
 
 extern void transformFromClause(ParseState *pstate, List *frmList);
 extern int	setTargetTable(ParseState *pstate, RangeVar *relation,


### PR DESCRIPTION
### Description

Previously, ORDER BY clauses combined with set operations like UNION could raise an error when specifying the table name with the column. T-SQL allows queries like this, several hooks have been added to allow the extension to modify how set operators are analyzed.
 
### Issues Resolved
BABEL-3215
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
