### PR TITLE
In CTE Null first order behavior is not correct

### DIFF
--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -55,6 +55,8 @@
 tle_name_comparison_hook_type  tle_name_comparison_hook = NULL;
 post_transform_from_clause_hook_type  post_transform_from_clause_hook = NULL;
 
+sortby_nulls_hook_type  sortby_nulls_hook = NULL;
+
 static int	extractRemainingColumns(ParseNamespaceColumn *src_nscolumns,
 									List *src_colnames,
 									List **src_colnos,
@@ -3389,6 +3391,10 @@ addTargetToSortList(ParseState *pstate, TargetEntry *tle,
 			case SORTBY_NULLS_DEFAULT:
 				/* NULLS FIRST is default for DESC; other way for ASC */
 				sortcl->nulls_first = reverse;
+				if (sortby_nulls_hook)
+				{
+					sortby_nulls_hook(sortcl, reverse);
+				}
 				break;
 			case SORTBY_NULLS_FIRST:
 				sortcl->nulls_first = true;


### PR DESCRIPTION
* Solve the bug in CTE Null first order behavior is not correct

Previously we add the Null first check after analyze, and in that case it'll miss to add the Null first tag to the sort clause for a CTE query

change the place adding Null first tag to the place sortClause is initialized


Task: BABEL-3991

### Description

cherry-pick babel-3991 
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
