### PR TITLE
Fix issue with ORDER BY in set operation

### DIFF
--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -53,6 +53,7 @@
 #include "utils/syscache.h"
 
 tle_name_comparison_hook_type  tle_name_comparison_hook = NULL;
+post_transform_from_clause_hook_type  post_transform_from_clause_hook = NULL;
 
 static int	extractRemainingColumns(ParseNamespaceColumn *src_nscolumns,
 									List *src_colnames,
@@ -151,6 +152,13 @@ transformFromClause(ParseState *pstate, List *frmList)
 	 * but those should have been that way already.
 	 */
 	setNamespaceLateralState(pstate->p_namespace, false, true);
+
+	/* 
+	 * Save the namespace -- tsql needs the leftmost select's namespace to
+	 * resolve some ORDER BY clauses used with set operations (i.e. UNION) 
+	 */
+	if (post_transform_from_clause_hook)
+		post_transform_from_clause_hook(pstate);
 }
 
 /*

--- a/src/include/parser/analyze.h
+++ b/src/include/parser/analyze.h
@@ -53,6 +53,20 @@ extern PGDLLIMPORT post_transform_insert_row_hook_type post_transform_insert_row
 typedef int (*set_target_table_alternative_hook_type) (ParseState *pstate, Node *stmt, CmdType command);
 extern PGDLLIMPORT set_target_table_alternative_hook_type set_target_table_alternative_hook;
 
+/* Hook for handle target table before transforming from clause */
+typedef void (*push_namespace_stack_hook_type) ();
+extern PGDLLIMPORT push_namespace_stack_hook_type push_namespace_stack_hook;
+
+/* Hook for handle target table before transforming from clause */
+typedef void (*pre_transform_sort_clause_hook_type) (ParseState *pstate, Query *qry, Query *leftmostQuery);
+extern PGDLLIMPORT pre_transform_sort_clause_hook_type pre_transform_sort_clause_hook;
+
+/* Hook for handle target table before transforming from clause */
+typedef void (*post_transform_sort_clause_hook_type) (Query *qry);
+extern PGDLLIMPORT post_transform_sort_clause_hook_type post_transform_sort_clause_hook;
+
+extern Query *parse_analyze_fixedparams(RawStmt *parseTree, const char *sourceText,
+										const Oid *paramTypes, int numParams, QueryEnvironment *queryEnv);
 extern Query *parse_analyze(RawStmt *parseTree, const char *sourceText,
 							Oid *paramTypes, int numParams, QueryEnvironment *queryEnv);
 extern Query *parse_analyze_varparams(RawStmt *parseTree, const char *sourceText,

--- a/src/include/parser/parse_clause.h
+++ b/src/include/parser/parse_clause.h
@@ -54,4 +54,10 @@ extern bool targetIsInSortList(TargetEntry *tle, Oid sortop, List *sortList);
 typedef bool (*tle_name_comparison_hook_type)(const char *tlename, const char *identifier);
 extern PGDLLIMPORT tle_name_comparison_hook_type tle_name_comparison_hook;
 
+typedef void (*post_transform_from_clause_hook_type)(ParseState *pstate);
+extern PGDLLIMPORT post_transform_from_clause_hook_type post_transform_from_clause_hook;
+
+typedef void (*sortby_nulls_hook_type)(SortGroupClause *sortcl, bool reverse);
+extern PGDLLIMPORT sortby_nulls_hook_type sortby_nulls_hook;
+
 #endif							/* PARSE_CLAUSE_H */


### PR DESCRIPTION
### Description

Previously, ORDER BY clauses combined with set operations like UNION could raise an error when specifying the table name with the column. T-SQL allows queries like this, several hooks have been added to allow the extension to modify how set operators are analyzed.

### Issues Resolved
BABEL-3215

### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
