### PR TITLE
CASTing a DATE literal without time part to TIME datatype fails

### DIFF
--- a/src/backend/utils/adt/datetime.c
+++ b/src/backend/utils/adt/datetime.c
@@ -31,6 +31,7 @@
 #include "utils/datetime.h"
 #include "utils/memutils.h"
 #include "utils/tzparser.h"
+#include "parser/parser.h"
 
 static int	DecodeNumber(int flen, char *field, bool haveTextMonth,
 						 int fmask, int *tmask,
@@ -1972,6 +1973,12 @@ DecodeTimeOnly(char **field, int *ftype, int nf,
 					if (dterr)
 						return dterr;
 				}
+				/*
+				 * For date format like 'yyyy-mm-dd', we should return time 00:00:00.0000000
+				 * instead of marking it as invalid time format
+				 */
+				else if (sql_dialect == SQL_DIALECT_TSQL && nf == 1 && ftype[nf - 1] == DTK_DATE)
+					return 0;
 				/* otherwise, this is a time and/or time zone */
 				else
 				{


### PR DESCRIPTION
### Description

For time datatype PG considers only date value(ex.- '2012-02-23') as bad i/p format. so, above testcase is throwing error from engine code time_in() much before coming to TDS side.

However, SQL Server allows casting a date literal string to a TIME datatype when the time component in the string is missing: o/p becomes 00:00:00.0000000

Fix is to add change in time_in() so that it considers date format with missing time info like above one, as valid input when the dialect is TSQL.

Task: BABEL-1528
Signed-off-by: Satarupa Biswas satarupb@amazon.com
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
