### PR TITLE
Created macro for (superuser() ? PGC_SUSET : PGC_USERSET)

### DIFF
--- a/src/backend/catalog/pg_proc.c
+++ b/src/backend/catalog/pg_proc.c
@@ -697,7 +697,7 @@ ProcedureCreate(const char *procedureName,
 			{
 				save_nestlevel = NewGUCNestLevel();
 				ProcessGUCArray(set_items,
-								(superuser() ? PGC_SUSET : PGC_USERSET),
+								GUC_CONTEXT_CONFIG,
 								PGC_S_SESSION,
 								GUC_ACTION_SAVE);
 			}

--- a/src/backend/utils/adt/ri_triggers.c
+++ b/src/backend/utils/adt/ri_triggers.c
@@ -98,7 +98,7 @@ do																											\
 	bool reset_dialect = (sql_dialect == SQL_DIALECT_TSQL);                                         \
 	if (reset_dialect)																						\
 		set_config_option("babelfishpg_tsql.sql_dialect", "postgres",										\
-			(superuser() ? PGC_SUSET : PGC_USERSET),						\
+			GUC_CONTEXT_CONFIG,						\
 			PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);												\
 																											\
 	PG_TRY();																								\
@@ -109,14 +109,14 @@ do																											\
 	{																										\
 		if (reset_dialect)																					\
 			set_config_option("babelfishpg_tsql.sql_dialect", "tsql",										\
-							(superuser() ? PGC_SUSET : PGC_USERSET),		\
+							GUC_CONTEXT_CONFIG,		\
 							PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);								\
 		PG_RE_THROW();																						\
 	}																										\
 	PG_END_TRY();																							\
 	if (reset_dialect)																						\
 		set_config_option("babelfishpg_tsql.sql_dialect", "tsql",											\
-						(superuser() ? PGC_SUSET : PGC_USERSET),			\
+						GUC_CONTEXT_CONFIG,			\
 						PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);									\
 } while (0)
 

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -76,6 +76,8 @@ typedef enum
 	PGC_USERSET
 } GucContext;
 
+#define GUC_CONTEXT_CONFIG (superuser() ? PGC_SUSET : PGC_USERSET)
+
 /*
  * The following type records the source of the current setting.  A
  * new setting can only take effect if the previous setting had the


### PR DESCRIPTION
### Description
This pr creates a macro for `(superuser() ? PGC_SUSET : PGC_USERSET)` named `GUC_CONTEXT_CONFIG` to avoid future merge conflicts when cherry-picking from the open source to internal repo

 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
