### PR TITLE
Create proc/func not visible in the pg_stat_statements view

### DIFF
--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -781,7 +781,10 @@ standard_ProcessUtility(PlannedStmt *pstmt,
 			if (sql_dialect != SQL_DIALECT_TSQL) {
 				PreventInTransactionBlock(isTopLevel, "CREATE DATABASE");
 			}
-			createdb(pstate, (CreatedbStmt *) parsetree);
+			else {
+				create_bbf_db(pstate, (CreatedbStmt *) parsetree);
+			}
+			//createdb(pstate, (CreatedbStmt *) parsetree);
 			break;
 
 		case T_AlterDatabaseStmt:

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -605,6 +605,12 @@ standard_ProcessUtility(PlannedStmt *pstmt,
 			{
 				TransactionStmt *stmt = (TransactionStmt *) parsetree;
 
+				// if (NestedTranCount > 0 || (sql_dialect == SQL_DIALECT_TSQL && !IsTransactionBlockActive()))
+				// {
+				// 	PLTsqlProcessTransaction(parsetree, params, qc);
+				// 	return;
+				// }
+
 				switch (stmt->kind)
 				{
 						/*
@@ -1659,37 +1665,37 @@ ProcessUtilitySlow(ParseState *pstate,
 
 			case T_CreateFunctionStmt:	/* CREATE FUNCTION */
 				{
-					CreateFunctionStmt *stmt = (CreateFunctionStmt *) parsetree;
-					ListCell *option = NULL; 
+					// CreateFunctionStmt *stmt = (CreateFunctionStmt *) parsetree;
+					// ListCell *option = NULL; 
 					
-					DefElem    *language_item = NULL;
-					char *language = NULL;
+					// DefElem    *language_item = NULL;
+					// char *language = NULL;
 		
-					foreach(option, stmt->options)
-					{
-						DefElem *defel = (DefElem *)lfirst(option); 
+					// foreach(option, stmt->options)
+					// {
+					// 	DefElem *defel = (DefElem *)lfirst(option); 
 
 						
-						if (strcmp(defel->defname, "language") == 0)
-						{
-							if (language_item)
-								ereport(ERROR,
-										(errcode(ERRCODE_SYNTAX_ERROR),
-										errmsg("conflicting or redundant options"),
-										parser_errposition(pstate, defel->location)));
-							language_item = defel;
-						}
-					}
+					// 	if (strcmp(defel->defname, "language") == 0)
+					// 	{
+					// 		if (language_item)
+					// 			ereport(ERROR,
+					// 					(errcode(ERRCODE_SYNTAX_ERROR),
+					// 					errmsg("conflicting or redundant options"),
+					// 					parser_errposition(pstate, defel->location)));
+					// 		language_item = defel;
+					// 	}
+					// }
 
-					if (language_item)
-						language = strVal(language_item->arg);
+					// if (language_item)
+					// 	language = strVal(language_item->arg);
 					
 
-					if ((language && !strcmp(language,"pltsql")) || sql_dialect == SQL_DIALECT_TSQL)
-					{
+					// if ((language && !strcmp(language,"pltsql")) || sql_dialect == SQL_DIALECT_TSQL)
+					// {
 							if (CreateFunctionStmt_hook)
 								(*CreateFunctionStmt_hook)(pstate, pstmt, queryString, false, context, params, true); 
-					}
+					//}
 					else
 					{
 						address = CreateFunction(pstate, (CreateFunctionStmt *) parsetree);

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -78,7 +78,6 @@
 /* Hook for plugins to get control in ProcessUtility() */
 ProcessUtility_hook_type ProcessUtility_hook = NULL;
 CreateFunctionStmt_hook_type CreateFunctionStmt_hook = NULL;
-CreatedbStmt_hook_type CreatedbStmt_hook = NULL;
 
 /* local function declarations */
 static int	ClassifyUtilityCommandAsReadOnly(Node *parsetree);
@@ -782,14 +781,7 @@ standard_ProcessUtility(PlannedStmt *pstmt,
 			if (sql_dialect != SQL_DIALECT_TSQL) {
 				PreventInTransactionBlock(isTopLevel, "CREATE DATABASE");
 			}
-			else 
-			{
-				if (CreateDbStmt_hook)
-					{
-						(*CreatedbStmt_hook)(pstate, stmt);
-					}
-			}
-			//createdb(pstate, (CreatedbStmt *) parsetree);
+			createdb(pstate, (CreatedbStmt *) parsetree);
 			break;
 
 		case T_AlterDatabaseStmt:

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -1660,7 +1660,7 @@ ProcessUtilitySlow(ParseState *pstate,
 			case T_CreateFunctionStmt:	/* CREATE FUNCTION */
 				{
 					if (CreateFunctionStmt_hook)
-						(*CreateFunctionStmt_hook)(pstate, pstmt, queryString, false, context, params); 
+						(*CreateFunctionStmt_hook)(pstate, pstmt, queryString, context, params); 
 					else
 					{
 						address = CreateFunction(pstate, (CreateFunctionStmt *) parsetree);

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -61,7 +61,6 @@
 #include "commands/view.h"
 #include "miscadmin.h"
 #include "parser/parser.h"
-#include "parser/parse_type.h"
 #include "parser/parse_utilcmd.h"
 #include "postmaster/bgwriter.h"
 #include "rewrite/rewriteDefine.h"
@@ -1666,7 +1665,7 @@ ProcessUtilitySlow(ParseState *pstate,
 						address = CreateFunction(pstate, (CreateFunctionStmt *) parsetree);
 					}
 					break;
-			}
+				}
 
 			case T_AlterFunctionStmt:	/* ALTER FUNCTION */
 				address = AlterFunction(pstate, (AlterFunctionStmt *) parsetree);

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -74,9 +74,8 @@
 #include "utils/rel.h"
 #include "utils/syscache.h"
 #include "parser/parse_type.h"
-
-#include "tcop/cmdtag.h"
-#include "tcop/tcopprot.h"
+//#include "tcop/cmdtag.h"
+//#include "tcop/tcopprot.h"
 
 
 /* Hook for plugins to get control in ProcessUtility() */

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -1665,37 +1665,8 @@ ProcessUtilitySlow(ParseState *pstate,
 
 			case T_CreateFunctionStmt:	/* CREATE FUNCTION */
 				{
-					// CreateFunctionStmt *stmt = (CreateFunctionStmt *) parsetree;
-					// ListCell *option = NULL; 
-					
-					// DefElem    *language_item = NULL;
-					// char *language = NULL;
-		
-					// foreach(option, stmt->options)
-					// {
-					// 	DefElem *defel = (DefElem *)lfirst(option); 
-
-						
-					// 	if (strcmp(defel->defname, "language") == 0)
-					// 	{
-					// 		if (language_item)
-					// 			ereport(ERROR,
-					// 					(errcode(ERRCODE_SYNTAX_ERROR),
-					// 					errmsg("conflicting or redundant options"),
-					// 					parser_errposition(pstate, defel->location)));
-					// 		language_item = defel;
-					// 	}
-					// }
-
-					// if (language_item)
-					// 	language = strVal(language_item->arg);
-					
-
-					// if ((language && !strcmp(language,"pltsql")) || sql_dialect == SQL_DIALECT_TSQL)
-					// {
-							if (CreateFunctionStmt_hook)
-								(*CreateFunctionStmt_hook)(pstate, pstmt, queryString, false, context, params, true); 
-					//}
+					if (CreateFunctionStmt_hook)
+						(*CreateFunctionStmt_hook)(pstate, pstmt, queryString, false, context, params); 
 					else
 					{
 						address = CreateFunction(pstate, (CreateFunctionStmt *) parsetree);

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -73,10 +73,7 @@
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
 #include "utils/syscache.h"
-#include "parser/parse_type.h"
 
-#include "tcop/cmdtag.h"
-#include "tcop/tcopprot.h"
 
 
 /* Hook for plugins to get control in ProcessUtility() */

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -604,13 +604,7 @@ standard_ProcessUtility(PlannedStmt *pstmt,
 		case T_TransactionStmt:
 			{
 				TransactionStmt *stmt = (TransactionStmt *) parsetree;
-
-				// if (NestedTranCount > 0 || (sql_dialect == SQL_DIALECT_TSQL && !IsTransactionBlockActive()))
-				// {
-				// 	PLTsqlProcessTransaction(parsetree, params, qc);
-				// 	return;
-				// }
-
+				
 				switch (stmt->kind)
 				{
 						/*

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -1659,37 +1659,37 @@ ProcessUtilitySlow(ParseState *pstate,
 
 			case T_CreateFunctionStmt:	/* CREATE FUNCTION */
 				{
-					// CreateFunctionStmt *stmt = (CreateFunctionStmt *) parsetree;
-					// ListCell *option = NULL; 
+					CreateFunctionStmt *stmt = (CreateFunctionStmt *) parsetree;
+					ListCell *option = NULL; 
 					
-					// DefElem    *language_item = NULL;
-					// char *language = NULL;
+					DefElem    *language_item = NULL;
+					char *language = NULL;
 		
-					// foreach(option, stmt->options)
-					// {
-					// 	DefElem *defel = (DefElem *)lfirst(option); 
+					foreach(option, stmt->options)
+					{
+						DefElem *defel = (DefElem *)lfirst(option); 
 
 						
-					// 	if (strcmp(defel->defname, "language") == 0)
-					// 	{
-					// 		if (language_item)
-					// 			ereport(ERROR,
-					// 					(errcode(ERRCODE_SYNTAX_ERROR),
-					// 					errmsg("conflicting or redundant options"),
-					// 					parser_errposition(pstate, defel->location)));
-					// 		language_item = defel;
-					// 	}
-					// }
+						if (strcmp(defel->defname, "language") == 0)
+						{
+							if (language_item)
+								ereport(ERROR,
+										(errcode(ERRCODE_SYNTAX_ERROR),
+										errmsg("conflicting or redundant options"),
+										parser_errposition(pstate, defel->location)));
+							language_item = defel;
+						}
+					}
 
-					// if (language_item)
-					// 	language = strVal(language_item->arg);
+					if (language_item)
+						language = strVal(language_item->arg);
 					
 
-					//if ((language && !strcmp(language,"pltsql")) || sql_dialect == SQL_DIALECT_TSQL)
-					//{
+					if ((language && !strcmp(language,"pltsql")) || sql_dialect == SQL_DIALECT_TSQL)
+					{
 							if (CreateFunctionStmt_hook)
 								(*CreateFunctionStmt_hook)(pstate, pstmt, queryString, false, context, params, true); 
-					//}
+					}
 					else
 					{
 						address = CreateFunction(pstate, (CreateFunctionStmt *) parsetree);

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -73,7 +73,10 @@
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
 #include "utils/syscache.h"
+#include "parser/parse_type.h"
 
+#include "tcop/cmdtag.h"
+#include "tcop/tcopprot.h"
 
 
 /* Hook for plugins to get control in ProcessUtility() */

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -1686,10 +1686,10 @@ ProcessUtilitySlow(ParseState *pstate,
 					}
 
 					if (language_item)
-						*language = strVal(language_item->arg);
+						language = strVal(language_item->arg);
 					
 
-					if ((language && strcmp(language,"pltsql")) || sql_dialect == SQL_DIALECT_TSQL)
+					if ((language && !strcmp(language,"pltsql")) || sql_dialect == SQL_DIALECT_TSQL)
 					{
 							if (CreateFunctionStmt_hook)
 								(*CreateFunctionStmt_hook)(pstate, pstmt, queryString, false, context, params, queryEnv, dest, qc);

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -78,6 +78,7 @@
 /* Hook for plugins to get control in ProcessUtility() */
 ProcessUtility_hook_type ProcessUtility_hook = NULL;
 CreateFunctionStmt_hook_type CreateFunctionStmt_hook = NULL;
+CreatedbStmt_hook_type CreatedbStmt_hook = NULL;
 
 /* local function declarations */
 static int	ClassifyUtilityCommandAsReadOnly(Node *parsetree);
@@ -781,8 +782,12 @@ standard_ProcessUtility(PlannedStmt *pstmt,
 			if (sql_dialect != SQL_DIALECT_TSQL) {
 				PreventInTransactionBlock(isTopLevel, "CREATE DATABASE");
 			}
-			else {
-				create_bbf_db(pstate, (CreatedbStmt *) parsetree);
+			else 
+			{
+				if (CreateDbStmt_hook)
+					{
+						(*CreatedbStmt_hook)(pstate, stmt);
+					}
 			}
 			//createdb(pstate, (CreatedbStmt *) parsetree);
 			break;
@@ -1691,7 +1696,7 @@ ProcessUtilitySlow(ParseState *pstate,
 					if ((language && !strcmp(language,"pltsql")) || sql_dialect == SQL_DIALECT_TSQL)
 					{
 							if (CreateFunctionStmt_hook)
-								(*CreateFunctionStmt_hook)(pstate, pstmt, queryString, false, context, params); //queryEnv, dest, qc);
+								(*CreateFunctionStmt_hook)(pstate, pstmt, queryString, false, context, params); 
 					}
 					else
 					{

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -61,6 +61,7 @@
 #include "commands/view.h"
 #include "miscadmin.h"
 #include "parser/parser.h"
+#include "parser/parse_type.h"
 #include "parser/parse_utilcmd.h"
 #include "postmaster/bgwriter.h"
 #include "rewrite/rewriteDefine.h"
@@ -73,10 +74,6 @@
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
 #include "utils/syscache.h"
-#include "parser/parse_type.h"
-//#include "tcop/cmdtag.h"
-//#include "tcop/tcopprot.h"
-
 
 /* Hook for plugins to get control in ProcessUtility() */
 ProcessUtility_hook_type ProcessUtility_hook = NULL;
@@ -1691,7 +1688,7 @@ ProcessUtilitySlow(ParseState *pstate,
 					if ((language && !strcmp(language,"pltsql")) || sql_dialect == SQL_DIALECT_TSQL)
 					{
 							if (CreateFunctionStmt_hook)
-								(*CreateFunctionStmt_hook)(pstate, pstmt, queryString, false, context, params, queryEnv, dest, qc);
+								(*CreateFunctionStmt_hook)(pstate, pstmt, queryString, false, context, params); //queryEnv, dest, qc);
 					}
 					else
 					{

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -1659,37 +1659,37 @@ ProcessUtilitySlow(ParseState *pstate,
 
 			case T_CreateFunctionStmt:	/* CREATE FUNCTION */
 				{
-					CreateFunctionStmt *stmt = (CreateFunctionStmt *) parsetree;
-					ListCell *option = NULL; 
+					// CreateFunctionStmt *stmt = (CreateFunctionStmt *) parsetree;
+					// ListCell *option = NULL; 
 					
-					DefElem    *language_item = NULL;
-					char *language = NULL;
+					// DefElem    *language_item = NULL;
+					// char *language = NULL;
 		
-					foreach(option, stmt->options)
-					{
-						DefElem *defel = (DefElem *)lfirst(option); 
+					// foreach(option, stmt->options)
+					// {
+					// 	DefElem *defel = (DefElem *)lfirst(option); 
 
 						
-						if (strcmp(defel->defname, "language") == 0)
-						{
-							if (language_item)
-								ereport(ERROR,
-										(errcode(ERRCODE_SYNTAX_ERROR),
-										errmsg("conflicting or redundant options"),
-										parser_errposition(pstate, defel->location)));
-							language_item = defel;
-						}
-					}
+					// 	if (strcmp(defel->defname, "language") == 0)
+					// 	{
+					// 		if (language_item)
+					// 			ereport(ERROR,
+					// 					(errcode(ERRCODE_SYNTAX_ERROR),
+					// 					errmsg("conflicting or redundant options"),
+					// 					parser_errposition(pstate, defel->location)));
+					// 		language_item = defel;
+					// 	}
+					// }
 
-					if (language_item)
-						language = strVal(language_item->arg);
+					// if (language_item)
+					// 	language = strVal(language_item->arg);
 					
 
-					if ((language && !strcmp(language,"pltsql")) || sql_dialect == SQL_DIALECT_TSQL)
-					{
+					//if ((language && !strcmp(language,"pltsql")) || sql_dialect == SQL_DIALECT_TSQL)
+					//{
 							if (CreateFunctionStmt_hook)
-								(*CreateFunctionStmt_hook)(pstate, pstmt, queryString, false, context, params); 
-					}
+								(*CreateFunctionStmt_hook)(pstate, pstmt, queryString, false, context, params, true); 
+					//}
 					else
 					{
 						address = CreateFunction(pstate, (CreateFunctionStmt *) parsetree);

--- a/src/include/parser/parse_type.h
+++ b/src/include/parser/parse_type.h
@@ -70,16 +70,4 @@ extern PGDLLIMPORT check_or_set_default_typmod_hook_type check_or_set_default_ty
 typedef void (*validate_var_datatype_scale_hook_type)(const TypeName *typeName, Type typ);
 extern PGDLLIMPORT validate_var_datatype_scale_hook_type validate_var_datatype_scale_hook;
 
-// typedef void (*CreateFunctionStmt_hook_type)(ParseState *pstate,
-// 											 PlannedStmt *pstmt,
-// 											 const char *queryString,
-// 											 bool readOnlyTree,
-// 											 ProcessUtilityContext context,
-// 											 ParamListInfo params,
-// 											 QueryEnvironment *queryEnv,
-// 											 DestReceiver *dest,
-// 											 QueryCompletion *qc);
-// extern PGDLLIMPORT CreateFunctionStmt_hook_type CreateFunctionStmt_hook;
-
-
 #endif							/* PARSE_TYPE_H */

--- a/src/include/parser/parse_type.h
+++ b/src/include/parser/parse_type.h
@@ -15,8 +15,6 @@
 
 #include "access/htup.h"
 #include "parser/parse_node.h"
-#include "tcop/cmdtag.h"
-#include "parser/parse_type.h"
 
 
 typedef HeapTuple Type;

--- a/src/include/parser/parse_type.h
+++ b/src/include/parser/parse_type.h
@@ -15,7 +15,12 @@
 
 #include "access/htup.h"
 #include "parser/parse_node.h"
-// #include "tcop/utility.h"
+#include "tcop/utility.h"
+#include "tcop/dest.h"
+#include "tcop/cmdtag.h"
+#include "parser/parse_type.h"
+#include "nodes/plannodes.h"
+#include "nodes/params.h"
 
 
 
@@ -70,16 +75,16 @@ extern PGDLLIMPORT check_or_set_default_typmod_hook_type check_or_set_default_ty
 typedef void (*validate_var_datatype_scale_hook_type)(const TypeName *typeName, Type typ);
 extern PGDLLIMPORT validate_var_datatype_scale_hook_type validate_var_datatype_scale_hook;
 
-// typedef void (*CreateFunctionStmt_hook_type)(ParseState *pstate,
-// 											 PlannedStmt *pstmt,
-// 											 const char *queryString,
-// 											 bool readOnlyTree,
-// 											 ProcessUtilityContext context,
-// 											 ParamListInfo params,
-// 											 QueryEnvironment *queryEnv,
-// 											 DestReceiver *dest,
-// 											 QueryCompletion *qc);
-// extern PGDLLIMPORT CreateFunctionStmt_hook_type CreateFunctionStmt_hook;
+typedef void (*CreateFunctionStmt_hook_type)(ParseState *pstate,
+											 PlannedStmt *pstmt,
+											 const char *queryString,
+											 bool readOnlyTree,
+											 ProcessUtilityContext context,
+											 ParamListInfo params,
+											 QueryEnvironment *queryEnv,
+											 DestReceiver *dest,
+											 QueryCompletion *qc);
+extern PGDLLIMPORT CreateFunctionStmt_hook_type CreateFunctionStmt_hook;
 
 
 #endif							/* PARSE_TYPE_H */

--- a/src/include/parser/parse_type.h
+++ b/src/include/parser/parse_type.h
@@ -15,12 +15,12 @@
 
 #include "access/htup.h"
 #include "parser/parse_node.h"
-#include "tcop/utility.h"
-#include "tcop/dest.h"
-#include "tcop/cmdtag.h"
-#include "parser/parse_type.h"
-#include "nodes/plannodes.h"
-#include "nodes/params.h"
+// #include "tcop/utility.h"
+// #include "tcop/dest.h"
+// #include "tcop/cmdtag.h"
+// #include "parser/parse_type.h"
+// #include "nodes/plannodes.h"
+// #include "nodes/params.h"
 
 
 
@@ -75,16 +75,16 @@ extern PGDLLIMPORT check_or_set_default_typmod_hook_type check_or_set_default_ty
 typedef void (*validate_var_datatype_scale_hook_type)(const TypeName *typeName, Type typ);
 extern PGDLLIMPORT validate_var_datatype_scale_hook_type validate_var_datatype_scale_hook;
 
-typedef void (*CreateFunctionStmt_hook_type)(ParseState *pstate,
-											 PlannedStmt *pstmt,
-											 const char *queryString,
-											 bool readOnlyTree,
-											 ProcessUtilityContext context,
-											 ParamListInfo params,
-											 QueryEnvironment *queryEnv,
-											 DestReceiver *dest,
-											 QueryCompletion *qc);
-extern PGDLLIMPORT CreateFunctionStmt_hook_type CreateFunctionStmt_hook;
+// typedef void (*CreateFunctionStmt_hook_type)(ParseState *pstate,
+// 											 PlannedStmt *pstmt,
+// 											 const char *queryString,
+// 											 bool readOnlyTree,
+// 											 ProcessUtilityContext context,
+// 											 ParamListInfo params,
+// 											 QueryEnvironment *queryEnv,
+// 											 DestReceiver *dest,
+// 											 QueryCompletion *qc);
+// extern PGDLLIMPORT CreateFunctionStmt_hook_type CreateFunctionStmt_hook;
 
 
 #endif							/* PARSE_TYPE_H */

--- a/src/include/parser/parse_type.h
+++ b/src/include/parser/parse_type.h
@@ -15,13 +15,8 @@
 
 #include "access/htup.h"
 #include "parser/parse_node.h"
-// #include "tcop/utility.h"
-// #include "tcop/dest.h"
- #include "tcop/cmdtag.h"
- #include "parser/parse_type.h"
-// #include "nodes/plannodes.h"
-// #include "nodes/params.h"
-
+#include "tcop/cmdtag.h"
+#include "parser/parse_type.h"
 
 
 typedef HeapTuple Type;

--- a/src/include/parser/parse_type.h
+++ b/src/include/parser/parse_type.h
@@ -15,12 +15,7 @@
 
 #include "access/htup.h"
 #include "parser/parse_node.h"
-#include "tcop/utility.h"
-#include "tcop/dest.h"
-#include "tcop/cmdtag.h"
-#include "parser/parse_type.h"
-#include "nodes/plannodes.h"
-#include "nodes/params.h"
+// #include "tcop/utility.h"
 
 
 
@@ -75,16 +70,16 @@ extern PGDLLIMPORT check_or_set_default_typmod_hook_type check_or_set_default_ty
 typedef void (*validate_var_datatype_scale_hook_type)(const TypeName *typeName, Type typ);
 extern PGDLLIMPORT validate_var_datatype_scale_hook_type validate_var_datatype_scale_hook;
 
-typedef void (*CreateFunctionStmt_hook_type)(ParseState *pstate,
-											 PlannedStmt *pstmt,
-											 const char *queryString,
-											 bool readOnlyTree,
-											 ProcessUtilityContext context,
-											 ParamListInfo params,
-											 QueryEnvironment *queryEnv,
-											 DestReceiver *dest,
-											 QueryCompletion *qc);
-extern PGDLLIMPORT CreateFunctionStmt_hook_type CreateFunctionStmt_hook;
+// typedef void (*CreateFunctionStmt_hook_type)(ParseState *pstate,
+// 											 PlannedStmt *pstmt,
+// 											 const char *queryString,
+// 											 bool readOnlyTree,
+// 											 ProcessUtilityContext context,
+// 											 ParamListInfo params,
+// 											 QueryEnvironment *queryEnv,
+// 											 DestReceiver *dest,
+// 											 QueryCompletion *qc);
+// extern PGDLLIMPORT CreateFunctionStmt_hook_type CreateFunctionStmt_hook;
 
 
 #endif							/* PARSE_TYPE_H */

--- a/src/include/parser/parse_type.h
+++ b/src/include/parser/parse_type.h
@@ -17,8 +17,8 @@
 #include "parser/parse_node.h"
 // #include "tcop/utility.h"
 // #include "tcop/dest.h"
-// #include "tcop/cmdtag.h"
-// #include "parser/parse_type.h"
+ #include "tcop/cmdtag.h"
+ #include "parser/parse_type.h"
 // #include "nodes/plannodes.h"
 // #include "nodes/params.h"
 

--- a/src/include/parser/parse_type.h
+++ b/src/include/parser/parse_type.h
@@ -15,6 +15,13 @@
 
 #include "access/htup.h"
 #include "parser/parse_node.h"
+#include "tcop/utility.h"
+#include "tcop/dest.h"
+#include "tcop/cmdtag.h"
+#include "parser/parse_type.h"
+#include "nodes/plannodes.h"
+#include "nodes/params.h"
+
 
 
 typedef HeapTuple Type;
@@ -67,5 +74,17 @@ extern PGDLLIMPORT check_or_set_default_typmod_hook_type check_or_set_default_ty
  */
 typedef void (*validate_var_datatype_scale_hook_type)(const TypeName *typeName, Type typ);
 extern PGDLLIMPORT validate_var_datatype_scale_hook_type validate_var_datatype_scale_hook;
+
+typedef void (*CreateFunctionStmt_hook_type)(ParseState *pstate,
+											 PlannedStmt *pstmt,
+											 const char *queryString,
+											 bool readOnlyTree,
+											 ProcessUtilityContext context,
+											 ParamListInfo params,
+											 QueryEnvironment *queryEnv,
+											 DestReceiver *dest,
+											 QueryCompletion *qc);
+extern PGDLLIMPORT CreateFunctionStmt_hook_type CreateFunctionStmt_hook;
+
 
 #endif							/* PARSE_TYPE_H */

--- a/src/include/tcop/utility.h
+++ b/src/include/tcop/utility.h
@@ -122,7 +122,4 @@ typedef void (*CreateFunctionStmt_hook_type)(ParseState *pstate,
 											 ParamListInfo params);
 extern PGDLLIMPORT CreateFunctionStmt_hook_type CreateFunctionStmt_hook;
 
-typedef void (*CreatedbStmt_hook_type)(ParseState *pstate, const CreatedbStmt *stmt);
-extern PGDLLIMPORT CreatedbStmt_hook_type CreatedbStmt_hook;
-
 #endif							/* UTILITY_H */

--- a/src/include/tcop/utility.h
+++ b/src/include/tcop/utility.h
@@ -114,7 +114,6 @@ extern LogStmtLevel GetCommandLogLevel(Node *parsetree);
 
 extern bool CommandIsReadOnly(PlannedStmt *pstmt);
 
-
 typedef void (*CreateFunctionStmt_hook_type)(ParseState *pstate,
 											 PlannedStmt *pstmt,
 											 const char *queryString,
@@ -123,5 +122,7 @@ typedef void (*CreateFunctionStmt_hook_type)(ParseState *pstate,
 											 ParamListInfo params);
 extern PGDLLIMPORT CreateFunctionStmt_hook_type CreateFunctionStmt_hook;
 
+typedef void (*CreatedbStmt_hook_type)(ParseState *pstate, const CreatedbStmt *stmt);
+extern PGDLLIMPORT CreatedbStmt_hook_type CreatedbStmt_hook;
 
 #endif							/* UTILITY_H */

--- a/src/include/tcop/utility.h
+++ b/src/include/tcop/utility.h
@@ -14,14 +14,13 @@
 #ifndef UTILITY_H
 #define UTILITY_H
 
-#include "tcop/cmdtag.h"
-#include "tcop/tcopprot.h"
-//#include "tcop/utility.h"
-#include "tcop/dest.h"
+#include "nodes/params.h"
+#include "nodes/plannodes.h"
 #include "parser/parse_node.h"
 #include "parser/parse_type.h"
-#include "nodes/plannodes.h"
-#include "nodes/params.h"
+#include "tcop/cmdtag.h"
+#include "tcop/dest.h"
+#include "tcop/tcopprot.h"
 
 typedef enum
 {
@@ -121,10 +120,10 @@ typedef void (*CreateFunctionStmt_hook_type)(ParseState *pstate,
 											 const char *queryString,
 											 bool readOnlyTree,
 											 ProcessUtilityContext context,
-											 ParamListInfo params,
-											 QueryEnvironment *queryEnv,
-											 DestReceiver *dest,
-											 QueryCompletion *qc);
+											 ParamListInfo params);
+											 //QueryEnvironment *queryEnv,
+											 //DestReceiver *dest,
+											 //QueryCompletion *qc);
 extern PGDLLIMPORT CreateFunctionStmt_hook_type CreateFunctionStmt_hook;
 
 

--- a/src/include/tcop/utility.h
+++ b/src/include/tcop/utility.h
@@ -109,17 +109,4 @@ extern LogStmtLevel GetCommandLogLevel(Node *parsetree);
 
 extern bool CommandIsReadOnly(PlannedStmt *pstmt);
 
-
-typedef void (*CreateFunctionStmt_hook_type)(ParseState *pstate,
-											 PlannedStmt *pstmt,
-											 const char *queryString,
-											 bool readOnlyTree,
-											 ProcessUtilityContext context,
-											 ParamListInfo params,
-											 QueryEnvironment *queryEnv,
-											 DestReceiver *dest,
-											 QueryCompletion *qc);
-extern PGDLLIMPORT CreateFunctionStmt_hook_type CreateFunctionStmt_hook;
-
-
 #endif							/* UTILITY_H */

--- a/src/include/tcop/utility.h
+++ b/src/include/tcop/utility.h
@@ -119,7 +119,7 @@ typedef void (*CreateFunctionStmt_hook_type)(ParseState *pstate,
 											 const char *queryString,
 											 bool readOnlyTree,
 											 ProcessUtilityContext context,
-											 ParamListInfo params);
+											 ParamListInfo params, int flag);
 extern PGDLLIMPORT CreateFunctionStmt_hook_type CreateFunctionStmt_hook;
 
 #endif							/* UTILITY_H */

--- a/src/include/tcop/utility.h
+++ b/src/include/tcop/utility.h
@@ -121,9 +121,6 @@ typedef void (*CreateFunctionStmt_hook_type)(ParseState *pstate,
 											 bool readOnlyTree,
 											 ProcessUtilityContext context,
 											 ParamListInfo params);
-											 //QueryEnvironment *queryEnv,
-											 //DestReceiver *dest,
-											 //QueryCompletion *qc);
 extern PGDLLIMPORT CreateFunctionStmt_hook_type CreateFunctionStmt_hook;
 
 

--- a/src/include/tcop/utility.h
+++ b/src/include/tcop/utility.h
@@ -117,7 +117,6 @@ extern bool CommandIsReadOnly(PlannedStmt *pstmt);
 typedef void (*CreateFunctionStmt_hook_type)(ParseState *pstate,
 											 PlannedStmt *pstmt,
 											 const char *queryString,
-											 bool readOnlyTree,
 											 ProcessUtilityContext context,
 											 ParamListInfo params);
 extern PGDLLIMPORT CreateFunctionStmt_hook_type CreateFunctionStmt_hook;

--- a/src/include/tcop/utility.h
+++ b/src/include/tcop/utility.h
@@ -109,4 +109,17 @@ extern LogStmtLevel GetCommandLogLevel(Node *parsetree);
 
 extern bool CommandIsReadOnly(PlannedStmt *pstmt);
 
+
+typedef void (*CreateFunctionStmt_hook_type)(ParseState *pstate,
+											 PlannedStmt *pstmt,
+											 const char *queryString,
+											 bool readOnlyTree,
+											 ProcessUtilityContext context,
+											 ParamListInfo params,
+											 QueryEnvironment *queryEnv,
+											 DestReceiver *dest,
+											 QueryCompletion *qc);
+extern PGDLLIMPORT CreateFunctionStmt_hook_type CreateFunctionStmt_hook;
+
+
 #endif							/* UTILITY_H */

--- a/src/include/tcop/utility.h
+++ b/src/include/tcop/utility.h
@@ -15,11 +15,11 @@
 #define UTILITY_H
 
 #include "tcop/cmdtag.h"
-#include "tcop/tcopprot.h"
-#include "tcop/utility.h"
+//#include "tcop/tcopprot.h"
+//#include "tcop/utility.h"
 #include "tcop/dest.h"
-#include "tcop/cmdtag.h"
-#include "parser/parse_type.h"
+#include "parser/parse_node.h"
+//#include "parser/parse_type.h"
 #include "nodes/plannodes.h"
 #include "nodes/params.h"
 

--- a/src/include/tcop/utility.h
+++ b/src/include/tcop/utility.h
@@ -15,11 +15,11 @@
 #define UTILITY_H
 
 #include "tcop/cmdtag.h"
-//#include "tcop/tcopprot.h"
+#include "tcop/tcopprot.h"
 //#include "tcop/utility.h"
 #include "tcop/dest.h"
 #include "parser/parse_node.h"
-//#include "parser/parse_type.h"
+#include "parser/parse_type.h"
 #include "nodes/plannodes.h"
 #include "nodes/params.h"
 

--- a/src/include/tcop/utility.h
+++ b/src/include/tcop/utility.h
@@ -16,6 +16,12 @@
 
 #include "tcop/cmdtag.h"
 #include "tcop/tcopprot.h"
+#include "tcop/utility.h"
+#include "tcop/dest.h"
+#include "tcop/cmdtag.h"
+#include "parser/parse_type.h"
+#include "nodes/plannodes.h"
+#include "nodes/params.h"
 
 typedef enum
 {
@@ -108,5 +114,18 @@ CreateCommandName(Node *parsetree)
 extern LogStmtLevel GetCommandLogLevel(Node *parsetree);
 
 extern bool CommandIsReadOnly(PlannedStmt *pstmt);
+
+
+typedef void (*CreateFunctionStmt_hook_type)(ParseState *pstate,
+											 PlannedStmt *pstmt,
+											 const char *queryString,
+											 bool readOnlyTree,
+											 ProcessUtilityContext context,
+											 ParamListInfo params,
+											 QueryEnvironment *queryEnv,
+											 DestReceiver *dest,
+											 QueryCompletion *qc);
+extern PGDLLIMPORT CreateFunctionStmt_hook_type CreateFunctionStmt_hook;
+
 
 #endif							/* UTILITY_H */

--- a/src/include/tcop/utility.h
+++ b/src/include/tcop/utility.h
@@ -119,7 +119,7 @@ typedef void (*CreateFunctionStmt_hook_type)(ParseState *pstate,
 											 const char *queryString,
 											 bool readOnlyTree,
 											 ProcessUtilityContext context,
-											 ParamListInfo params, int flag);
+											 ParamListInfo params);
 extern PGDLLIMPORT CreateFunctionStmt_hook_type CreateFunctionStmt_hook;
 
 #endif							/* UTILITY_H */


### PR DESCRIPTION
### Description

Currently Babelfish does not show create proc/func query inside the pg_stat_statements table. After my change now it is visible in the view.
pg_stat_statements displays planning and execution statistics for all SQL statements executed by a server. Some statements like create proc/func was not being tracked. Mainly because subsequent processutility hooks after bbf_processutilty were not being called.
Created a hook for that and called it inside relevant ProcessUtility function.



[Describe what this change achieves]
 

### Issues Resolved

[List any issues this PR will resolve]
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
