### PR TITLE
Incorrect metadata for sql_variant datatype on a restored server

### DIFF
--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -1279,12 +1279,13 @@ hasSqlvariantColumn(TableInfo *tbinfo)
  * returns the length of a multibyte string
  */
 static int
-getMbstrlen(const char* mbstr,Archive* fout)
+getMbstrlen(const char* mbstr, Archive* fout)
 {
 	int len = 0;
-
+	if(*mbstr == NULL)
+		return 0;
 	while (*mbstr){
-		mbstr+= PQmblen(mbstr, fout->encoding);
+		mbstr += PQmblen(mbstr, fout->encoding);
 		len++;
 	}
 	return len;

--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -1036,7 +1036,7 @@ fixBbfSqlvariantData(Archive *fout, PGresult* res, PQExpBuffer q, char* attgener
 								fout);
 	castSqlvariantToBasetype(res, fout, q, tuple, *field);
 
-	*(orig_field)++;
+	*orig_field = *(orig_field) + 1;
 	*field = *(field) + 2;
 	return;
 }

--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -945,49 +945,24 @@ fixCopyCommand(Archive *fout, PQExpBuffer copyBuf, TableInfo *tbinfo, bool isFro
 	destroyPQExpBuffer(q);
 }
 
-/*
- * dumpSqlvariantTableData:
- * Dump the contents of a table with atleast one column of sql_variant data
- * type. We use insert commands to dump the table data irrespective of value of
- * dopt->dump_inserts. This function is derived from dumpTableData_insert in
- * pg_dump.c modified to handle tables with sql_variant data type columns
- * separately.
- */
-int
-dumpSqlvariantTableData(Archive *fout, const void *dcontext)
+void
+fixCursorForBbfSqlvariantTableData(Archive *fout, TableInfo *tbinfo, PQExpBuffer buf, int *nfields, bool **is_sqlvariant_column, bool *has_sqlvariant_column)
 {
-	TableDataInfo *tdinfo = (TableDataInfo *) dcontext;
-	TableInfo  *tbinfo = tdinfo->tdtable;
-	DumpOptions *dopt = fout->dopt;
-	PQExpBuffer q = createPQExpBuffer();
-	PQExpBuffer insertStmt = NULL;
-	char		*attgenerated;
-	bool		*is_sqlvariant_column;
-	PGresult	*res;
-	int 		nfields, i;
-	int 		rows_per_statement = dopt->dump_inserts;
-	int 		rows_this_statement = 0;
-	int 		nfields_new;
-	int 		orig_field;
+	int nfields_new = 0;
+	*(has_sqlvariant_column) = hasSqlvariantColumn(tbinfo);
 
-	/*
-	 * If we're going to emit INSERTs with column names, the most efficient
-	 * way to deal with generated columns is to exclude them entirely.  For
-	 * INSERTs without column names, we have to emit DEFAULT rather than the
-	 * actual column value --- but we can save a few cycles by fetching nulls
-	 * rather than the uninteresting-to-us value.
-	 */
-	attgenerated = (char *) pg_malloc(tbinfo->numatts * sizeof(char));
-	is_sqlvariant_column = (bool *) pg_malloc0(3 * tbinfo->numatts * sizeof(bool));
+	if(!has_sqlvariant_column || !isBabelfishDatabase(fout))
+		return;
 
-	appendPQExpBufferStr(q, "DECLARE _pg_dump_cursor CURSOR FOR SELECT ");
-	nfields = 0;
-	nfields_new = 0;
-	for (i = 0; i < tbinfo->numatts; i++)
+	*(is_sqlvariant_column) = (bool *) pg_malloc0(3 * tbinfo->numatts * sizeof(bool));
+	resetPQExpBuffer(buf);
+	appendPQExpBufferStr(buf, "DECLARE _pg_dump_cursor CURSOR FOR SELECT ");
+
+	for (int i = 0; i < tbinfo->numatts; i++)
 	{
 		if (tbinfo->attisdropped[i])
 			continue;
-		if (tbinfo->attgenerated[i] && dopt->column_inserts)
+		if (tbinfo->attgenerated[i] && fout->dopt->column_inserts)
 			continue;
 
 		/* Skip TSQL ROWVERSION/TIMESTAMP column, it should be re-generated during restore. */
@@ -997,13 +972,13 @@ dumpSqlvariantTableData(Archive *fout, const void *dcontext)
 				quote_all_identifiers ? "\"sys\".\"timestamp\"" : "sys.timestamp") == 0)
 			continue;
 
-		if (nfields > 0)
-			appendPQExpBufferStr(q, ", ");
+		if (nfields_new > 0)
+			appendPQExpBufferStr(buf, ", ");
 		if (tbinfo->attgenerated[i])
