### PR TITLE
Fix the crash when set client_encoding from pg endpoint using babel database

### DIFF
--- a/src/backend/postmaster/pgstat.c
+++ b/src/backend/postmaster/pgstat.c
@@ -1907,7 +1907,7 @@ pgstat_init_function_usage(FunctionCallInfo fcinfo,
 	PgStat_BackendFunctionEntry *htabent;
 	bool		found;
 
-	if (pre_function_call_hook)
+	if (pre_function_call_hook && IsTransactionState())
 	{
 		HeapTuple proctup = SearchSysCache1(PROCOID, ObjectIdGetDatum(fcinfo->flinfo->fn_oid));
 		if (HeapTupleIsValid(proctup))

--- a/src/backend/utils/fmgr/fmgr.c
+++ b/src/backend/utils/fmgr/fmgr.c
@@ -16,6 +16,7 @@
 #include "postgres.h"
 
 #include "access/detoast.h"
+#include "access/xact.h"
 #include "catalog/namespace.h"
 #include "catalog/pg_language.h"
 #include "catalog/pg_namespace.h"
@@ -787,12 +788,13 @@ fmgr_security_definer(PG_FUNCTION_ARGS)
 						GUC_ACTION_SAVE);
 	}
 
-	if (set_sql_dialect)
+	if (set_sql_dialect && IsTransactionState())
 	{
 		HeapTuple	tuple;
 		Form_pg_proc procedureStruct;
 		tuple = SearchSysCache1(PROCOID,
 								ObjectIdGetDatum(fcinfo->flinfo->fn_oid));
+
 		if (!HeapTupleIsValid(tuple))
 			elog(ERROR, "cache lookup failed for function %u",
 				 fcinfo->flinfo->fn_oid);


### PR DESCRIPTION
Previously when try to set variable from pg endpoint when that backend is using babel database, the postgres backend will crash.

The root cause for this crash is pg backend when returnning will call security definer in report Guc changes, in such condition, it's not within a transaction.

This commit fix this issue by checking the transaction state in security definer.

Task: BABEL-3301

### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
