### PR TITLE
Add support for rowcount in execution

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -75,6 +75,7 @@ ExecutorFinish_hook_type ExecutorFinish_hook = NULL;
 ExecutorEnd_hook_type ExecutorEnd_hook = NULL;
 
 TriggerRecuresiveCheck_hook_type TriggerRecuresiveCheck_hook = NULL;
+check_rowcount_hook_type check_rowcount_hook = NULL;
 /* Hook for plugin to get control in ExecCheckRTPerms() */
 ExecutorCheckPerms_hook_type ExecutorCheckPerms_hook = NULL;
 

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -3793,11 +3793,6 @@ ExecModifyTable(PlanState *pstate)
 	 */
 	for (;;)
 	{
-		if (estate->es_processed == estate->tsql_row_count && estate->tsql_row_count > 0)
-		{
-			slot = NULL;
-			break;
-		}
 		/*
 		 * Reset the per-output-tuple exprcontext.  This is needed because
 		 * triggers expect to use that context as workspace.  It's a bit ugly
@@ -3813,6 +3808,12 @@ ExecModifyTable(PlanState *pstate)
 		 */
 		if (pstate->ps_ExprContext)
 			ResetExprContext(pstate->ps_ExprContext);
+
+		if (estate->es_processed == estate->tsql_row_count && estate->tsql_row_count > 0)
+		{
+			slot = NULL;
+			break;
+		}
 
 		if (tsql_insert_exec)
 		{

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -3793,6 +3793,11 @@ ExecModifyTable(PlanState *pstate)
 	 */
 	for (;;)
 	{
+		if (estate->es_processed == estate->tsql_row_count && estate->tsql_row_count > 0)
+		{
+			slot = NULL;
+			break;
+		}
 		/*
 		 * Reset the per-output-tuple exprcontext.  This is needed because
 		 * triggers expect to use that context as workspace.  It's a bit ugly

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -3809,7 +3809,8 @@ ExecModifyTable(PlanState *pstate)
 		if (pstate->ps_ExprContext)
 			ResetExprContext(pstate->ps_ExprContext);
 
-		if (check_rowcount_hook && check_rowcount_hook(estate->es_processed))
+		if (sql_dialect == SQL_DIALECT_TSQL && check_rowcount_hook &&
+			 check_rowcount_hook(estate->es_processed))
 		{
 			slot = NULL;
 			break;

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -3809,7 +3809,7 @@ ExecModifyTable(PlanState *pstate)
 		if (pstate->ps_ExprContext)
 			ResetExprContext(pstate->ps_ExprContext);
 
-		if (estate->es_processed == estate->tsql_row_count && estate->tsql_row_count > 0)
+		if (check_rowcount_hook && check_rowcount_hook(estate->es_processed))
 		{
 			slot = NULL;
 			break;

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -87,6 +87,9 @@ extern PGDLLIMPORT ExecutorCheckPerms_hook_type ExecutorCheckPerms_hook;
 typedef bool (*TriggerRecuresiveCheck_hook_type) (ResultRelInfo *resultRelInfo);
 extern PGDLLIMPORT TriggerRecuresiveCheck_hook_type TriggerRecuresiveCheck_hook;
 
+typedef bool (*check_rowcount_hook_type) (int es_processed);
+extern PGDLLIMPORT check_rowcount_hook_type check_rowcount_hook;
+
 /*
  * prototypes from functions in execAmi.c
  */

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -700,6 +700,9 @@ typedef struct EState
 
 	/* List of ResultRelInfoExtra structs (see above) */
 	List	   *es_resultrelinfo_extra;
+
+	/* row count for babel node modify execution*/
+	int        tsql_row_count;
 } EState;
 
 

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -700,9 +700,6 @@ typedef struct EState
 
 	/* List of ResultRelInfoExtra structs (see above) */
 	List	   *es_resultrelinfo_extra;
-
-	/* row count for babel node modify execution*/
-	int        tsql_row_count;
 } EState;
 
 


### PR DESCRIPTION
previously we don't allow set rowcount other than 0 in this commit, we'll support rowcount for SELECT/UPDATE/INSERT/DELETE

Issues Resolved
BABEL-233

Signed-off-by: Zhibai Song <szh@amazon.com>


### Check List

- [x ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