-			appendPQExpBufferStr(q, "NULL");
+			appendPQExpBufferStr(buf, "NULL");
 		else
 		{
-			appendPQExpBufferStr(q, fmtId(tbinfo->attnames[i]));
+			appendPQExpBufferStr(buf, fmtId(tbinfo->attnames[i]));
 			/*
 			 * To find the basetype and bytelength of string data types we
 			 * invoke sys.sql_variant_property and sys.datalength function on
@@ -1013,251 +988,364 @@ dumpSqlvariantTableData(Archive *fout, const void *dcontext)
 			if (pg_strcasecmp(tbinfo->atttypnames[i],
 				quote_all_identifiers ? "\"sys\".\"sql_variant\"" : "sys.sql_variant") == 0)
 			{
-					appendPQExpBuffer(q, ", sys.SQL_VARIANT_PROPERTY(%s, 'BaseType')", tbinfo->attnames[i]);
-					appendPQExpBuffer(q, ", sys.datalength(%s)", tbinfo->attnames[i]);
+					appendPQExpBuffer(buf, ", sys.SQL_VARIANT_PROPERTY(%s, 'BaseType')", tbinfo->attnames[i]);
+					appendPQExpBuffer(buf, ", sys.datalength(%s)", tbinfo->attnames[i]);
+								pg_log_info("yes %d %d", i, nfields_new);
 					is_sqlvariant_column[nfields_new] = true;
+					pg_log_info("yes1");
 					nfields_new = nfields_new + 2;
 			}
 		}
-		attgenerated[nfields] = tbinfo->attgenerated[i];
-		nfields++; nfields_new++;
+		nfields_new++;
 	}
-
-	/* Servers before 9.4 will complain about zero-column SELECT */
-	if (nfields == 0)
-		appendPQExpBufferStr(q, "NULL");
-	appendPQExpBuffer(q, " FROM ONLY %s",
-					  fmtQualifiedDumpable(tbinfo));
-	if (tdinfo->filtercond)
-		appendPQExpBuffer(q, " %s", tdinfo->filtercond);
-
-	fixCursorForBbfCatalogTableData(fout, tbinfo, q, &nfields, attgenerated);
-	ExecuteSqlStatement(fout, q->data);
-
-	while (1)
-	{
-		res = ExecuteSqlQuery(fout, "FETCH 100 FROM _pg_dump_cursor",
-							  PGRES_TUPLES_OK);
-
-		/* cross-check field count, allowing for dummy NULL if any */
-		if (nfields != PQnfields(res) &&
-			!(nfields == 0 && PQnfields(res) == 1))
-				if(!(PQnfields(res) == nfields_new))
-					pg_fatal("wrong number of fields retrieved from table \"%s\"",
-					 tbinfo->dobj.name);
-
-		/*
-		 * First time through, we build as much of the INSERT statement as
-		 * possible in "insertStmt", which we can then just print for each
-		 * statement. If the table happens to have zero dumpable columns then
-		 * this will be a complete statement, otherwise it will end in
-		 * "VALUES" and be ready to have the row's column values printed.
-		 */
-		if (insertStmt == NULL)
-		{
-			TableInfo  *targettab;
-
-			insertStmt = createPQExpBuffer();
-
-			/*
-			 * When load-via-partition-root is set, get the root table name
-			 * for the partition table, so that we can reload data through the
-			 * root table.
-			 */
-			if (dopt->load_via_partition_root && tbinfo->ispartition)
-				targettab = getRootTableInfo(tbinfo);
-			else
-				targettab = tbinfo;
-
-			appendPQExpBuffer(insertStmt, "INSERT INTO %s ",
-							  fmtQualifiedDumpable(targettab));
-
-			/* corner case for zero-column table */
-			if (nfields == 0)
-			{
-				appendPQExpBufferStr(insertStmt, "DEFAULT VALUES;\n");
-			}
-			else
-			{
-				/* append the list of column names if required */
-				if (dopt->column_inserts)
-				{
-					appendPQExpBufferChar(insertStmt, '(');
-					for (int field = 0; field < nfields_new; field++)
-					{
-						if (field > 0)
-							appendPQExpBufferStr(insertStmt, ", ");
-						appendPQExpBufferStr(insertStmt,
-							fmtId(PQfname(res, field)));
-						/*
-						 * skip over columns defined additionally for
-						 * sql_variant data type columns
-						 */
-						if (is_sqlvariant_column[field])
-								field=field+2;
-					}
-					appendPQExpBufferStr(insertStmt, ") ");
-				}
-
-				if (tbinfo->needs_override)
-					appendPQExpBufferStr(insertStmt, "OVERRIDING SYSTEM VALUE ");
-
-				appendPQExpBufferStr(insertStmt, "VALUES");
-			}
-		}
-
-		for (int tuple = 0; tuple < PQntuples(res); tuple++)
-		{
-			/* Write the INSERT if not in the middle of a multi-row INSERT. */
-			if (rows_this_statement == 0)
-				archputs(insertStmt->data, fout);
-
-			/*
-			 * If it is zero-column table then we've already written the
-			 * complete statement, which will mean we've disobeyed
-			 * --rows-per-insert when it's set greater than 1.  We do support
-			 * a way to make this multi-row with: SELECT UNION ALL SELECT
-			 * UNION ALL ... but that's non-standard so we should avoid it
-			 * given that using INSERTs is mostly only ever needed for
-			 * cross-database exports.
-			 */
-			if (nfields == 0)
-				continue;
-
-			/* Emit a row heading */
-			if (rows_per_statement == 1)
-				archputs(" (", fout);
-			else if (rows_this_statement > 0)
-				archputs(",\n\t(", fout);
-			else
-				archputs("\n\t(", fout);
-
-			orig_field = 0;
-			for (int field = 0; field < nfields_new; field++)
-			{
-				if(field > 0 && is_sqlvariant_column[field - 1])
-				{
-					field++;
-					continue;
-				}
-
-				if (field > 0)
-					archputs(", ", fout);
-				if (attgenerated[orig_field])
-				{
-					archputs("DEFAULT", fout);
-					orig_field++;
-					continue;
-				}
-				if (PQgetisnull(res, tuple, field))
-				{
-					archputs("NULL", fout);
-					orig_field++;
-					continue;
-				}
-
-				/* XXX This code is partially duplicated in ruleutils.c */
-				switch (PQftype(res, field))
-				{
-					case INT2OID:
-					case INT4OID:
-					case INT8OID:
-					case OIDOID:
-					case FLOAT4OID:
-					case FLOAT8OID:
-					case NUMERICOID:
-						{
-							/*
-							 * These types are printed without quotes unless
-							 * they contain values that aren't accepted by the
-							 * scanner unquoted (e.g., 'NaN').  Note that
-							 * strtod() and friends might accept NaN, so we
-							 * can't use that to test.
-							 *
-							 * In reality we only need to defend against
-							 * infinity and NaN, so we need not get too crazy
-							 * about pattern matching here.
-							 */
-							const char *s = PQgetvalue(res, tuple, field);
-
-							if (strspn(s, "0123456789 +-eE.") == strlen(s))
-								archputs(s, fout);
-							else
-								archprintf(fout, "'%s'", s);
-						}
-						break;
-
-					case BITOID:
-					case VARBITOID:
-						archprintf(fout, "B'%s'",
-								   PQgetvalue(res, tuple, field));
-						break;
-
-					case BOOLOID:
-						if (strcmp(PQgetvalue(res, tuple, field), "t") == 0)
-							archputs("true", fout);
-						else
-							archputs("false", fout);
-						break;
-
-					default:
-						/* All other types are printed as string literals. */
-						resetPQExpBuffer(q);
-						appendStringLiteralAH(q,
-											  PQgetvalue(res, tuple, field),
-											  fout);
-						if (is_sqlvariant_column[field])
-								castSqlvariantToBasetype(res, fout, q, tuple, field);
-						else
-							archputs(q->data, fout);
-						break;
-				}
-				orig_field++;
-			}
-
-			/* Terminate the row ... */
-			archputs(")", fout);
-
-			/* ... and the statement, if the target no. of rows is reached */
-			if (++rows_this_statement >= rows_per_statement)
-			{
-				if (dopt->do_nothing)
-					archputs(" ON CONFLICT DO NOTHING;\n", fout);
-				else
-					archputs(";\n", fout);
-				/* Reset the row counter */
-				rows_this_statement = 0;
-			}
-		}
-
-		if (PQntuples(res) <= 0)
-		{
-			PQclear(res);
-			break;
-		}
-		PQclear(res);
-	}
-
-	/* Terminate any statements that didn't make the row count. */
-	if (rows_this_statement > 0)
-	{
-		if (dopt->do_nothing)
-			archputs(" ON CONFLICT DO NOTHING;\n", fout);
-		else
-			archputs(";\n", fout);
-	}
-
-	archputs("\n\n", fout);
-
-	ExecuteSqlStatement(fout, "CLOSE _pg_dump_cursor");
-
-	destroyPQExpBuffer(q);
-	if (insertStmt != NULL)
-		destroyPQExpBuffer(insertStmt);
-	free(attgenerated);
-	free(is_sqlvariant_column);
-	return 1;
+	*(nfields) = nfields_new;
+	pg_log_info("%s", buf->data);
+	pg_log_info("%s", tbinfo->attnames[0]);
+	return;
 }
