### PR TITLE
Update / Delete / Insert with TOP

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -3290,6 +3290,7 @@ _copyDeleteStmt(const DeleteStmt *from)
 	COPY_NODE_FIELD(whereClause);
 	COPY_NODE_FIELD(returningList);
 	COPY_NODE_FIELD(withClause);
+	COPY_NODE_FIELD(limitCount);
 
 	return newnode;
 }
@@ -3305,6 +3306,7 @@ _copyUpdateStmt(const UpdateStmt *from)
 	COPY_NODE_FIELD(fromClause);
 	COPY_NODE_FIELD(returningList);
 	COPY_NODE_FIELD(withClause);
+	COPY_NODE_FIELD(limitCount);
 
 	return newnode;
 }

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -3276,6 +3276,7 @@ _copyInsertStmt(const InsertStmt *from)
 	COPY_NODE_FIELD(withClause);
 	COPY_SCALAR_FIELD(override);
 	COPY_NODE_FIELD(execStmt);
+	COPY_NODE_FIELD(limitCount);
 
 	return newnode;
 }

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -559,6 +559,11 @@ transformDeleteStmt(ParseState *pstate, DeleteStmt *stmt)
 	qual = transformWhereClause(pstate, stmt->whereClause,
 								EXPR_KIND_WHERE, "WHERE");
 
+	qry->limitCount = transformLimitClause(pstate, stmt->limitCount,
+										EXPR_KIND_LIMIT, "LIMIT",
+										LIMIT_OPTION_COUNT);
+	qry->limitOption = LIMIT_OPTION_COUNT;
+
 	if (pre_transform_returning_hook)
 		(*pre_transform_returning_hook) (qry, stmt->returningList, pstate);
 	
@@ -2512,6 +2517,11 @@ transformUpdateStmt(ParseState *pstate, UpdateStmt *stmt)
 	else
 		qual = transformWhereClause(pstate, stmt->whereClause,
 								EXPR_KIND_WHERE, "WHERE");
+
+	qry->limitCount = transformLimitClause(pstate, stmt->limitCount,
+									EXPR_KIND_LIMIT, "LIMIT",
+									LIMIT_OPTION_COUNT);
+	qry->limitOption = LIMIT_OPTION_COUNT;
 
 	qry->returningList = transformReturningList(pstate, stmt->returningList);
 

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -686,6 +686,11 @@ transformInsertStmt(ParseState *pstate, InsertStmt *stmt)
 	icolumns = checkInsertTargets(pstate, stmt->cols, &attrnos);
 	Assert(list_length(icolumns) == list_length(attrnos));
 
+	qry->limitCount = transformLimitClause(pstate, stmt->limitCount,
+											EXPR_KIND_LIMIT, "LIMIT",
+											LIMIT_OPTION_COUNT);
+	qry->limitOption = LIMIT_OPTION_COUNT;
+
 	/*
 	 * For INSERT ... EXECUTE, transform the CallStmt/DoStmt, and attach it to
 	 * the Query's utilityStmt.

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1637,7 +1637,7 @@ typedef struct InsertStmt
 	WithClause *withClause;		/* WITH clause */
 	OverridingKind override;	/* OVERRIDING clause */
 	Node	   *execStmt; 		/* for INSERT ... EXECUTE */
-	Node       *limitCount;
+	Node       *limitCount;		/* used by INSERT TOP in T-SQL*/
 } InsertStmt;
 
 /* ----------------------
@@ -1652,7 +1652,7 @@ typedef struct DeleteStmt
 	Node	   *whereClause;	/* qualifications */
 	List	   *returningList;	/* list of expressions to return */
 	WithClause *withClause;		/* WITH clause */
-	Node	   *limitCount;		/* # of result tuples to return */
+	Node	   *limitCount;		/* used with DELETE TOP in T-SQL */
 } DeleteStmt;
 
 /* ----------------------
@@ -1668,7 +1668,7 @@ typedef struct UpdateStmt
 	List	   *fromClause;		/* optional from clause for more tables */
 	List	   *returningList;	/* list of expressions to return */
 	WithClause *withClause;		/* WITH clause */
-	Node	   *limitCount;		/* # of result tuples to return */
+	Node	   *limitCount;		/* used with UPDATE TOP in T-SQL */
 } UpdateStmt;
 
 /* ----------------------

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1651,6 +1651,7 @@ typedef struct DeleteStmt
 	Node	   *whereClause;	/* qualifications */
 	List	   *returningList;	/* list of expressions to return */
 	WithClause *withClause;		/* WITH clause */
+	Node	   *limitCount;		/* # of result tuples to return */
 } DeleteStmt;
 
 /* ----------------------
@@ -1666,6 +1667,7 @@ typedef struct UpdateStmt
 	List	   *fromClause;		/* optional from clause for more tables */
 	List	   *returningList;	/* list of expressions to return */
 	WithClause *withClause;		/* WITH clause */
+	Node	   *limitCount;		/* # of result tuples to return */
 } UpdateStmt;
 
 /* ----------------------

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1637,6 +1637,7 @@ typedef struct InsertStmt
 	WithClause *withClause;		/* WITH clause */
 	OverridingKind override;	/* OVERRIDING clause */
 	Node	   *execStmt; 		/* for INSERT ... EXECUTE */
+	Node       *limitCount;
 } InsertStmt;
 
 /* ----------------------

--- a/src/include/parser/analyze.h
+++ b/src/include/parser/analyze.h
@@ -33,9 +33,11 @@ extern PGDLLIMPORT pre_parse_analyze_hook_type pre_parse_analyze_hook;
 typedef void (*pre_transform_returning_hook_type) (Query *query, List *returningList, ParseState *pstate);
 extern PGDLLIMPORT pre_transform_returning_hook_type pre_transform_returning_hook;
 
-/* Hook to modify insert statement in output clause */
-typedef void (*pre_transform_insert_hook_type) (InsertStmt *stmt, Oid relid);
+typedef void (*post_transform_delete_hook_type) (ParseState *pstate, DeleteStmt *stmt, Query *query);
+extern PGDLLIMPORT post_transform_delete_hook_type post_transform_delete_hook;
 
+/* Hook to modify insert statement in output clause */
+typedef void (*pre_transform_insert_hook_type) (ParseState *pstate, InsertStmt *stmt, Query *query);
 extern PGDLLIMPORT pre_transform_insert_hook_type pre_transform_insert_hook;
 
 /* Hook to perform self-join transformation on UpdateStmt in output clause */


### PR DESCRIPTION
### Description
Previously, update and delete statements were handled by query re-writing to account for differences in pg and tsql. Due to a variety of issues with this approach, a more comprehensive solution was done (see Support and re-design UPDATE/DELETE).
However, this work did not support the TOP clause in UPDATE/DELETE. This change continues this work to now support TOP in in UPDATE/DELETE.

### Issues Resolved
BABEL-3725 and BABEL-3909

### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
