### PR TITLE
In CTE Null first order behavior is not correct

### DIFF
--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -54,6 +54,8 @@
 
 tle_name_comparison_hook_type  tle_name_comparison_hook = NULL;
 
+sort_nulls_first_hook_type  sort_nulls_first_hook = NULL;
+
 static int	extractRemainingColumns(ParseNamespaceColumn *src_nscolumns,
 									List *src_colnames,
 									List **src_colnos,
@@ -3383,10 +3385,8 @@ addTargetToSortList(ParseState *pstate, TargetEntry *tle,
 			case SORTBY_NULLS_DEFAULT:
 				/* NULLS FIRST is default for DESC; other way for ASC */
 				sortcl->nulls_first = reverse;
-				if (sql_dialect == SQL_DIALECT_TSQL)
-				{
-					/* Tsql NULLS FIRST is default for ASC; other way for DESC */
-					sortcl->nulls_first = !reverse;
+				if (sort_nulls_first_hook){
+					sort_nulls_first_hook(sortcl, reverse);
 				}
 				break;
 			case SORTBY_NULLS_FIRST:

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -3383,6 +3383,11 @@ addTargetToSortList(ParseState *pstate, TargetEntry *tle,
 			case SORTBY_NULLS_DEFAULT:
 				/* NULLS FIRST is default for DESC; other way for ASC */
 				sortcl->nulls_first = reverse;
+				if (sql_dialect == SQL_DIALECT_TSQL)
+				{
+					/* Tsql NULLS FIRST is default for ASC; other way for DESC */
+					sortcl->nulls_first = !reverse;
+				}
 				break;
 			case SORTBY_NULLS_FIRST:
 				sortcl->nulls_first = true;

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -54,7 +54,7 @@
 
 tle_name_comparison_hook_type  tle_name_comparison_hook = NULL;
 
-sort_nulls_first_hook_type  sort_nulls_first_hook = NULL;
+sortby_nulls_hook_type  sortby_nulls_hook = NULL;
 
 static int	extractRemainingColumns(ParseNamespaceColumn *src_nscolumns,
 									List *src_colnames,
@@ -3385,8 +3385,9 @@ addTargetToSortList(ParseState *pstate, TargetEntry *tle,
 			case SORTBY_NULLS_DEFAULT:
 				/* NULLS FIRST is default for DESC; other way for ASC */
 				sortcl->nulls_first = reverse;
-				if (sort_nulls_first_hook){
-					sort_nulls_first_hook(sortcl, reverse);
+				if (sortby_nulls_hook)
+				{
+					sortby_nulls_hook(sortcl, reverse);
 				}
 				break;
 			case SORTBY_NULLS_FIRST:

--- a/src/include/parser/parse_clause.h
+++ b/src/include/parser/parse_clause.h
@@ -54,7 +54,7 @@ extern bool targetIsInSortList(TargetEntry *tle, Oid sortop, List *sortList);
 typedef bool (*tle_name_comparison_hook_type)(const char *tlename, const char *identifier);
 extern PGDLLIMPORT tle_name_comparison_hook_type tle_name_comparison_hook;
 
-typedef void (*sort_nulls_first_hook_type)(SortGroupClause *sortcl, bool reverse);
-extern PGDLLIMPORT sort_nulls_first_hook_type sort_nulls_first_hook;
+typedef void (*sortby_nulls_hook_type)(SortGroupClause *sortcl, bool reverse);
+extern PGDLLIMPORT sortby_nulls_hook_type sortby_nulls_hook;
 
 #endif							/* PARSE_CLAUSE_H */

--- a/src/include/parser/parse_clause.h
+++ b/src/include/parser/parse_clause.h
@@ -54,4 +54,7 @@ extern bool targetIsInSortList(TargetEntry *tle, Oid sortop, List *sortList);
 typedef bool (*tle_name_comparison_hook_type)(const char *tlename, const char *identifier);
 extern PGDLLIMPORT tle_name_comparison_hook_type tle_name_comparison_hook;
 
+typedef void (*sort_nulls_first_hook_type)(SortGroupClause *sortcl, bool reverse);
+extern PGDLLIMPORT sort_nulls_first_hook_type sort_nulls_first_hook;
+
 #endif							/* PARSE_CLAUSE_H */


### PR DESCRIPTION
Previously we add the Null first check after analyze, and in that case it'll miss to add the Null first tag to the sort clause for a CTE query

change the place adding Null first tag to the place sortClause is initialized

Task: BABEL-3991
Signed-off-by: Zhibai Song <szh@amazon.com>

### Description

the following sql not produce the right order for NULL : 
```
drop table if exists t1;
create table t1(a int);
insert t1 values (1);
insert t1 values (3);
insert t1 values (null);
with t1cte AS (
select top(3) a from t1 order by 1
)
select * from t1cte; -- Returns NULL at bottom not expected
select top(3) a from t1 order by 1; -- Returns NULL at the TOP as expected
```

the root cause is we deal with sort clause inproperly

### Issues Resolved

Will return the right order for null include 
- asc order by return NULL first
- no order by , natural asc, return NULL last
- desc order by return NULL last

checked this behavior with 
- simple select
- select order by
- subquery order by 
- cte with inner query order by
- babel_functions
- etc other remainning explain query



### Check List
- [ x ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).