### PR TITLE
Transaction statements not visible in pg_stat_statements view

### DIFF
--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -1665,8 +1665,8 @@ ProcessUtilitySlow(ParseState *pstate,
 				break;
 
 			case T_CreateFunctionStmt:	/* CREATE FUNCTION */
-					address = CreateFunction(pstate, (CreateFunctionStmt *) parsetree);
-					break;
+				address = CreateFunction(pstate, (CreateFunctionStmt *) parsetree);
+				break;
 
 			case T_AlterFunctionStmt:	/* ALTER FUNCTION */
 				address = AlterFunction(pstate, (AlterFunctionStmt *) parsetree);

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -602,8 +602,11 @@ standard_ProcessUtility(PlannedStmt *pstmt,
 			 */
 		case T_TransactionStmt:
 			{
+				if (NestedTranCount > 0 || (sql_dialect == SQL_DIALECT_TSQL && !IsTransactionBlockActive()))
+				{
 				if (transactionStmt_hook)
 					(*transactionStmt_hook)(pstmt, params, qc); 
+				}
 				else
 				{
 					TransactionStmt *stmt = (TransactionStmt *) parsetree;

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -613,9 +613,9 @@ standard_ProcessUtility(PlannedStmt *pstmt,
 				switch (stmt->kind)
 				{
 						/*
-						* START TRANSACTION, as defined by SQL99: Identical
-						* to BEGIN.  Same code for both.
-						*/
+						 * START TRANSACTION, as defined by SQL99: Identical
+						 * to BEGIN.  Same code for both.
+						 */
 					case TRANS_STMT_BEGIN:
 					case TRANS_STMT_START:
 						{
@@ -628,16 +628,16 @@ standard_ProcessUtility(PlannedStmt *pstmt,
 
 								if (strcmp(item->defname, "transaction_isolation") == 0)
 									SetPGVariable("transaction_isolation",
-												list_make1(item->arg),
-												true);
+												  list_make1(item->arg),
+												  true);
 								else if (strcmp(item->defname, "transaction_read_only") == 0)
 									SetPGVariable("transaction_read_only",
-												list_make1(item->arg),
-												true);
+												  list_make1(item->arg),
+												  true);
 								else if (strcmp(item->defname, "transaction_deferrable") == 0)
 									SetPGVariable("transaction_deferrable",
-												list_make1(item->arg),
-												true);
+												  list_make1(item->arg),
+												  true);
 							}
 						}
 						break;
@@ -689,9 +689,9 @@ standard_ProcessUtility(PlannedStmt *pstmt,
 						RollbackToSavepoint(stmt->savepoint_name);
 
 						/*
-						* CommitTransactionCommand is in charge of
-						* re-defining the savepoint again
-						*/
+						 * CommitTransactionCommand is in charge of
+						 * re-defining the savepoint again
+						 */
 						break;
 				}
 			}

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -602,11 +602,8 @@ standard_ProcessUtility(PlannedStmt *pstmt,
 			 */
 		case T_TransactionStmt:
 			{
-				if(NestedTranCount > 0 || (sql_dialect == SQL_DIALECT_TSQL && !IsTransactionBlockActive()))
-				{
-					if (transactionStmt_hook)
-						(*transactionStmt_hook)(pstmt, params, qc); 
-				}
+				if (transactionStmt_hook)
+					(*transactionStmt_hook)(pstmt, params, qc); 
 				else
 				{
 					TransactionStmt *stmt = (TransactionStmt *) parsetree;
@@ -1665,10 +1662,8 @@ ProcessUtilitySlow(ParseState *pstate,
 				break;
 
 			case T_CreateFunctionStmt:	/* CREATE FUNCTION */
-				{
 					address = CreateFunction(pstate, (CreateFunctionStmt *) parsetree);
 					break;
-				}
 
 			case T_AlterFunctionStmt:	/* ALTER FUNCTION */
 				address = AlterFunction(pstate, (AlterFunctionStmt *) parsetree);

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -602,12 +602,7 @@ standard_ProcessUtility(PlannedStmt *pstmt,
 			 */
 		case T_TransactionStmt:
 			{
-				if (NestedTranCount > 0 || (sql_dialect == SQL_DIALECT_TSQL && !IsTransactionBlockActive()))
-				{
-				if (transactionStmt_hook)
-					(*transactionStmt_hook)(pstmt, params, qc); 
-				}
-				else
+				if(sql_dialect != SQL_DIALECT_TSQL )
 				{
 					TransactionStmt *stmt = (TransactionStmt *) parsetree;
 
@@ -695,6 +690,11 @@ standard_ProcessUtility(PlannedStmt *pstmt,
 							*/
 							break;
 					}
+				}
+				else
+				{
+					if (transactionStmt_hook)
+						(*transactionStmt_hook)(pstmt, params, qc); 
 				}
 			}
 			break;

--- a/src/include/tcop/utility.h
+++ b/src/include/tcop/utility.h
@@ -109,8 +109,6 @@ extern LogStmtLevel GetCommandLogLevel(Node *parsetree);
 
 extern bool CommandIsReadOnly(PlannedStmt *pstmt);
 
-
-
 typedef void (*transactionStmt_hook_type)(PlannedStmt *pstmt, ParamListInfo params, QueryCompletion *qc);
 extern PGDLLIMPORT transactionStmt_hook_type transactionStmt_hook;
 

--- a/src/include/tcop/utility.h
+++ b/src/include/tcop/utility.h
@@ -109,4 +109,9 @@ extern LogStmtLevel GetCommandLogLevel(Node *parsetree);
 
 extern bool CommandIsReadOnly(PlannedStmt *pstmt);
 
+
+
+typedef void (*transactionStmt_hook_type)(PlannedStmt *pstmt, ParamListInfo params, QueryCompletion *qc);
+extern PGDLLIMPORT transactionStmt_hook_type transactionStmt_hook;
+
 #endif							/* UTILITY_H */


### PR DESCRIPTION
Currently Babelfish does not show transaction queries inside the pg_stat_statements table. After my change now it will be visible in the view.
pg_stat_statements displays planning and execution statistics for all SQL statements executed by a server. Some of the statements are not being tracked by it. Mainly because subsequent processutility hooks after bbf_processutilty are not being called, what happens is inside bbf_processUtility, babelfish specific function is called and it does not trigger the subsequent hooks due to which query statistics are not being stored in the table. 
Created a hook for that and called it inside relevant ProcessUtility function.

### Description

[Describe what this change achieves]
 
### Issues Resolved

[List any issues this PR will resolve]
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
