### PR TITLE
Fix UNION regression

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -1931,7 +1931,6 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 	/* add jnsitem to column namespace only */
 	addNSItemToQuery(pstate, jnsitem, false, false, true);
 	
-	/* tsql needs the leftmost query's targetlist and ns to handle ORDER BY */
 	if (pre_transform_sort_clause_hook)
 		pre_transform_sort_clause_hook(pstate, qry, leftmostQuery);
 
@@ -1949,13 +1948,6 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 										  EXPR_KIND_ORDER_BY,
 										  false /* allow SQL92 rules */ );
 
-	/* 
-	 * UNION ALL with Numeric types require the the TLE's var to have a typmod
-	 * of -1. Reset the targetlist to the dummy tl, but fill in ressortgroupref
-	 */
-	if (post_transform_sort_clause_hook)
-		post_transform_sort_clause_hook(qry);
-
 	/* restore namespace, remove join RTE from rtable */
 	pstate->p_namespace = sv_namespace;
 	pstate->p_rtable = list_truncate(pstate->p_rtable, sv_rtable_length);
@@ -1968,6 +1960,9 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 				 errhint("Add the expression/function to every SELECT, or move the UNION into a FROM clause."),
 				 parser_errposition(pstate,
 									exprLocation(list_nth(qry->targetList, tllen)))));
+
+	if (post_transform_sort_clause_hook)
+		post_transform_sort_clause_hook(qry);
 
 	qry->limitOffset = transformLimitClause(pstate, limitOffset,
 											EXPR_KIND_OFFSET, "OFFSET",


### PR DESCRIPTION
### Description

Previous work to fix ORDER BY clauses with UNION statements introduced a regression. These changes temporarily repalce the top-level target list, which is checked to ensure the length does not change. The problem arises when the new target list contains resjunk columns, which results in a different length than the original target list. This change fixes this issue.
 
### Issues Resolved
BABEL-4169
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
