### PR TITLE
[BABEL-3238] Add helper function error_stack_full() (#121)

### DIFF
--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -3618,3 +3618,9 @@ trace_recovery(int trace_level)
 
 	return trace_level;
 }
+
+bool
+error_stack_full(void)
+{
+	return (errordata_stack_depth+1 >= ERRORDATA_STACK_SIZE);
+}

--- a/src/include/utils/elog.h
+++ b/src/include/utils/elog.h
@@ -456,4 +456,5 @@ extern void set_syslog_parameters(const char *ident, int facility);
  */
 extern void write_stderr(const char *fmt,...) pg_attribute_printf(1, 2);
 
+extern bool error_stack_full(void);
 #endif							/* ELOG_H */


### PR DESCRIPTION
### Description

Add helper function error_stack_full() that can be used outside elog.c
 
### Issues Resolved

[List any issues this PR will resolve]
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
