### PR TITLE
Support database-level dump/restore

### DIFF
--- a/src/backend/commands/copyfromparse.c
+++ b/src/backend/commands/copyfromparse.c
@@ -147,6 +147,8 @@ if (1) \
 /* NOTE: there's a copy of this in copyto.c */
 static const char BinarySignature[11] = "PGCOPY\n\377\r\n\0";
 
+/* hooks */
+fill_missing_values_in_copyfrom_hook_type fill_missing_values_in_copyfrom_hook = NULL;
 
 /* non-export function prototypes */
 static bool CopyReadLine(CopyFromState cstate);
@@ -1022,6 +1024,9 @@ NextCopyFrom(CopyFromState cstate, ExprContext *econtext,
 		values[defmap[i]] = ExecEvalExpr(defexprs[i], econtext,
 										 &nulls[defmap[i]]);
 	}
+
+	if (fill_missing_values_in_copyfrom_hook)
+		fill_missing_values_in_copyfrom_hook(cstate->rel, values, nulls);
 
 	return true;
 }

--- a/src/bin/pg_dump/Makefile
+++ b/src/bin/pg_dump/Makefile
@@ -43,8 +43,8 @@ pg_dump: pg_dump.o common.o pg_dump_sort.o dump_babel_utils.o $(OBJS) | submake-
 pg_restore: pg_restore.o $(OBJS) | submake-libpq submake-libpgport submake-libpgfeutils
 	$(CC) $(CFLAGS) pg_restore.o $(OBJS) $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@$(X)
 
-pg_dumpall: pg_dumpall.o dumputils.o $(WIN32RES) | submake-libpq submake-libpgport submake-libpgfeutils
-	$(CC) $(CFLAGS) pg_dumpall.o dumputils.o $(WIN32RES) $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@$(X)
+pg_dumpall: pg_dumpall.o dumputils.o dumpall_babel_utils.o $(WIN32RES) | submake-libpq submake-libpgport submake-libpgfeutils
+	$(CC) $(CFLAGS) pg_dumpall.o dumputils.o dumpall_babel_utils.o $(WIN32RES) $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@$(X)
 
 install: all installdirs
 	$(INSTALL_PROGRAM) pg_dump$(X) '$(DESTDIR)$(bindir)'/pg_dump$(X)

