### PR TITLE
Block cross version and cross migration mode dump/restore

### DIFF
--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -171,7 +171,6 @@ void
 dumpBabelRestoreChecks(Archive *fout)
 {
 	PGresult	*res;
-	PGresult	*res_server_version;
 	char		*dump_migration_mode;
 	char		*dump_server_version;
 	PQExpBuffer	qry;

--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -144,7 +144,9 @@ void
 dumpBabelGUCs(Archive *fout)
 {
 	char		*oid;
+	char		*migration_mode;
 	PQExpBuffer	qry;
+	PGresult	*res;
 
 	if (!isBabelfishDatabase(fout))
 		return;
@@ -158,6 +160,11 @@ dumpBabelGUCs(Archive *fout)
 		free(oid);
 	}
 
+	res = ExecuteSqlQuery(fout, "SHOW babelfishpg_tsql.migration_mode", PGRES_TUPLES_OK);
+	migration_mode = PQgetvalue(res, 0, 0);
+	pg_log_info("migration_mode: %s", migration_mode);
+
+	// appendPQExpBuffer(qry, "SET babelfishpg_tsql.migration_mode = %s;\n", migration_mode);
 	ArchiveEntry(fout, nilCatalogId, createDumpId(),
 				 ARCHIVE_OPTS(.tag = "BABELFISHGUCS",
 							  .description = "BABELFISHGUCS",
@@ -165,6 +172,7 @@ dumpBabelGUCs(Archive *fout)
 							  .createStmt = qry->data));
 
 	destroyPQExpBuffer(qry);
+	PQclear(res);
 }
 
 /*

--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -51,5 +51,5 @@ extern void castSqlvariantToBasetype(PGresult *res,
                                     int row,
                                     int field,
                                     int sqlvariant_pos);
-extern void dumpBabelMigrationModeCheck(Archive *fout);
+extern void dumpBabelRestoreChecks(Archive *fout);
 #endif

--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -51,5 +51,5 @@ extern void castSqlvariantToBasetype(PGresult *res,
                                     int row,
                                     int field,
                                     int sqlvariant_pos);
-extern void blockCrossMigrationDumpRestore(Archive *fout);
+extern void dumpBabelMigrationModeCheck(Archive *fout);
 #endif

--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -51,5 +51,5 @@ extern void castSqlvariantToBasetype(PGresult *res,
                                     int row,
                                     int field,
                                     int sqlvariant_pos);
-
+extern void blockCrossMigrationDumpRestore(Archive *fout);
 #endif

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -919,8 +919,7 @@ main(int argc, char **argv)
 		dumpDatabase(fout);
 
 	dumpBabelGUCs(fout);
-	if (bbf_db_name != NULL)
-		blockCrossMigrationDumpRestore(fout);
+	dumpBabelMigrationModeCheck(fout);
 	/* Now the rearrangeable objects. */
 	for (i = 0; i < numObjs; i++)
 		dumpDumpableObject(fout, dobjs[i]);

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -919,7 +919,7 @@ main(int argc, char **argv)
 		dumpDatabase(fout);
 
 	dumpBabelGUCs(fout);
-
+	blockCrossMigrationDumpRestore(fout);
 	/* Now the rearrangeable objects. */
 	for (i = 0; i < numObjs; i++)
 		dumpDumpableObject(fout, dobjs[i]);

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -919,7 +919,8 @@ main(int argc, char **argv)
 		dumpDatabase(fout);
 
 	dumpBabelGUCs(fout);
-	blockCrossMigrationDumpRestore(fout);
+	if (bbf_db_name != NULL)
+		blockCrossMigrationDumpRestore(fout);
 	/* Now the rearrangeable objects. */
 	for (i = 0; i < numObjs; i++)
 		dumpDumpableObject(fout, dobjs[i]);

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -919,7 +919,7 @@ main(int argc, char **argv)
 		dumpDatabase(fout);
 
 	dumpBabelGUCs(fout);
-	dumpBabelMigrationModeCheck(fout);
+	dumpBabelRestoreChecks(fout);
 	/* Now the rearrangeable objects. */
 	for (i = 0; i < numObjs; i++)
 		dumpDumpableObject(fout, dobjs[i]);


### PR DESCRIPTION
### Description

Babelfish currently only supports Database level dump and restore for databases with same migration mode ( i.e. either singledb->singledb or multidb->multidb). With this change the restore process with stop execution if the migration mode in the target cluster is different than the one from which the dump file was created. 
 
### Issues Resolved

BABEL-4055
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
