### PR TITLE
Fix the crash when set client_encoding from pg endpoint using babel database

### DIFF
--- a/src/backend/utils/activity/pgstat_function.c
+++ b/src/backend/utils/activity/pgstat_function.c
@@ -23,6 +23,7 @@
 #include "utils/inval.h"
 #include "utils/pgstat_internal.h"
 #include "utils/syscache.h"
+#include "access/xact.h"
 
 
 /* ----------

--- a/src/backend/utils/activity/pgstat_function.c
+++ b/src/backend/utils/activity/pgstat_function.c
@@ -79,7 +79,7 @@ pgstat_init_function_usage(FunctionCallInfo fcinfo,
 	PgStat_BackendFunctionEntry *pending;
 	bool		created_entry;
 
-	if (pre_function_call_hook)
+	if (pre_function_call_hook && IsTransactionState())
 	{
 		HeapTuple proctup = SearchSysCache1(PROCOID, ObjectIdGetDatum(fcinfo->flinfo->fn_oid));
 		if (HeapTupleIsValid(proctup))

--- a/src/backend/utils/fmgr/fmgr.c
+++ b/src/backend/utils/fmgr/fmgr.c
@@ -16,6 +16,7 @@
 #include "postgres.h"
 
 #include "access/detoast.h"
+#include "access/xact.h"
 #include "catalog/namespace.h"
 #include "catalog/pg_language.h"
 #include "catalog/pg_namespace.h"

--- a/src/backend/utils/fmgr/fmgr.c
+++ b/src/backend/utils/fmgr/fmgr.c
@@ -701,7 +701,6 @@ fmgr_security_definer(PG_FUNCTION_ARGS)
 	int			sys_func_count = 0;
 	int			non_tsql_proc_count = 0;
 	void	   *newextra = NULL;
-	bool        started_trx = false;
 
 	if (!fcinfo->flinfo->fn_extra)
 	{
@@ -814,6 +813,7 @@ fmgr_security_definer(PG_FUNCTION_ARGS)
 		sql_dialect_value_old = sql_dialect;
 		sql_dialect = sql_dialect_value;
 		assign_sql_dialect(sql_dialect_value, newextra);
+
 	}
 
 	/* function manager hook */
@@ -873,6 +873,7 @@ fmgr_security_definer(PG_FUNCTION_ARGS)
 
 		sql_dialect = sql_dialect_value_old;
 		assign_sql_dialect(sql_dialect_value_old, newextra);
+
 		if (sql_dialect_value == pg_dialect)
 			non_tsql_proc_entry_hook(non_tsql_proc_count * -1, sys_func_count * -1);
 	}


### PR DESCRIPTION
Previously when try to set variable from pg endpoint when that backend is using babel database, the postgres backend will crash.

The root cause for this crash is pg backend when returnning will call security definer in report Guc changes, in such condition, it's not within a transaction.

This commit fix this issue by checking the transaction state in security definer.

Task: BABEL-3301

### Description

 Previously when try to set variable from pg endpoint when that backend is using babel database, the postgres backend will crash.

like this : 

```
psql -d jdbc_test

set client_encoding = 'WIN1252'; 

the db will crash

```
the problem stack : 
```
37: #0  0x0000000000b61f64 in ResourceArrayEnlarge (resarr=0x40) at resowner.c:1051
38: #1  ResourceOwnerEnlargeCatCacheRefs (owner=0x0) at resowner.c:1052
39: #2  0x0000000000b037c4 in SearchCatCacheInternal (v4=0, v3=0, v2=0, v1=4358, nkeys=1, cache=0x40000767e880) at catcache.c:1435
40: #3  SearchCatCache1 (cache=0x40000767e880, v1=4358) at catcache.c:1329
41: #4  0x0000000000b19574 in SearchSysCache1 (cacheId=cacheId@entry=43, key1=<optimized out>) at syscache.c:1158
42: #5  0x0000000000b2aa34 in fmgr_security_definer (fcinfo=0x0) at fmgr.c:831
43: #6  0x0000000000b29aa4 in FunctionCall6Coll (flinfo=flinfo@entry=0x4000075812c0, collation=collation@entry=0, arg1=arg1@entry=6, arg2=arg2@entry=24, arg3=arg3@entry=16379480, arg4=arg4@entry=70368867203440, arg5=arg5@entry=15, arg6=arg6@entry=0) at fmgr.c:1445
44: #7  0x0000000000b37dc8 in perform_default_encoding_conversion (src=0xf9ee58 "client_encoding", len=15, is_client_to_server=<optimized out>) at mbutils.c:836
45: #8  0x0000000000852d30 in pq_sendstring (buf=0xfffff1b9f418, str=0xf9ee58 "client_encoding") at pqformat.c:202
46: #9  0x000000000090d74c in libpq_report_param_status (name=0xf9ee58 "client_encoding", val=0x400007553548 "WIN1252") at postmaster.c:7807
47: #10 0x0000000000b40538 in ReportGUCOption (record=0x2de50f8 <ConfigureNamesString+2184>) at guc.c:8561
48: #11 0x0000000000b406ec in ReportChangedGUCOptions () at guc.c:8540
49: #12 0x00000000009cb130 in PostgresMain (argc=argc@entry=1, argv=argv@entry=0xfffff1b9f880, dbname=<optimized out>, dbname@entry=0x400007549fe8 "babelfish_db", dboid=<optimized out>, username=<optimized out>) at postgres.c:4714
50: #13 0x000000000090d870 in libpq_mainfunc (port=0x400007465800, argc=1, argv=0xfffff1b9f880) at postmaster.c:7777
51: #14 0x0000000000911c90 in BackendRun (port=0x400007465800) at postmaster.c:5368
52: #15 BackendStartup (port=port@entry=0x400007465800) at postmaster.c:5016
53: #16 0x0000000000914e48 in ServerLoop () at postmaster.c:2148
54: #17 PostmasterMain (argc=argc@entry=9, argv=argv@entry=0x400007527e20) at postmaster.c:1798
55: #18 0x00000000005d1500 in main (argc=9, argv=0x400007527e20) at main.c:220
```

### Issues Resolved

resolve the issue : BABEL-3301

 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
