### PR TITLE
create proc/func/trigger, create/drop database, transaction statements are not being tracked by the extensions which utilize processutility hook

### DIFF
--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -599,7 +599,6 @@ standard_ProcessUtility(PlannedStmt *pstmt,
 	if(miscProcessUtility_hook)
 		(*miscProcessUtility_hook)(pstate, pstmt, queryString, context, params, qc, &flag);
 
-	
 	if(flag)
 	{
 		return;

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -597,12 +597,8 @@ standard_ProcessUtility(PlannedStmt *pstmt,
 	pstate->p_queryEnv = queryEnv;
 
 	if(bbfCustomProcessUtility_hook)
-		(*bbfCustomProcessUtility_hook)(pstate, pstmt, queryString, context, params, qc, &flag);
-
-	if(flag)
-	{
-		return;
-	}
+		if((*bbfCustomProcessUtility_hook)(pstate, pstmt, queryString, context, params, qc))
+			return;
 
 	switch (nodeTag(parsetree))
 	{

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -596,11 +596,9 @@ standard_ProcessUtility(PlannedStmt *pstmt,
 	pstate->p_sourcetext = queryString;
 	pstate->p_queryEnv = queryEnv;
 
-	if(sql_dialect == SQL_DIALECT_TSQL)
-	{
-		if(miscProcessUtility_hook)
-			(*miscProcessUtility_hook)(pstate, pstmt, queryString, context, params, qc, &flag);
-	}
+	if(miscProcessUtility_hook)
+		(*miscProcessUtility_hook)(pstate, pstmt, queryString, context, params, qc, &flag);
+
 	
 	if(flag)
 	{

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -76,7 +76,7 @@
 
 /* Hook for plugins to get control in ProcessUtility() */
 ProcessUtility_hook_type ProcessUtility_hook = NULL;
-miscProcessUtility_hook_type miscProcessUtility_hook = NULL;
+bbfCustomProcessUtility_hook_type bbfCustomProcessUtility_hook = NULL;
 
 /* local function declarations */
 static int	ClassifyUtilityCommandAsReadOnly(Node *parsetree);
@@ -596,8 +596,8 @@ standard_ProcessUtility(PlannedStmt *pstmt,
 	pstate->p_sourcetext = queryString;
 	pstate->p_queryEnv = queryEnv;
 
-	if(miscProcessUtility_hook)
-		(*miscProcessUtility_hook)(pstate, pstmt, queryString, context, params, qc, &flag);
+	if(bbfCustomProcessUtility_hook)
+		(*bbfCustomProcessUtility_hook)(pstate, pstmt, queryString, context, params, qc, &flag);
 
 	if(flag)
 	{

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -560,7 +560,6 @@ standard_ProcessUtility(PlannedStmt *pstmt,
 	bool		isAtomicContext = (!(context == PROCESS_UTILITY_TOPLEVEL || context == PROCESS_UTILITY_QUERY_NONATOMIC) || IsTransactionBlock());
 	ParseState *pstate;
 	int			readonly_flags;
-	int flag = false;
 
 	/* This can recurse, so check for excessive recursion */
 	check_stack_depth();

--- a/src/include/tcop/utility.h
+++ b/src/include/tcop/utility.h
@@ -16,7 +16,6 @@
 
 #include "tcop/cmdtag.h"
 #include "tcop/tcopprot.h"
-#include "parser/parse_node.h"
 
 typedef enum
 {
@@ -109,7 +108,7 @@ CreateCommandName(Node *parsetree)
 extern LogStmtLevel GetCommandLogLevel(Node *parsetree);
 
 extern bool CommandIsReadOnly(PlannedStmt *pstmt);
-typedef bool (*bbfCustomProcessUtility_hook_type)(ParseState *pstate, PlannedStmt *pstmt, const char *queryString, ProcessUtilityContext context, 
+typedef bool (*bbfCustomProcessUtility_hook_type)(struct ParseState *pstate, PlannedStmt *pstmt, const char *queryString, ProcessUtilityContext context, 
 						  ParamListInfo params, QueryCompletion *qc);
 extern PGDLLIMPORT bbfCustomProcessUtility_hook_type bbfCustomProcessUtility_hook;
 

--- a/src/include/tcop/utility.h
+++ b/src/include/tcop/utility.h
@@ -109,8 +109,8 @@ CreateCommandName(Node *parsetree)
 extern LogStmtLevel GetCommandLogLevel(Node *parsetree);
 
 extern bool CommandIsReadOnly(PlannedStmt *pstmt);
-typedef void (*bbfCustomProcessUtility_hook_type)(ParseState *pstate, PlannedStmt *pstmt, const char *queryString, ProcessUtilityContext context, 
-						  ParamListInfo params, QueryCompletion *qc, int *flag);
+typedef bool (*bbfCustomProcessUtility_hook_type)(ParseState *pstate, PlannedStmt *pstmt, const char *queryString, ProcessUtilityContext context, 
+						  ParamListInfo params, QueryCompletion *qc);
 extern PGDLLIMPORT bbfCustomProcessUtility_hook_type bbfCustomProcessUtility_hook;
 
 extern void PLTsqlProcessTransaction(Node *parsetree,

--- a/src/include/tcop/utility.h
+++ b/src/include/tcop/utility.h
@@ -113,4 +113,8 @@ typedef void (*miscProcessUtility_hook_type)(ParseState *pstate, PlannedStmt *ps
 						  ParamListInfo params, QueryCompletion *qc, int *flag);
 extern PGDLLIMPORT miscProcessUtility_hook_type miscProcessUtility_hook;
 
+extern void PLTsqlProcessTransaction(Node *parsetree,
+						            ParamListInfo params,
+						 			QueryCompletion *qc);
+
 #endif							/* UTILITY_H */

--- a/src/include/tcop/utility.h
+++ b/src/include/tcop/utility.h
@@ -109,9 +109,9 @@ CreateCommandName(Node *parsetree)
 extern LogStmtLevel GetCommandLogLevel(Node *parsetree);
 
 extern bool CommandIsReadOnly(PlannedStmt *pstmt);
-typedef void (*miscProcessUtility_hook_type)(ParseState *pstate, PlannedStmt *pstmt, const char *queryString, ProcessUtilityContext context, 
+typedef void (*bbfCustomProcessUtility_hook_type)(ParseState *pstate, PlannedStmt *pstmt, const char *queryString, ProcessUtilityContext context, 
 						  ParamListInfo params, QueryCompletion *qc, int *flag);
-extern PGDLLIMPORT miscProcessUtility_hook_type miscProcessUtility_hook;
+extern PGDLLIMPORT bbfCustomProcessUtility_hook_type bbfCustomProcessUtility_hook;
 
 extern void PLTsqlProcessTransaction(Node *parsetree,
 						            ParamListInfo params,

--- a/src/include/tcop/utility.h
+++ b/src/include/tcop/utility.h
@@ -16,6 +16,7 @@
 
 #include "tcop/cmdtag.h"
 #include "tcop/tcopprot.h"
+#include "parser/parse_node.h"
 
 typedef enum
 {
@@ -108,5 +109,8 @@ CreateCommandName(Node *parsetree)
 extern LogStmtLevel GetCommandLogLevel(Node *parsetree);
 
 extern bool CommandIsReadOnly(PlannedStmt *pstmt);
+typedef void (*miscProcessUtility_hook_type)(ParseState *pstate, PlannedStmt *pstmt, const char *queryString, ProcessUtilityContext context, 
+						  ParamListInfo params, QueryCompletion *qc, int *flag);
+extern PGDLLIMPORT miscProcessUtility_hook_type miscProcessUtility_hook;
 
 #endif							/* UTILITY_H */

--- a/src/include/tcop/utility.h
+++ b/src/include/tcop/utility.h
@@ -112,7 +112,7 @@ typedef bool (*bbfCustomProcessUtility_hook_type)(struct ParseState *pstate, Pla
 						  ParamListInfo params, QueryCompletion *qc);
 extern PGDLLIMPORT bbfCustomProcessUtility_hook_type bbfCustomProcessUtility_hook;
 
-extern void PLTsqlProcessTransaction(Node *parsetree,
+void PLTsqlProcessTransaction(Node *parsetree,
 						            ParamListInfo params,
 						 			QueryCompletion *qc);
 

--- a/src/include/tcop/utility.h
+++ b/src/include/tcop/utility.h
@@ -112,8 +112,4 @@ typedef bool (*bbfCustomProcessUtility_hook_type)(struct ParseState *pstate, Pla
 						  ParamListInfo params, QueryCompletion *qc);
 extern PGDLLIMPORT bbfCustomProcessUtility_hook_type bbfCustomProcessUtility_hook;
 
-void PLTsqlProcessTransaction(Node *parsetree,
-						            ParamListInfo params,
-						 			QueryCompletion *qc);
-
 #endif							/* UTILITY_H */

--- a/src/include/tcop/utility.h
+++ b/src/include/tcop/utility.h
@@ -112,7 +112,7 @@ typedef bool (*bbfCustomProcessUtility_hook_type)(struct ParseState *pstate, Pla
 						  ParamListInfo params, QueryCompletion *qc);
 extern PGDLLIMPORT bbfCustomProcessUtility_hook_type bbfCustomProcessUtility_hook;
 
-extern bool PLTsqlProcessTransaction(Node *parsetree,
+extern void PLTsqlProcessTransaction(Node *parsetree,
 						            ParamListInfo params,
 						 			QueryCompletion *qc);
 

--- a/src/include/tcop/utility.h
+++ b/src/include/tcop/utility.h
@@ -112,7 +112,7 @@ typedef bool (*bbfCustomProcessUtility_hook_type)(struct ParseState *pstate, Pla
 						  ParamListInfo params, QueryCompletion *qc);
 extern PGDLLIMPORT bbfCustomProcessUtility_hook_type bbfCustomProcessUtility_hook;
 
-extern void PLTsqlProcessTransaction(Node *parsetree,
+extern bool PLTsqlProcessTransaction(Node *parsetree,
 						            ParamListInfo params,
 						 			QueryCompletion *qc);
 


### PR DESCRIPTION
Currently statements like create proc/func/trigger/database, drop database and transaction statements are not being tracked by the extensions which utilises the processutility hooks in Babelfish. Above issue happens because bbf_processutility doesn't call subsequent/previous processutility hook for above statements due to which these subsequent extension hooks are not being executed.
This commit resolves above issue by adding a custom processutility hook in engine to execute above Babelfish statements so that execution happens at last step of processutility hook chain which makes sure that subsequent extension hooks are executed.

Before:
processUtility_hooks()-> ... -> bbf_processUtility_hook() -> executes above statements -> execution completed/doesn't return to previous hook execution or doesn't execute subsequent hooks

After:
processUtility_hooks()-> ... -> bbf_processUtility_hook() -> ... -> processUtility_hooks()-> ... -> Standard_processUtility()-> executes above statements using custom hook -> returns to previous hook execution

Task: BABEL-4218

Since this PR includes calling the engine side function to extension side using hook, we do not require extra test scenarios to test it, it is already being covered in previous tests.
We have separate test PR for testing pg_stat_statements extension.

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
