### PR TITLE
Loss of decimal digits when converting from REAL to DECIMAL

### DIFF
--- a/src/backend/utils/adt/numeric.c
+++ b/src/backend/utils/adt/numeric.c
@@ -43,6 +43,7 @@
 #include "utils/numeric.h"
 #include "utils/pg_lsn.h"
 #include "utils/sortsupport.h"
+#include "common/shortest_dec.h"
 
 /* ----------
  * Uncomment the following to enable compilation of dump_numeric()
@@ -4535,7 +4536,15 @@ float4_numeric(PG_FUNCTION_ARGS)
 			PG_RETURN_NUMERIC(make_result(&const_pinf));
 	}
 
-	snprintf(buf, sizeof(buf), "%.*g", FLT_DIG, val);
+	/*
+	 * REAL datatype can store upto 4B of floating point data;
+	 * anything larger than that gets truncated unless
+	 * buf has extra places to store those extra_float_digits
+	 */
+	if (sql_dialect == SQL_DIALECT_TSQL && extra_float_digits > 0)
+		float_to_shortest_decimal_buf(val, buf);
+	else
+		snprintf(buf, sizeof(buf), "%.*g", FLT_DIG, val);
 
 	init_var(&result);
 


### PR DESCRIPTION
### Description

123456.25 requires 37 bits ( > 4 bytes) to get stored without any dataloss. REAL datatype can store upto 4B of floating point data; anything larger than that gets truncated while casting by underlying PG functions.

REAL datatype in sql server relaxes this storage restriction and hence can cast the entire data without any further dataloss.

Task: BABEL-3066
Signed-off-by: Satarupa Biswas [satarupb@amazon.com]


- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