+
+void
+fixBbfSqlvariantData(Archive *fout, PGresult* res, PQExpBuffer q, char* attgenerated, int tuple, int *orig_field, int *field)
+{
+
+	pg_log_info("yes");
+	int temp_field = *field;
+	
+	if (temp_field > 0)
+		archputs(", ", fout);
+	if (attgenerated[*orig_field])
+	{
+		archputs("DEFAULT", fout);
+		(*orig_field)++;
+		return;
+	}
+	if (PQgetisnull(res, tuple, temp_field))
+	{
+		archputs("NULL", fout);
+		(*orig_field)++;
+		return;
+	}
+
+	castSqlvariantToBasetype(res, fout, q, tuple, temp_field);
+
+	*(orig_field)++;
+	*(field) = temp_field + 2;
+	return;
+}
+
+/*
+ * dumpSqlvariantTableData:
+ * Dump the contents of a table with atleast one column of sql_variant data
+ * type. We use insert commands to dump the table data irrespective of value of
+ * dopt->dump_inserts. This function is derived from dumpTableData_insert in
+ * pg_dump.c modified to handle tables with sql_variant data type columns
+ * separately.
+ */
+// int
+// dumpSqlvariantTableData(Archive *fout, const void *dcontext)
+// {
+// 	TableDataInfo *tdinfo = (TableDataInfo *) dcontext;
+// 	TableInfo  *tbinfo = tdinfo->tdtable;
+// 	DumpOptions *dopt = fout->dopt;
+// 	PQExpBuffer q = createPQExpBuffer();
+// 	PQExpBuffer insertStmt = NULL;
+// 	char		*attgenerated;
+// 	bool		*is_sqlvariant_column;
+// 	PGresult	*res;
+// 	int 		nfields, i;
+// 	int 		rows_per_statement = dopt->dump_inserts;
+// 	int 		rows_this_statement = 0;
+// 	int 		nfields_new;
+// 	int 		orig_field;
+
+// 	/*
+// 	 * If we're going to emit INSERTs with column names, the most efficient
+// 	 * way to deal with generated columns is to exclude them entirely.  For
+// 	 * INSERTs without column names, we have to emit DEFAULT rather than the
+// 	 * actual column value --- but we can save a few cycles by fetching nulls
+// 	 * rather than the uninteresting-to-us value.
+// 	 */
+// 	attgenerated = (char *) pg_malloc(tbinfo->numatts * sizeof(char));
+// 	is_sqlvariant_column = (bool *) pg_malloc0(3 * tbinfo->numatts * sizeof(bool));
+
+// 	appendPQExpBufferStr(q, "DECLARE _pg_dump_cursor CURSOR FOR SELECT ");
+// 	nfields = 0;
+// 	nfields_new = 0;
+// 	for (i = 0; i < tbinfo->numatts; i++)
+// 	{
+// 		if (tbinfo->attisdropped[i])
+// 			continue;
+// 		if (tbinfo->attgenerated[i] && dopt->column_inserts)
+// 			continue;
+
+// 		/* Skip TSQL ROWVERSION/TIMESTAMP column, it should be re-generated during restore. */
+// 		if (pg_strcasecmp(tbinfo->atttypnames[i],
+// 				quote_all_identifiers ? "\"sys\".\"rowversion\"" : "sys.rowversion") == 0 ||
+// 			pg_strcasecmp(tbinfo->atttypnames[i],
+// 				quote_all_identifiers ? "\"sys\".\"timestamp\"" : "sys.timestamp") == 0)
+// 			continue;
+
+// 		if (nfields > 0)
+// 			appendPQExpBufferStr(q, ", ");
+// 		if (tbinfo->attgenerated[i])
+// 			appendPQExpBufferStr(q, "NULL");
+// 		else
+// 		{
+// 			appendPQExpBufferStr(q, fmtId(tbinfo->attnames[i]));
+// 			/*
+// 			 * To find the basetype and bytelength of string data types we
+// 			 * invoke sys.sql_variant_property and sys.datalength function on
+// 			 * the sqlvariant column. These extra columns are carefully handled
+// 			 * so that they do not interfere with expected dump behaviour.
+// 			*/
+// 			if (pg_strcasecmp(tbinfo->atttypnames[i],
+// 				quote_all_identifiers ? "\"sys\".\"sql_variant\"" : "sys.sql_variant") == 0)
+// 			{
+// 					appendPQExpBuffer(q, ", sys.SQL_VARIANT_PROPERTY(%s, 'BaseType')", tbinfo->attnames[i]);
+// 					appendPQExpBuffer(q, ", sys.datalength(%s)", tbinfo->attnames[i]);
+// 					is_sqlvariant_column[nfields_new] = true;
+// 					nfields_new = nfields_new + 2;
+// 			}
+// 		}
+// 		attgenerated[nfields] = tbinfo->attgenerated[i];
+// 		nfields++; nfields_new++;
+// 	}
+
+// 	/* Servers before 9.4 will complain about zero-column SELECT */
+// 	if (nfields == 0)
+// 		appendPQExpBufferStr(q, "NULL");
+// 	appendPQExpBuffer(q, " FROM ONLY %s",
+// 					  fmtQualifiedDumpable(tbinfo));
+// 	if (tdinfo->filtercond)
+// 		appendPQExpBuffer(q, " %s", tdinfo->filtercond);
+
+// 	fixCursorForBbfCatalogTableData(fout, tbinfo, q, &nfields, attgenerated);
+// 	ExecuteSqlStatement(fout, q->data);
+
+// 	while (1)
+// 	{
+// 		res = ExecuteSqlQuery(fout, "FETCH 100 FROM _pg_dump_cursor",
+// 							  PGRES_TUPLES_OK);
+
+// 		/* cross-check field count, allowing for dummy NULL if any */
+// 		if (nfields != PQnfields(res) &&
+// 			!(nfields == 0 && PQnfields(res) == 1))
+// 				if(!(PQnfields(res) == nfields_new))
+// 					pg_fatal("wrong number of fields retrieved from table \"%s\"",
+// 					 tbinfo->dobj.name);
+
+// 		/*
+// 		 * First time through, we build as much of the INSERT statement as
+// 		 * possible in "insertStmt", which we can then just print for each
+// 		 * statement. If the table happens to have zero dumpable columns then
+// 		 * this will be a complete statement, otherwise it will end in
+// 		 * "VALUES" and be ready to have the row's column values printed.
+// 		 */
+// 		if (insertStmt == NULL)
+// 		{
+// 			TableInfo  *targettab;
+
+// 			insertStmt = createPQExpBuffer();
+
+// 			/*
+// 			 * When load-via-partition-root is set, get the root table name
+// 			 * for the partition table, so that we can reload data through the
+// 			 * root table.
+// 			 */
+// 			if (dopt->load_via_partition_root && tbinfo->ispartition)
+// 				targettab = getRootTableInfo(tbinfo);
+// 			else
+// 				targettab = tbinfo;
+
+// 			appendPQExpBuffer(insertStmt, "INSERT INTO %s ",
+// 							  fmtQualifiedDumpable(targettab));
+
+// 			/* corner case for zero-column table */
+// 			if (nfields == 0)
+// 			{
+// 				appendPQExpBufferStr(insertStmt, "DEFAULT VALUES;\n");
+// 			}
+// 			else
+// 			{
+// 				/* append the list of column names if required */
+// 				if (dopt->column_inserts)
+// 				{
+// 					appendPQExpBufferChar(insertStmt, '(');
+// 					for (int field = 0; field < nfields_new; field++)
+// 					{
+// 						if (field > 0)
+// 							appendPQExpBufferStr(insertStmt, ", ");
+// 						appendPQExpBufferStr(insertStmt,
+// 							fmtId(PQfname(res, field)));
+// 						/*
+// 						 * skip over columns defined additionally for
+// 						 * sql_variant data type columns
+// 						 */
+// 						if (is_sqlvariant_column[field])
+// 								field=field+2;
+// 					}
+// 					appendPQExpBufferStr(insertStmt, ") ");
+// 				}
+
+// 				if (tbinfo->needs_override)
+// 					appendPQExpBufferStr(insertStmt, "OVERRIDING SYSTEM VALUE ");
+
+// 				appendPQExpBufferStr(insertStmt, "VALUES");
+// 			}
+// 		}
+
+// 		for (int tuple = 0; tuple < PQntuples(res); tuple++)
+// 		{
+// 			/* Write the INSERT if not in the middle of a multi-row INSERT. */
+// 			if (rows_this_statement == 0)
+// 				archputs(insertStmt->data, fout);
+
+// 			/*
+// 			 * If it is zero-column table then we've already written the
+// 			 * complete statement, which will mean we've disobeyed
+// 			 * --rows-per-insert when it's set greater than 1.  We do support
+// 			 * a way to make this multi-row with: SELECT UNION ALL SELECT
+// 			 * UNION ALL ... but that's non-standard so we should avoid it
+// 			 * given that using INSERTs is mostly only ever needed for
+// 			 * cross-database exports.
+// 			 */
+// 			if (nfields == 0)
+// 				continue;
+
+// 			/* Emit a row heading */
+// 			if (rows_per_statement == 1)
+// 				archputs(" (", fout);
+// 			else if (rows_this_statement > 0)
+// 				archputs(",\n\t(", fout);
+// 			else
+// 				archputs("\n\t(", fout);
+
+// 			orig_field = 0;
+// 			for (int field = 0; field < nfields_new; field++)
+// 			{
+// 				if(field > 0 && is_sqlvariant_column[field - 1])
+// 				{
+// 					field++;
+// 					continue;
+// 				}
+
+// 				if (field > 0)
+// 					archputs(", ", fout);
+// 				if (attgenerated[orig_field])
+// 				{
+// 					archputs("DEFAULT", fout);
+// 					orig_field++;
+// 					continue;
+// 				}
+// 				if (PQgetisnull(res, tuple, field))
+// 				{
+// 					archputs("NULL", fout);
+// 					orig_field++;
+// 					continue;
+// 				}
+
+// 				/* XXX This code is partially duplicated in ruleutils.c */
+// 				switch (PQftype(res, field))
+// 				{
+// 					case INT2OID:
+// 					case INT4OID:
+// 					case INT8OID:
+// 					case OIDOID:
+// 					case FLOAT4OID:
+// 					case FLOAT8OID:
+// 					case NUMERICOID:
+// 						{
+// 							/*
+// 							 * These types are printed without quotes unless
+// 							 * they contain values that aren't accepted by the
+// 							 * scanner unquoted (e.g., 'NaN').  Note that
+// 							 * strtod() and friends might accept NaN, so we
+// 							 * can't use that to test.
+// 							 *
+// 							 * In reality we only need to defend against
+// 							 * infinity and NaN, so we need not get too crazy
+// 							 * about pattern matching here.
+// 							 */
+// 							const char *s = PQgetvalue(res, tuple, field);
+
+// 							if (strspn(s, "0123456789 +-eE.") == strlen(s))
+// 								archputs(s, fout);
+// 							else
+// 								archprintf(fout, "'%s'", s);
+// 						}
+// 						break;
+
+// 					case BITOID:
+// 					case VARBITOID:
+// 						archprintf(fout, "B'%s'",
+// 								   PQgetvalue(res, tuple, field));
+// 						break;
+
+// 					case BOOLOID:
+// 						if (strcmp(PQgetvalue(res, tuple, field), "t") == 0)
+// 							archputs("true", fout);
+// 						else
+// 							archputs("false", fout);
+// 						break;
+
+// 					default:
+// 						/* All other types are printed as string literals. */
+// 						resetPQExpBuffer(q);
+// 						appendStringLiteralAH(q,
+// 											  PQgetvalue(res, tuple, field),
+// 											  fout);
+// 						if (is_sqlvariant_column[field])
+// 								castSqlvariantToBasetype(res, fout, q, tuple, field);
+// 						else
+// 							archputs(q->data, fout);
+// 						break;
+// 				}
+// 				orig_field++;
+// 			}
+
+// 			/* Terminate the row ... */
+// 			archputs(")", fout);
+
+// 			/* ... and the statement, if the target no. of rows is reached */
+// 			if (++rows_this_statement >= rows_per_statement)
+// 			{
+// 				if (dopt->do_nothing)
+// 					archputs(" ON CONFLICT DO NOTHING;\n", fout);
+// 				else
+// 					archputs(";\n", fout);
+// 				/* Reset the row counter */
+// 				rows_this_statement = 0;
+// 			}
+// 		}
+
+// 		if (PQntuples(res) <= 0)
+// 		{
+// 			PQclear(res);
+// 			break;
+// 		}
+// 		PQclear(res);
+// 	}
+
+// 	/* Terminate any statements that didn't make the row count. */
+// 	if (rows_this_statement > 0)
+// 	{
+// 		if (dopt->do_nothing)
+// 			archputs(" ON CONFLICT DO NOTHING;\n", fout);
+// 		else
+// 			archputs(";\n", fout);
+// 	}
+
+// 	archputs("\n\n", fout);
+
+// 	ExecuteSqlStatement(fout, "CLOSE _pg_dump_cursor");
+
+// 	destroyPQExpBuffer(q);
+// 	if (insertStmt != NULL)
+// 		destroyPQExpBuffer(insertStmt);
+// 	free(attgenerated);
+// 	free(is_sqlvariant_column);
+// 	return 1;
+// }
 
 /*
  * hasSqlvariantColumn:
@@ -1282,7 +1370,7 @@ static int
 getMbstrlen(const char* mbstr, Archive* fout)
 {
 	int len = 0;
-	if(*mbstr == NULL)
+	if(!mbstr)
 		return 0;
 	while (*mbstr){
 		mbstr += PQmblen(mbstr, fout->encoding);

--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -41,6 +41,8 @@ extern void dumpBabelGUCs(Archive *fout);
 extern void fixCursorForBbfCatalogTableData(Archive *fout, TableInfo *tbinfo, PQExpBuffer buf, int *nfields, char *attgenerated);
 extern void fixCopyCommand(Archive *fout, PQExpBuffer copyBuf, TableInfo *tbinfo, bool isFrom);
 extern bool hasSqlvariantColumn(TableInfo *tbinfo);
-extern int dumpSqlvariantTableData(Archive *fout, const void *dcontext);
+// extern int dumpSqlvariantTableData(Archive *fout, const void *dcontext);
+extern void fixBbfSqlvariantData(Archive *fout, PGresult* res, PQExpBuffer q, char* attgenerated, int tuple, int *orig_field, int *field);
+extern void fixCursorForBbfSqlvariantTableData(Archive *fout, TableInfo *tbinfo, PQExpBuffer buf, int *nfields, bool **is_sqlvariant_column, bool *has_sqlvariant_column);
 
 #endif

--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -41,7 +41,15 @@ extern void dumpBabelGUCs(Archive *fout);
 extern void fixCursorForBbfCatalogTableData(Archive *fout, TableInfo *tbinfo, PQExpBuffer buf, int *nfields, char *attgenerated);
 extern void fixCopyCommand(Archive *fout, PQExpBuffer copyBuf, TableInfo *tbinfo, bool isFrom);
 extern bool hasSqlvariantColumn(TableInfo *tbinfo);
-extern void fixBbfSqlvariantData(Archive *fout, PGresult* res, PQExpBuffer q, char* attgenerated, int tuple, int *orig_field, int *field);
-extern void fixCursorForBbfSqlvariantTableData(Archive *fout, TableInfo *tbinfo, PQExpBuffer buf, int *nfields, bool *is_sqlvariant_column, bool *has_sqlvariant_column);
+extern int fixCursorForBbfSqlvariantTableData(Archive *fout,
+                                            TableInfo *tbinfo,
+                                            PQExpBuffer query,
+                                            int nfields,
+                                            int **sqlvar_metdata_pos);
+extern void castSqlvariantToBasetype(PGresult *res,
+                                    Archive *fout,
+                                    int row,
+                                    int field,
+                                    int sqlvariant_pos);
 
 #endif

--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -41,8 +41,7 @@ extern void dumpBabelGUCs(Archive *fout);
 extern void fixCursorForBbfCatalogTableData(Archive *fout, TableInfo *tbinfo, PQExpBuffer buf, int *nfields, char *attgenerated);
 extern void fixCopyCommand(Archive *fout, PQExpBuffer copyBuf, TableInfo *tbinfo, bool isFrom);
 extern bool hasSqlvariantColumn(TableInfo *tbinfo);
-// extern int dumpSqlvariantTableData(Archive *fout, const void *dcontext);
 extern void fixBbfSqlvariantData(Archive *fout, PGresult* res, PQExpBuffer q, char* attgenerated, int tuple, int *orig_field, int *field);
-extern void fixCursorForBbfSqlvariantTableData(Archive *fout, TableInfo *tbinfo, PQExpBuffer buf, int *nfields, bool **is_sqlvariant_column, bool *has_sqlvariant_column);
+extern void fixCursorForBbfSqlvariantTableData(Archive *fout, TableInfo *tbinfo, PQExpBuffer buf, int *nfields, bool *is_sqlvariant_column, bool *has_sqlvariant_column);
 
 #endif

--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -40,5 +40,7 @@ extern void setBabelfishDependenciesForLogicalDatabaseDump(Archive *fout);
 extern void dumpBabelGUCs(Archive *fout);
 extern void fixCursorForBbfCatalogTableData(Archive *fout, TableInfo *tbinfo, PQExpBuffer buf, int *nfields, char *attgenerated);
 extern void fixCopyCommand(Archive *fout, PQExpBuffer copyBuf, TableInfo *tbinfo, bool isFrom);
+extern bool hasSqlvariantColumn(TableInfo *tbinfo);
+extern int dumpSqlvariantTableData(Archive *fout, const void *dcontext);
 
 #endif

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -2148,12 +2148,12 @@ dumpTableData_insert(Archive *fout, const void *dcontext)
 	int			rows_per_statement = dopt->dump_inserts;
 	int			rows_this_statement = 0;
 	/*
-	 * sqlvar_metdata_pos stores the position of the extra columns added in
+	 * sqlvar_metadata_pos stores the position of the extra columns added in
 	 * fixCursorForBbfSqlvariantTableData which fetch the metadata of sql_variant
 	 * column values. The array is NULL if no sql_variant columns are present in
 	 * the table, and the value stored is 0 if it is not a sql_variant column.
 	 */