--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -121,8 +121,9 @@ static bool
 isBabelfishConfigTable(TableInfo *tbinfo)
 {
 	/* We don't want to dump logins during logical database dump */
-	if (tbinfo->relkind != RELKIND_RELATION ||
-		(tbinfo && tbinfo->dobj.namespace &&
+	if (tbinfo == NULL || tbinfo->relkind != RELKIND_RELATION ||
+		(tbinfo->dobj.namespace &&
+		strcmp(tbinfo->dobj.namespace->dobj.name, "sys") == 0 &&
 		strcmp(tbinfo->dobj.name, "babelfish_authid_login_ext") == 0))
 		return false;
 

--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -121,8 +121,9 @@ static bool
 isBabelfishConfigTable(TableInfo *tbinfo)
 {
 	/* We don't want to dump logins during logical database dump */
-	if (tbinfo && tbinfo->dobj.namespace &&
-		strcmp(tbinfo->dobj.name, "babelfish_authid_login_ext") == 0)
+	if (tbinfo->relkind != RELKIND_RELATION ||
+		(tbinfo && tbinfo->dobj.namespace &&
+		strcmp(tbinfo->dobj.name, "babelfish_authid_login_ext") == 0))
 		return false;
 
 	if (catalog_table_include_oids.head != NULL &&

--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -20,9 +20,10 @@
 #define PLTSQL_TVFTYPE_MSTVF 1
 #define PLTSQL_TVFTYPE_ITVF  2
 
+extern char *bbf_db_name;
 
-extern char *getMinOid(Archive *fout);
 extern void bbf_selectDumpableCast(CastInfo *cast);
+extern void bbf_selectDumpableTableData(TableInfo *tbinfo, Archive *fout);
 extern void fixTsqlDefaultExpr(Archive *fout, AttrDefInfo *attrDefInfo);
 extern bool isBabelfishDatabase(Archive *fout);
 extern void fixOprRegProc(Archive *fout, const OprInfo *oprinfo, const char *oprleft, const char *oprright, char **oprregproc);
@@ -33,5 +34,11 @@ extern void fixAttoptionsBbfOriginalName(Archive *fout, Oid relOid, const TableI
 extern void setOrResetPltsqlFuncRestoreGUCs(Archive *fout, PQExpBuffer q, const FuncInfo *finfo, char prokind, bool proretset, bool is_set);
 extern void dumpBabelfishSpecificConfig(Archive *AH, const char *dbname, PQExpBuffer outbuf);
 extern void updateExtConfigArray(Archive *fout, char ***extconfigarray, int nconfigitems);
+extern char *babelfish_handle_view_def(Archive *fout, char *view_def);
+extern void prepareForLogicalDatabaseDump(Archive *fout, SimpleStringList *schema_include_patterns);
+extern void getBabelfishDependencies(Archive *fout);
+extern void dumpBabelGUCs(Archive *fout);
+extern void getCursorForBbfCatalogTableData(Archive *fout, TableInfo *tbinfo, PQExpBuffer buf, int *nfields);
+extern void fixCopyCommand(Archive *fout, PQExpBuffer copyBuf, TableInfo *tbinfo, bool isFrom);
 
 #endif

--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -36,9 +36,9 @@ extern void dumpBabelfishSpecificConfig(Archive *AH, const char *dbname, PQExpBu
 extern void updateExtConfigArray(Archive *fout, char ***extconfigarray, int nconfigitems);
 extern char *babelfish_handle_view_def(Archive *fout, char *view_def);
 extern void prepareForLogicalDatabaseDump(Archive *fout, SimpleStringList *schema_include_patterns);
-extern void getBabelfishDependencies(Archive *fout);
+extern void setBabelfishDependenciesForLogicalDatabaseDump(Archive *fout);
 extern void dumpBabelGUCs(Archive *fout);
-extern void getCursorForBbfCatalogTableData(Archive *fout, TableInfo *tbinfo, PQExpBuffer buf, int *nfields);
+extern void fixCursorForBbfCatalogTableData(Archive *fout, TableInfo *tbinfo, PQExpBuffer buf, int *nfields, char *attgenerated);
 extern void fixCopyCommand(Archive *fout, PQExpBuffer copyBuf, TableInfo *tbinfo, bool isFrom);
 
 #endif

--- a/src/bin/pg_dump/dumpall_babel_utils.c
+++ b/src/bin/pg_dump/dumpall_babel_utils.c
@@ -89,7 +89,7 @@ getBabelfishRolesQuery(PQExpBuffer buf, char *role_catalog, bool drop_query)
 }
 
 /*
- * Returns query to fetch al the roles, members and grantors related
+ * Returns query to fetch all the roles, members and grantors related
  * to Babelfish users of specified logical database.
  */
 void

--- a/src/bin/pg_dump/dumpall_babel_utils.c
+++ b/src/bin/pg_dump/dumpall_babel_utils.c
@@ -1,0 +1,124 @@
+/*-------------------------------------------------------------------------
+ *
+ * Utility routines for babelfish objects
+ *
+ * Portions Copyright (c) 1996-2021, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * src/bin/pg_dump/dumpall_babel_utils.c
+ *
+ *-------------------------------------------------------------------------
+ */
+#include "postgres_fe.h"
+
+#include "catalog/pg_class_d.h"
+#include "catalog/pg_proc_d.h"
+#include "catalog/pg_type_d.h"
+#include "common/logging.h"
+#include "dumpall_babel_utils.h"
+#include "fe_utils/string_utils.h"
+#include "pg_backup_db.h"
+#include "pg_backup_utils.h"
+#include "pg_backup.h"
+#include "pg_dump.h"
+#include "pqexpbuffer.h"
+
+/* Babelfish virtual database to dump */
+char *bbf_db_name = NULL;
+
+/*
+ * Returns query to fetch all Babelfish users of specified logical database
+ * and all the logins.
+ * drop_query decides whether the qeury is to DROP the roles.
+ */
+void
+getBabelfishRolesQuery(PQExpBuffer buf, char *role_catalog, bool drop_query)
+{
+	char *escaped_bbf_db_name;
+
+	if (!bbf_db_name)
+		return;
+
+	/*
+	 * Get escaped bbf_db_name to handle special characters in it.
+	 * 2*strlen+1 bytes are required for PQescapeString according to the documentation.
+	 */
+	escaped_bbf_db_name = pg_malloc(2 * strlen(bbf_db_name) + 1);
+	PQescapeString(escaped_bbf_db_name, bbf_db_name, strlen(bbf_db_name));
+
+	resetPQExpBuffer(buf);
+	if (drop_query)
+	{
+		printfPQExpBuffer(buf,
+						  "WITH bbf_roles AS "
+						  "(SELECT rolname from sys.babelfish_authid_user_ext "
+						  "WHERE database_name = '%s' AND "
+						  "rolname NOT IN ('master_dbo', 'master_db_owner', 'master_guest') "
+						  "UNION SELECT rolname from sys.babelfish_authid_login_ext) "
+						  "SELECT rc.rolname "
+						  "FROM %s rc "
+						  "INNER JOIN bbf_roles bc "
+						  "ON rc.rolname = bc.rolname "
+						  "WHERE rc.rolname !~ '^pg_' "
+						  "ORDER BY 1", escaped_bbf_db_name, role_catalog);
+	}
+	else
+	{
+		printfPQExpBuffer(buf,
+						  "WITH bbf_roles AS "
+						  "(SELECT rolname from sys.babelfish_authid_user_ext "
+						  "WHERE database_name = '%s' AND "
+						  "rolname NOT IN ('master_dbo', 'master_db_owner', 'master_guest') "
+						  "UNION SELECT rolname from sys.babelfish_authid_login_ext) "
+						  "SELECT oid, rc.rolname, rolsuper, rolinherit, "
+						  "rolcreaterole, rolcreatedb, "
+						  "rolcanlogin, rolconnlimit, rolpassword, "
+						  "rolvaliduntil, rolreplication, rolbypassrls, "
+						  "pg_catalog.shobj_description(oid, '%s') as rolcomment, "
+						  "rc.rolname = current_user AS is_current_user "
+						  "FROM %s rc "
+						  "INNER JOIN bbf_roles bc "
+						  "ON rc.rolname = bc.rolname "
+						  "WHERE rc.rolname !~ '^pg_' "
+						  "ORDER BY 2", escaped_bbf_db_name, role_catalog, role_catalog);
+	}
+}
+
+/*
+ * Returns query to fetch al the roles, members and grantors related
+ * to Babelfish users and logins.
+ */
+void
+getBabelfishRoleMembershipQuery(PQExpBuffer buf, char *role_catalog)
+{
+	char *escaped_bbf_db_name;
+
+	if (!bbf_db_name)
+		return;
+
+	/*
+	 * Get escaped bbf_db_name to handle special characters in it.
+	 * 2*strlen+1 bytes are required for PQescapeString according to the documentation.
+	 */
+	escaped_bbf_db_name = pg_malloc(2 * strlen(bbf_db_name) + 1);
+	PQescapeString(escaped_bbf_db_name, bbf_db_name, strlen(bbf_db_name));
+
+	resetPQExpBuffer(buf);
+	printfPQExpBuffer(buf, "WITH bbf_roles AS "
+					  "(SELECT rc.oid, rc.rolname FROM %s rc "
+					  "INNER JOIN sys.babelfish_authid_user_ext bc "
+					  "ON rc.rolname = bc.rolname WHERE bc.database_name = '%s' "
+					  "UNION SELECT rc.oid, rc.rolname FROM %s rc "
+					  "INNER JOIN sys.babelfish_authid_login_ext bc "
+					  "ON rc.rolname = bc.rolname) "
+					  "SELECT ur.rolname AS roleid, "
+					  "um.rolname AS member, "
+					  "a.admin_option, "
+					  "ug.rolname AS grantor "
+					  "FROM pg_auth_members a "
+					  "INNER JOIN bbf_roles ur on ur.oid = a.roleid "
+					  "INNER JOIN bbf_roles um on um.oid = a.member "
+					  "LEFT JOIN bbf_roles ug on ug.oid = a.grantor "
+					  "WHERE NOT (ur.rolname ~ '^pg_' AND um.rolname ~ '^pg_')"
+					  "ORDER BY 1,2,3", role_catalog, escaped_bbf_db_name, role_catalog);
+}

--- a/src/bin/pg_dump/dumpall_babel_utils.c
+++ b/src/bin/pg_dump/dumpall_babel_utils.c
@@ -27,18 +27,23 @@
 char *bbf_db_name = NULL;
 
 /*
- * Returns query to fetch all Babelfish users of specified logical database
- * and all the logins.
- * drop_query decides whether the qeury is to DROP the roles.
+ * Returns query to fetch default Babelfish users of specified logical database.
+ * For a database DB, default roles will be: DB_dbo, DB_db_owner, DB_guest
+ * drop_query decides whether the query is to DROP the roles.
  */
 void
 getBabelfishRolesQuery(PQExpBuffer buf, char *role_catalog, bool drop_query)
 {
-	char *escaped_bbf_db_name;
+	char	*escaped_bbf_db_name;
+	bool	is_builtin_db = false;
 
 	if (!bbf_db_name)
 		return;
 
+	is_builtin_db = (pg_strcasecmp(bbf_db_name, "master") == 0 ||
+			pg_strcasecmp(bbf_db_name, "tempdb") == 0 ||
+			pg_strcasecmp(bbf_db_name, "msdb") == 0)
+			? true : false;
 	/*
 	 * Get escaped bbf_db_name to handle special characters in it.
 	 * 2*strlen+1 bytes are required for PQescapeString according to the documentation.
@@ -50,48 +55,47 @@ getBabelfishRolesQuery(PQExpBuffer buf, char *role_catalog, bool drop_query)
 	if (drop_query)
 	{
 		printfPQExpBuffer(buf,
-						  "WITH bbf_roles AS "
-						  "(SELECT rolname from sys.babelfish_authid_user_ext "
-						  "WHERE database_name = '%s' AND "
-						  "rolname NOT IN ('master_dbo', 'master_db_owner', 'master_guest') "
-						  "UNION SELECT rolname from sys.babelfish_authid_login_ext) "
-						  "SELECT rc.rolname "
-						  "FROM %s rc "
-						  "INNER JOIN bbf_roles bc "
-						  "ON rc.rolname = bc.rolname "
-						  "WHERE rc.rolname !~ '^pg_' "
-						  "ORDER BY 1", escaped_bbf_db_name, role_catalog);
+						  "SELECT rolname "
+						  "FROM %s "
+						  "WHERE rolname !~ '^pg_' "
+						  "AND rolname IN ('dbo', 'db_owner', '%s_dbo', '%s_db_owner', '%s_guest') "
+						  "ORDER BY 1 ",
+						  role_catalog, escaped_bbf_db_name,
+						  escaped_bbf_db_name, escaped_bbf_db_name);
+
+		/* builtin db users will already be present in the target server so no need to dump them */
+		if (is_builtin_db)
+			appendPQExpBufferStr(buf, "LIMIT 0");
 	}
 	else
 	{
 		printfPQExpBuffer(buf,
-						  "WITH bbf_roles AS "
-						  "(SELECT rolname from sys.babelfish_authid_user_ext "
-						  "WHERE database_name = '%s' AND "
-						  "rolname NOT IN ('master_dbo', 'master_db_owner', 'master_guest') "
-						  "UNION SELECT rolname from sys.babelfish_authid_login_ext) "
-						  "SELECT oid, rc.rolname, rolsuper, rolinherit, "
+						  "SELECT oid, rolname, rolsuper, rolinherit, "
 						  "rolcreaterole, rolcreatedb, "
 						  "rolcanlogin, rolconnlimit, rolpassword, "
 						  "rolvaliduntil, rolreplication, rolbypassrls, "
 						  "pg_catalog.shobj_description(oid, '%s') as rolcomment, "
-						  "rc.rolname = current_user AS is_current_user "
-						  "FROM %s rc "
-						  "INNER JOIN bbf_roles bc "
-						  "ON rc.rolname = bc.rolname "
-						  "WHERE rc.rolname !~ '^pg_' "
-						  "ORDER BY 2", escaped_bbf_db_name, role_catalog, role_catalog);
+						  "rolname = current_user AS is_current_user "
+						  "FROM %s "
+						  "WHERE rolname !~ '^pg_' "
+						  "AND rolname IN ('dbo', 'db_owner', '%s_dbo', '%s_db_owner', '%s_guest') "
+						  "ORDER BY 2 ", role_catalog, role_catalog, escaped_bbf_db_name,
+						  escaped_bbf_db_name, escaped_bbf_db_name);
+
+		/* builtin db users will already be present in the target server so no need to dump them */
+		if (is_builtin_db)
+			appendPQExpBufferStr(buf, "LIMIT 0");
 	}
 }
 
 /*
  * Returns query to fetch al the roles, members and grantors related
- * to Babelfish users and logins.
+ * to Babelfish users of specified logical database.
  */
 void
 getBabelfishRoleMembershipQuery(PQExpBuffer buf, char *role_catalog)
 {
-	char *escaped_bbf_db_name;
+	char	*escaped_bbf_db_name;
 
 	if (!bbf_db_name)
 		return;
@@ -104,21 +108,22 @@ getBabelfishRoleMembershipQuery(PQExpBuffer buf, char *role_catalog)
 	PQescapeString(escaped_bbf_db_name, bbf_db_name, strlen(bbf_db_name));
 
 	resetPQExpBuffer(buf);
-	printfPQExpBuffer(buf, "WITH bbf_roles AS "
-					  "(SELECT rc.oid, rc.rolname FROM %s rc "
-					  "INNER JOIN sys.babelfish_authid_user_ext bc "
-					  "ON rc.rolname = bc.rolname WHERE bc.database_name = '%s' "
-					  "UNION SELECT rc.oid, rc.rolname FROM %s rc "
-					  "INNER JOIN sys.babelfish_authid_login_ext bc "
-					  "ON rc.rolname = bc.rolname) "
+	printfPQExpBuffer(buf,
 					  "SELECT ur.rolname AS roleid, "
 					  "um.rolname AS member, "
 					  "a.admin_option, "
 					  "ug.rolname AS grantor "
 					  "FROM pg_auth_members a "
-					  "INNER JOIN bbf_roles ur on ur.oid = a.roleid "
-					  "INNER JOIN bbf_roles um on um.oid = a.member "
-					  "LEFT JOIN bbf_roles ug on ug.oid = a.grantor "
-					  "WHERE NOT (ur.rolname ~ '^pg_' AND um.rolname ~ '^pg_')"
-					  "ORDER BY 1,2,3", role_catalog, escaped_bbf_db_name, role_catalog);
+					  "LEFT JOIN %s ur on ur.oid = a.roleid "
+					  "LEFT JOIN %s um on um.oid = a.member "
+					  "LEFT JOIN %s ug on ug.oid = a.grantor "
+					  "WHERE NOT (ur.rolname ~ '^pg_' AND um.rolname ~ '^pg_') "
+					  "AND ur.rolname IN ('dbo', 'db_owner', '%s_dbo', '%s_db_owner', '%s_guest', 'sysadmin') "
+					  "AND um.rolname IN ('dbo', 'db_owner', '%s_dbo', '%s_db_owner', '%s_guest', 'sysadmin') "
+					  "AND ug.rolname IN ('dbo', 'db_owner', '%s_dbo', '%s_db_owner', '%s_guest', 'sysadmin') "
+					  "ORDER BY 1,2,3",
+					  role_catalog, role_catalog, role_catalog,
+					  escaped_bbf_db_name, escaped_bbf_db_name, escaped_bbf_db_name,
+					  escaped_bbf_db_name, escaped_bbf_db_name, escaped_bbf_db_name,
+					  escaped_bbf_db_name, escaped_bbf_db_name, escaped_bbf_db_name);
 }

--- a/src/bin/pg_dump/dumpall_babel_utils.h
+++ b/src/bin/pg_dump/dumpall_babel_utils.h
@@ -1,0 +1,22 @@
+/*-------------------------------------------------------------------------
+ *
+ * Utility routines for babelfish objects
+ *
+ * Portions Copyright (c) 1996-2021, PostgreSQL Global Development Group
+ * Portions Copyright (c) 1994, Regents of the University of California
+ *
+ * src/bin/pg_dump/dumpall_babel_utils.h
+ *
+ *-------------------------------------------------------------------------
+ */
+#ifndef DUMPALL_BABEL_UTILS_H
+#define DUMPALL_BABEL_UTILS_H
+
+#include "pqexpbuffer.h"
+
+extern char *bbf_db_name;
+
+extern void getBabelfishRolesQuery(PQExpBuffer buf, char *role_catalog, bool drop_query);
+extern void getBabelfishRoleMembershipQuery(PQExpBuffer buf, char *role_catalog);
+
+#endif

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -2467,19 +2467,6 @@ dumpTableData(Archive *fout, const TableDataInfo *tdinfo)
 	}
 
 	/*
-	 * Always restore sys.babelfish_authid_login_ext Babelfish catalog table
-	 * using INSERT. This is needed because some inserts might fail due to certain
-	 * login being pre-existing on the target server.
-	 */
-	if (isBabelfishDatabase(fout) && bbf_db_name != NULL &&
-		strcmp(tbinfo->dobj.namespace->dobj.name, "sys") == 0 &&
-		strcmp(tbinfo->dobj.name, "babelfish_authid_login_ext") == 0)
-	{
-		dumpFn = dumpTableData_insert;
-		copyStmt = NULL;
-	}
-
-	/*
 	 * Note: although the TableDataInfo is a full DumpableObject, we treat its
 	 * dependency on its table as "special" and pass it to ArchiveEntry now.
 	 * See comments for BuildArchiveDependencies.

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -416,7 +416,7 @@ main(int argc, char **argv)
 		{"on-conflict-do-nothing", no_argument, &dopt.do_nothing, 1},
 		{"rows-per-insert", required_argument, NULL, 10},
 		{"include-foreign-data", required_argument, NULL, 11},
-		{"bbf-database-name", required_argument, NULL, 12},
+		{"bbf-database-name", required_argument, NULL, 30},
 
 		{NULL, 0, NULL, 0}
 	};
@@ -627,7 +627,7 @@ main(int argc, char **argv)
 										  optarg);
 				break;
 
-			case 12:			/* Babelfish logical database name */
+			case 30:			/* Babelfish logical database name */
 				bbf_db_name = pg_strdup(optarg);
 				dopt.include_everything = false;
 				break;
@@ -2189,7 +2189,7 @@ dumpTableData_insert(Archive *fout, const void *dcontext)
 	if (tdinfo->filtercond)
 		appendPQExpBuffer(q, " %s", tdinfo->filtercond);
 
-	getCursorForBbfCatalogTableData(fout, tbinfo, q, &nfields);
+	fixCursorForBbfCatalogTableData(fout, tbinfo, q, &nfields, attgenerated);
 	ExecuteSqlStatement(fout, q->data);
 
 	while (1)
@@ -17914,7 +17914,7 @@ getDependencies(Archive *fout)
 	}
 	
 	if (bbf_db_name != NULL)
-		getBabelfishDependencies(fout);
+		setBabelfishDependenciesForLogicalDatabaseDump(fout);
 
 	PQclear(res);
 

--- a/src/bin/pg_dump/pg_dumpall.c
+++ b/src/bin/pg_dump/pg_dumpall.c
@@ -153,7 +153,7 @@ main(int argc, char *argv[])
 		{"no-unlogged-table-data", no_argument, &no_unlogged_table_data, 1},
 		{"on-conflict-do-nothing", no_argument, &on_conflict_do_nothing, 1},
 		{"rows-per-insert", required_argument, NULL, 7},
-		{"bbf-database-name", required_argument, NULL, 8},
+		{"bbf-database-name", required_argument, NULL, 30},
 
 		{NULL, 0, NULL, 0}
 	};
@@ -337,7 +337,7 @@ main(int argc, char *argv[])
 				appendShellString(pgdumpopts, optarg);
 				break;
 
-			case 8:			/* Babelfish virtual database name */
+			case 30:			/* Babelfish virtual database name */
 				bbf_db_name = pg_strdup(optarg);
 				break;
 

--- a/src/include/commands/copy.h
+++ b/src/include/commands/copy.h
@@ -99,4 +99,7 @@ extern List *CopyGetAttnums(TupleDesc tupDesc, Relation rel,
 
 typedef bool (*is_tsql_rowversion_or_timestamp_datatype_hook_type)(Oid oid);
 extern PGDLLIMPORT is_tsql_rowversion_or_timestamp_datatype_hook_type is_tsql_rowversion_or_timestamp_datatype_hook;
+typedef void (*fill_missing_values_in_copyfrom_hook_type)(Relation rel, Datum *values, bool *nulls);
+extern PGDLLIMPORT fill_missing_values_in_copyfrom_hook_type fill_missing_values_in_copyfrom_hook;
+
 #endif							/* COPY_H */


### PR DESCRIPTION
### Description
Added support for dumping a single Babelfish logical database. Changes are
summarized in following bullet points:
1. Added a new option `--bbf-database-name` in both pg_dumpall and pg_dump to
let user provide the name of logical database to be dumped.
2. Fetch all the physical schema names corresponding to the given logical database
and add all of them into `schema_include_patterns` list. With this, existing dump
logic will make sure to only dump all these schemas as well as all the objects
contained by these schemas.
3. Function `bbf_selectDumpableTableData` takes care of explicitly marking all
Babelfish catalog table data to be dumped.
4. We need to selectively dump the Babelfish catalog table data corresponding to
given logical database which is being handled by function `getCursorForBbfCatalogTableData`
for `COLUMN-INSERT` and `fixCopyCommand` for `COPY`. These function prepares
query using joins and conditions to filter the data.
5. We skip dumping the `dbid` column as it might conflict with the existing database's `dbid`
so we generate the new `dbid` during restore. It has been handled for both `COLUMN-INSERT`
and `COPY` options:
 a. `COPY`: Implemented a hook `fill_missing_values_in_copyfrom_hook` which will use the
 sequence to generate the new `dbid`.  
 b. `COLUMN-INSERT`: Used existing `pre_parse_analyze_hook` hook to handle this case.
5. Added a new file `dumpall_babel_utils.c` to implement Babelfish specific logic to
selectively dump users. New file is needed since existing `dump_babel_utils.c` can't
be used with pg_dumpall utility.
7. Logins do not belong to a single database so we will not be dumping the logins so it and
we will only dump default users of the database (dbo, db_owner and db_guest).
Due to this `CREATE` and `INSERT` might fail for certain logins but it should be fine.
8. Current implementation does not dump foreign servers and foreign data wrappers as
these are global objects and does not belong to a single logical database.
9. **Note**: A logical database with certain migration mode (single-db/multi-db) can only be 
restored on the Babelfish server with the same migration mode. Which means a single-db
database can be restored only on single-db Babelfish server, same thing applies to multi-db.
Although the builtin databases like `master` can be restored on any kind of server.

Task: BABEL-3870
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>
 
### Check List

- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
