### PR TITLE
Skip shared memory cache invalidation for ENR

### DIFF
--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -2195,7 +2195,7 @@ heap_insert(Relation relation, HeapTuple tup, CommandId cid,
 	 * the heaptup data structure is all in local memory, not in the shared
 	 * buffer.
 	 */
-	CacheInvalidateHeapTuple(relation, heaptup, NULL);
+	CacheInvalidateHeapTuple(relation, heaptup, NULL, false);
 
 	/* Note: speculative insertions are counted too, even if aborted later */
 	pgstat_count_heap_insert(relation, 1);
@@ -2592,7 +2592,7 @@ heap_multi_insert(Relation relation, TupleTableSlot **slots, int ntuples,
 	if (IsCatalogRelation(relation))
 	{
 		for (i = 0; i < ntuples; i++)
-			CacheInvalidateHeapTuple(relation, heaptuples[i], NULL);
+			CacheInvalidateHeapTuple(relation, heaptuples[i], NULL, false);
 	}
 
 	/* copy t_self fields back to the caller's slots */
@@ -3057,7 +3057,7 @@ l1:
 	 * boundary. We have to do this before releasing the buffer because we
 	 * need to look at the contents of the tuple.
 	 */
-	CacheInvalidateHeapTuple(relation, &tp, NULL);
+	CacheInvalidateHeapTuple(relation, &tp, NULL, false);
 
 	/* Now we can release the buffer */
 	ReleaseBuffer(buffer);
@@ -3973,7 +3973,7 @@ l2:
 	 * both tuple versions in one call to inval.c so we can avoid redundant
 	 * sinval messages.)
 	 */
-	CacheInvalidateHeapTuple(relation, &oldtup, heaptup);
+	CacheInvalidateHeapTuple(relation, &oldtup, heaptup, false);
 
 	/* Now we can release the buffer(s) */
 	if (newbuf != buffer)
@@ -6094,7 +6094,7 @@ heap_inplace_update(Relation relation, HeapTuple tuple)
 	 * bothering with index updates either, so that's true a fortiori.
 	 */
 	if (!IsBootstrapProcessingMode())
-		CacheInvalidateHeapTuple(relation, tuple, NULL);
+		CacheInvalidateHeapTuple(relation, tuple, NULL,  false);
 }
 
 #define		FRM_NOOP				0x0001

--- a/src/backend/commands/typecmds.c
+++ b/src/backend/commands/typecmds.c
@@ -2924,7 +2924,7 @@ AlterDomainDropConstraint(List *names, const char *constrName,
 	 * dependent plans get rebuilt.  Since this command doesn't change the
 	 * domain's pg_type row, that won't happen automatically; do it manually.
 	 */
-	CacheInvalidateHeapTuple(rel, tup, NULL);
+	CacheInvalidateHeapTuple(rel, tup, NULL, false);
 
 	ObjectAddressSet(address, TypeRelationId, domainoid);
 
@@ -3040,7 +3040,7 @@ AlterDomainAddConstraint(List *names, Node *newConstraint,
 	 * dependent plans get rebuilt.  Since this command doesn't change the
 	 * domain's pg_type row, that won't happen automatically; do it manually.
 	 */
-	CacheInvalidateHeapTuple(typrel, tup, NULL);
+	CacheInvalidateHeapTuple(typrel, tup, NULL, false);
 
 	ObjectAddressSet(address, TypeRelationId, domainoid);
 

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -826,17 +826,17 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 				case ENR_OP_ADD:
 					newtup = heap_copytuple(tup);
 					*list_ptr = list_insert_nth(*list_ptr, insert_at, newtup);
-					CacheInvalidateHeapTuple(catalog_rel, newtup, NULL);
+					CacheInvalidateHeapTuple(catalog_rel, newtup, NULL, true);
 					break;
 				case ENR_OP_UPDATE:
 					oldtup = lfirst(lc);
 					lfirst(lc) = heap_copytuple(tup);
-					CacheInvalidateHeapTuple(catalog_rel, oldtup, tup);
+					CacheInvalidateHeapTuple(catalog_rel, oldtup, tup, true);
 					break;
 				case ENR_OP_DROP:
 					tmp = lfirst(lc);
 					*list_ptr = list_delete_ptr(*list_ptr, tmp);
-					CacheInvalidateHeapTuple(catalog_rel, tup, NULL);
+					CacheInvalidateHeapTuple(catalog_rel, tup, NULL, true);
 					heap_freetuple(tmp);
 					break;
 				default:
@@ -979,7 +979,7 @@ extern void ENRDropCatalogEntry(Relation catalog_relation, Oid relid)
 			{
 				htup = list_nth(*list_ptr, 0);
 				*list_ptr = list_delete_ptr(*list_ptr, htup);
-				CacheInvalidateHeapTuple(catalog_relation, htup, NULL);
+				CacheInvalidateHeapTuple(catalog_relation, htup, NULL, true);
 				heap_freetuple(htup); // heap_copytuple was called during ADD
 			}
 

--- a/src/include/utils/inval.h
+++ b/src/include/utils/inval.h
@@ -36,7 +36,8 @@ extern void CommandEndInvalidationMessages(void);
 
 extern void CacheInvalidateHeapTuple(Relation relation,
 									 HeapTuple tuple,
-									 HeapTuple newtuple);
+									 HeapTuple newtuple,
+									 bool isEnr);
 
 extern void CacheInvalidateCatalog(Oid catalogId);
 


### PR DESCRIPTION
### Description

With #130 checkin - as ENR access uses system catalog cache, DDLs related to ENR must call cache invalidation APIs. However, as table variables have local scope, we do not need to invalidate shared memory for other backends which creates lock based contention. 

This change gives an improvement in performance in situations with many concurrent connections using temp tables or table variables. 

Local test results on a sample of 500 connections simultaneously creating and manipulating table variables showed a modest (~4%) performance increase. 
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