-	int			*sqlvar_metdata_pos = NULL;
+	int			*sqlvar_metadata_pos = NULL;
 	/* Total number of columns in select cursor including sql_variant metadata
 	columns, if they exist. */
 	int			nfields_new = 0;
@@ -2192,7 +2192,7 @@ dumpTableData_insert(Archive *fout, const void *dcontext)
 		nfields++;
 	}
 	nfields_new = fixCursorForBbfSqlvariantTableData(fout, tbinfo, q, nfields,
-										&sqlvar_metdata_pos);
+										&sqlvar_metadata_pos);
 	/* Servers before 9.4 will complain about zero-column SELECT */
 	if (nfields == 0)
 		appendPQExpBufferStr(q, "NULL");
@@ -2311,10 +2311,10 @@ dumpTableData_insert(Archive *fout, const void *dcontext)
 					continue;
 				}
 
-				if(sqlvar_metdata_pos && sqlvar_metdata_pos[field])
+				if(sqlvar_metadata_pos && sqlvar_metadata_pos[field] > 0)
 				{
 					castSqlvariantToBasetype(res, fout, tuple, field,
-										sqlvar_metdata_pos[field]);
+										sqlvar_metadata_pos[field]);
 					continue;
 				}
 				/* XXX This code is partially duplicated in ruleutils.c */
