### PR TITLE
Create/Drop database not visible in the pg_stat_statements view

### DIFF
--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -778,14 +778,14 @@ standard_ProcessUtility(PlannedStmt *pstmt,
 			 * transaction blocks to turn batch mode ON by default.
 			 */
 			if (sql_dialect != SQL_DIALECT_TSQL) {
-				PreventInTransactionBlock(isTopLevel, "CREATE DATABASE");
+				createdb(pstate, (CreatedbStmt *) parsetree);
 			}
 			else 
 			{
 				if (CreateDbStmt_hook)
 					(*CreateDbStmt_hook)(pstate, pstmt);
 			}
-			//createdb(pstate, (CreatedbStmt *) parsetree);
+			// createdb(pstate, (CreatedbStmt *) parsetree);
 			break;
 
 		case T_AlterDatabaseStmt:

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -780,6 +780,7 @@ standard_ProcessUtility(PlannedStmt *pstmt,
 			 */
 			if (sql_dialect != SQL_DIALECT_TSQL) {
 				createdb(pstate, (CreatedbStmt *) parsetree);
+				PreventInTransactionBlock(isTopLevel, "CREATE DATABASE");
 			}
 			else 
 			{
@@ -810,6 +811,7 @@ standard_ProcessUtility(PlannedStmt *pstmt,
 			 */
 			if (sql_dialect != SQL_DIALECT_TSQL) {
 				DropDatabase(pstate, (DropdbStmt *) parsetree);
+				PreventInTransactionBlock(isTopLevel, "DROP DATABASE");
 			}
 			else
 			{

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -779,8 +779,8 @@ standard_ProcessUtility(PlannedStmt *pstmt,
 			 * transaction blocks to turn batch mode ON by default.
 			 */
 			if (sql_dialect != SQL_DIALECT_TSQL) {
-				createdb(pstate, (CreatedbStmt *) parsetree);
 				PreventInTransactionBlock(isTopLevel, "CREATE DATABASE");
+				createdb(pstate, (CreatedbStmt *) parsetree);
 			}
 			else 
 			{
@@ -810,8 +810,8 @@ standard_ProcessUtility(PlannedStmt *pstmt,
 			 * transaction blocks to turn batch mode ON by default.
 			 */
 			if (sql_dialect != SQL_DIALECT_TSQL) {
-				DropDatabase(pstate, (DropdbStmt *) parsetree);
 				PreventInTransactionBlock(isTopLevel, "DROP DATABASE");
+				DropDatabase(pstate, (DropdbStmt *) parsetree);
 			}
 			else
 			{

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -76,6 +76,7 @@
 
 /* Hook for plugins to get control in ProcessUtility() */
 ProcessUtility_hook_type ProcessUtility_hook = NULL;
+CreateDbStmt_hook_type CreateDbStmt_hook = NULL;
 
 /* local function declarations */
 static int	ClassifyUtilityCommandAsReadOnly(Node *parsetree);
@@ -779,7 +780,12 @@ standard_ProcessUtility(PlannedStmt *pstmt,
 			if (sql_dialect != SQL_DIALECT_TSQL) {
 				PreventInTransactionBlock(isTopLevel, "CREATE DATABASE");
 			}
-			createdb(pstate, (CreatedbStmt *) parsetree);
+			else 
+			{
+				if (CreateDbStmt_hook)
+					(*CreateDbStmt_hook)(pstate, pstmt);
+			}
+			//createdb(pstate, (CreatedbStmt *) parsetree);
 			break;
 
 		case T_AlterDatabaseStmt:

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -780,7 +780,7 @@ standard_ProcessUtility(PlannedStmt *pstmt,
 			 */
 			if (sql_dialect != SQL_DIALECT_TSQL) {
 				createdb(pstate, (CreatedbStmt *) parsetree);
-				//gPreventInTransactionBlock(isTopLevel, "CREATE DATABASE");
+				PreventInTransactionBlock(isTopLevel, "CREATE DATABASE");
 			}
 			else 
 			{

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -780,7 +780,7 @@ standard_ProcessUtility(PlannedStmt *pstmt,
 			 */
 			if (sql_dialect != SQL_DIALECT_TSQL) {
 				createdb(pstate, (CreatedbStmt *) parsetree);
-				PreventInTransactionBlock(isTopLevel, "CREATE DATABASE");
+				//gPreventInTransactionBlock(isTopLevel, "CREATE DATABASE");
 			}
 			else 
 			{

--- a/src/include/tcop/utility.h
+++ b/src/include/tcop/utility.h
@@ -113,5 +113,7 @@ extern bool CommandIsReadOnly(PlannedStmt *pstmt);
 typedef void (*CreateDbStmt_hook_type)(ParseState *pstate, PlannedStmt *pstmt);
 extern PGDLLIMPORT CreateDbStmt_hook_type CreateDbStmt_hook;
 
+typedef void (*DropDbStmt_hook_type)(PlannedStmt *pstmt);
+extern PGDLLIMPORT DropDbStmt_hook_type DropDbStmt_hook;
 
 #endif							/* UTILITY_H */

--- a/src/include/tcop/utility.h
+++ b/src/include/tcop/utility.h
@@ -14,6 +14,7 @@
 #ifndef UTILITY_H
 #define UTILITY_H
 
+#include "parser/parse_node.h"
 #include "tcop/cmdtag.h"
 #include "tcop/tcopprot.h"
 
@@ -108,5 +109,9 @@ CreateCommandName(Node *parsetree)
 extern LogStmtLevel GetCommandLogLevel(Node *parsetree);
 
 extern bool CommandIsReadOnly(PlannedStmt *pstmt);
+
+typedef void (*CreateDbStmt_hook_type)(ParseState *pstate, PlannedStmt *pstmt);
+extern PGDLLIMPORT CreateDbStmt_hook_type CreateDbStmt_hook;
+
 
 #endif							/* UTILITY_H */


### PR DESCRIPTION
Currently Babelfish does not show create database query inside the pg_stat_statements table. After my change it will be visible in the view.
pg_stat_statements displays planning and execution statistics for all SQL statements executed by a server. Some statements like create and drop database was not being tracked. Mainly because subsequent processutility hooks after bbf_processutilty were not being called.
Created a hook for that and called it inside relevant ProcessUtility function.

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
