### PR TITLE
Expose extension_config_remove function through a wrapper

### DIFF
--- a/src/backend/commands/extension.c
+++ b/src/backend/commands/extension.c
@@ -2537,7 +2537,7 @@ pg_extension_config_dump(PG_FUNCTION_ARGS)
  * This is not currently exposed as a function, but it could be;
  * for now, we just invoke it from ALTER EXTENSION DROP.
  */
-void
+static void
 extension_config_remove(Oid extensionoid, Oid tableoid)
 {
 	Relation	extRel;
@@ -2701,6 +2701,18 @@ extension_config_remove(Oid extensionoid, Oid tableoid)
 	systable_endscan(extScan);
 
 	table_close(extRel, RowExclusiveLock);
+}
+
+/*
+ * It's simply a wrapper of extension_config_remove function so that
+ * it can be used by the extensions.
+ * We should remove this wrapper when community exposes extension_config_remove
+ * as a SQL function or makes it non-static.
+ */
+void
+extension_config_remove_wrapper(Oid extensionoid, Oid tableoid)
+{
+	extension_config_remove(extensionoid, tableoid);
 }
 
 /*

--- a/src/include/commands/extension.h
+++ b/src/include/commands/extension.h
@@ -51,6 +51,6 @@ extern bool extension_file_exists(const char *extensionName);
 
 extern ObjectAddress AlterExtensionNamespace(const char *extensionName, const char *newschema,
 											 Oid *oldschema);
-extern void extension_config_remove(Oid extensionoid, Oid tableoid);
+extern void extension_config_remove_wrapper(Oid extensionoid, Oid tableoid);
 
 #endif							/* EXTENSION_H */


### PR DESCRIPTION
### Description
Expose extension_config_remove function through a wrapper so that it can be used by extensions.
 
### Check List

- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