@@ -2412,8 +2412,8 @@ dumpTableData_insert(Archive *fout, const void *dcontext)
 	if (insertStmt != NULL)
 		destroyPQExpBuffer(insertStmt);
 	free(attgenerated);
-	if(sqlvar_metdata_pos)
-		free(sqlvar_metdata_pos);
+	if(sqlvar_metadata_pos)
+		free(sqlvar_metadata_pos);
 
 	return 1;
 }

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -320,7 +320,6 @@ static void appendReloptionsArrayAH(PQExpBuffer buffer, const char *reloptions,
 									const char *prefix, Archive *fout);
 static char *get_synchronized_snapshot(Archive *fout);
 static void setupDumpWorker(Archive *AHX);
-// static TableInfo *getRootTableInfo(const TableInfo *tbinfo);
 
 
 int
@@ -2439,7 +2438,7 @@ dumpTableData(Archive *fout, const TableDataInfo *tdinfo)
 	/* We had better have loaded per-column details about this table */
 	Assert(tbinfo->interesting);
 
-	if(hasSqlvariantColumn(tbinfo)){
+	if(isBabelfishDatabase(fout) && hasSqlvariantColumn(tbinfo)){
 		/* handle tables with sql_variant datatype columns separately */
 		dumpFn = dumpSqlvariantTableData;
 		copyStmt = NULL;

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -322,8 +322,10 @@ static char *get_synchronized_snapshot(Archive *fout);
 static void setupDumpWorker(Archive *AHX);
 static TableInfo *getRootTableInfo(const TableInfo *tbinfo);
 static int get_mbbytlen(const char* mbstr,Archive* fout);
-static void cast_sqlvariant_to_basetype(PGresult* res, Archive* fout, PQExpBuffer q, int tuple, int field);
+static void cast_sqlvariant_to_basetype(PGresult* res, Archive* fout, 
+										PQExpBuffer q, int tuple, int field);
 static bool has_sqlvariant_column(TableInfo *tbinfo);
+
 
 int
 main(int argc, char **argv)
@@ -2496,7 +2498,7 @@ dumpTableData(Archive *fout, const TableDataInfo *tdinfo)
 	{
 		/* Dump/restore using COPY */
 		dumpFn = dumpTableData_copy;
-		
+
 		/*
 		 * When load-via-partition-root is set, get the root table name for
 		 * the partition table, so that we can reload data through the root

--- a/src/bin/pg_dump/pg_dump.h
+++ b/src/bin/pg_dump/pg_dump.h
@@ -745,6 +745,5 @@ extern void getPublicationNamespaces(Archive *fout);
 extern void getPublicationTables(Archive *fout, TableInfo tblinfo[],
 								 int numTables);
 extern void getSubscriptions(Archive *fout);
-extern TableInfo *getRootTableInfo(const TableInfo *tbinfo);
 
 #endif							/* PG_DUMP_H */

--- a/src/bin/pg_dump/pg_dump.h
+++ b/src/bin/pg_dump/pg_dump.h
@@ -745,5 +745,6 @@ extern void getPublicationNamespaces(Archive *fout);
 extern void getPublicationTables(Archive *fout, TableInfo tblinfo[],
 								 int numTables);
 extern void getSubscriptions(Archive *fout);
+extern TableInfo *getRootTableInfo(const TableInfo *tbinfo);
 
 #endif							/* PG_DUMP_H */


### PR DESCRIPTION
### Description
When pg_dump/restore is performed on database with table containing sql_variant data type columns, it was observed that the metadata seemed to get lost during the dump process. Therefore, the values were not correctly restored, which reflected in the failure of some test cases in JDBC framework. This change aims to separately handle table containing sql_variant data type columns so that the values can be correctly dumped and restored. 
 
Tests added in extensions PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1385
### Issues Resolved

BABEL-4036 
Signed-off-by: Aditya Verma <adiityav@amazon.com>
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
