### PR TITLE
like with bracket work improper for some corner cases

### DIFF
--- a/src/backend/catalog/pg_collation.c
+++ b/src/backend/catalog/pg_collation.c
@@ -41,6 +41,11 @@ PreCreateCollation_hook_type PreCreateCollation_hook = NULL;
 /* Hook for plugins to get control if a collation name is not found */
 TranslateCollation_hook_type TranslateCollation_hook = NULL;
 
+set_like_collation_hook_type set_like_collation_hook = NULL;
+
+get_like_collation_hook_type get_like_collation_hook = NULL;
+
+
 /*
  * CollationCreate
  *

--- a/src/backend/utils/adt/like.c
+++ b/src/backend/utils/adt/like.c
@@ -152,10 +152,9 @@ SB_lower_char(unsigned char c, pg_locale_t locale, bool locale_is_c)
 static inline int
 GenericMatchText(const char *s, int slen, const char *p, int plen, Oid collation)
 {
-	pg_locale_t locale;
-	if ((sql_dialect == SQL_DIALECT_TSQL) || (collation && !lc_ctype_is_c(collation)))
+	if (collation && !lc_ctype_is_c(collation))
 	{
-		locale = pg_newlocale_from_collation(collation);
+		pg_locale_t locale = pg_newlocale_from_collation(collation);
 
 		if (locale && !locale->deterministic)
 			ereport(ERROR,
@@ -164,11 +163,11 @@ GenericMatchText(const char *s, int slen, const char *p, int plen, Oid collation
 	}
 
 	if (pg_database_encoding_max_length() == 1)
-		return SB_MatchText(s, slen, p, plen, sql_dialect == SQL_DIALECT_TSQL ? locale : 0, true, collation);
+		return SB_MatchText(s, slen, p, plen, 0, true, collation);
 	else if (GetDatabaseEncoding() == PG_UTF8)
-		return UTF8_MatchText(s, slen, p, plen, sql_dialect == SQL_DIALECT_TSQL ? locale : 0, true, collation);
+		return UTF8_MatchText(s, slen, p, plen, 0, true, collation);
 	else
-		return MB_MatchText(s, slen, p, plen, sql_dialect == SQL_DIALECT_TSQL ? locale : 0, true, collation);
+		return MB_MatchText(s, slen, p, plen, 0, true, collation);
 }
 
 static inline int
@@ -222,9 +221,9 @@ Generic_Text_IC_like(text *str, text *pat, Oid collation)
 		s = VARDATA_ANY(str);
 		slen = VARSIZE_ANY_EXHDR(str);
 		if (GetDatabaseEncoding() == PG_UTF8)
-			return UTF8_MatchText(s, slen, p, plen, sql_dialect == SQL_DIALECT_TSQL ? locale : 0, true, collation);
+			return UTF8_MatchText(s, slen, p, plen, 0, true, collation);
 		else
-			return MB_MatchText(s, slen, p, plen, sql_dialect == SQL_DIALECT_TSQL ? locale : 0, true, collation);
+			return MB_MatchText(s, slen, p, plen, 0, true, collation);
 	}
 	else
 	{

--- a/src/backend/utils/adt/like.c
+++ b/src/backend/utils/adt/like.c
@@ -26,6 +26,8 @@
 #include "utils/builtins.h"
 #include "utils/pg_locale.h"
 #include "utils/varlena.h"
+#include "postgres_ext.h"
+
 
 
 #define LIKE_TRUE						1

--- a/src/backend/utils/adt/like_match.c
+++ b/src/backend/utils/adt/like_match.c
@@ -207,7 +207,7 @@ MatchText(const char *t, int tlen, const char *p, int plen,
 		else if (*p == '[' && sql_dialect == SQL_DIALECT_TSQL)
 		{
 			/* Tsql deal with [ and ] wild character */
-			Oid cid;
+			Oid cid = InvalidOid;
 			bool find_match = false, reverse_mode = false;
 			const char * prev = NULL;
 			if (get_like_collation_hook)
@@ -231,6 +231,7 @@ MatchText(const char *t, int tlen, const char *p, int plen,
 				if (*p == '-' && prev)
 				{
 					NextByte(p, plen);
+					Assert(cid != InvalidOid);
 					if (varstr_cmp(t, 1, prev, 1, cid) >= 0 && varstr_cmp(t, 1, p, 1, cid) <= 0)
 					{
 						find_match = true;

--- a/src/backend/utils/adt/like_match.c
+++ b/src/backend/utils/adt/like_match.c
@@ -78,7 +78,7 @@
 
 static int
 MatchText(const char *t, int tlen, const char *p, int plen,
-		  pg_locale_t locale, bool locale_is_c)
+		  pg_locale_t locale, bool locale_is_c, Oid cid)
 {
 	/* Fast path for match-everything pattern */
 	if (plen == 1 && *p == '%')
@@ -176,14 +176,14 @@ MatchText(const char *t, int tlen, const char *p, int plen,
 				if (GETCHAR(*t) == firstpat)
 				{
 					int			matched = MatchText(t, tlen, p, plen,
-													locale, locale_is_c);
+													locale, locale_is_c, cid);
 
 					if (matched != LIKE_FALSE)
 						return matched; /* TRUE or ABORT */
 				} else if (firstpat == '[' && sql_dialect == SQL_DIALECT_TSQL)
 				{
 					int			matched = MatchText(t, tlen, p, plen,
-													locale, locale_is_c);
+													locale, locale_is_c, cid);
 					if (matched != LIKE_FALSE)
 						return matched; /* TRUE or ABORT */
 				}
@@ -228,7 +228,7 @@ MatchText(const char *t, int tlen, const char *p, int plen,
 				if (*p == '-' && prev)
 				{
 					NextByte(p, plen);
-					if (varstr_cmp(t, 1, prev, 1, locale) >= 0 && varstr_cmp(t, 1, p, 1, locale) <= 0)
+					if (varstr_cmp(t, 1, prev, 1, cid) >= 0 && varstr_cmp(t, 1, p, 1, cid) <= 0)
 					{
 						find_match = true;
 					}

--- a/src/backend/utils/adt/like_match.c
+++ b/src/backend/utils/adt/like_match.c
@@ -208,7 +208,7 @@ MatchText(const char *t, int tlen, const char *p, int plen,
 		{
 			/* Tsql deal with [ and ] wild character */
 			Oid cid = InvalidOid;
-			bool find_match = false, reverse_mode = false;
+			bool find_match = false, reverse_mode = false, close_bracket = false;
 			const char * prev = NULL;
 			if (get_like_collation_hook)
 				cid = get_like_collation_hook();
@@ -222,7 +222,10 @@ MatchText(const char *t, int tlen, const char *p, int plen,
 			while (plen > 0)
 			{
 				if (*p == ']')
+				{
+					close_bracket = true;
 					break;
+				}
 				if (find_match)
 				{
 					NextByte(p, plen);
@@ -249,6 +252,10 @@ MatchText(const char *t, int tlen, const char *p, int plen,
 				NextByte(p, plen);
 			}
 			if (!find_match && !reverse_mode)
+			{
+				return LIKE_FALSE;
+			}
+			if (find_match && !close_bracket)
 			{
 				return LIKE_FALSE;
 			}

--- a/src/backend/utils/adt/like_match.c
+++ b/src/backend/utils/adt/like_match.c
@@ -78,7 +78,7 @@
 
 static int
 MatchText(const char *t, int tlen, const char *p, int plen,
-		  pg_locale_t locale, bool locale_is_c, Oid cid)
+		  pg_locale_t locale, bool locale_is_c)
 {
 	/* Fast path for match-everything pattern */
 	if (plen == 1 && *p == '%')
@@ -176,14 +176,14 @@ MatchText(const char *t, int tlen, const char *p, int plen,
 				if (GETCHAR(*t) == firstpat)
 				{
 					int			matched = MatchText(t, tlen, p, plen,
-													locale, locale_is_c, cid);
+													locale, locale_is_c);
 
 					if (matched != LIKE_FALSE)
 						return matched; /* TRUE or ABORT */
 				} else if (firstpat == '[' && sql_dialect == SQL_DIALECT_TSQL)
 				{
 					int			matched = MatchText(t, tlen, p, plen,
-													locale, locale_is_c, cid);
+													locale, locale_is_c);
 					if (matched != LIKE_FALSE)
 						return matched; /* TRUE or ABORT */
 				}
@@ -207,8 +207,11 @@ MatchText(const char *t, int tlen, const char *p, int plen,
 		else if (*p == '[' && sql_dialect == SQL_DIALECT_TSQL)
 		{
 			/* Tsql deal with [ and ] wild character */
+			Oid cid;
 			bool find_match = false, reverse_mode = false;
 			const char * prev = NULL;
+			if (get_like_collation_hook)
+				cid = get_like_collation_hook();
 
 			NextByte(p, plen);
 			if (*p == '^')

--- a/src/include/catalog/pg_collation.h
+++ b/src/include/catalog/pg_collation.h
@@ -114,7 +114,7 @@ extern PGDLLIMPORT TranslateCollation_hook_type TranslateCollation_hook;
 typedef void (*set_like_collation_hook_type) (Oid collation);
 extern PGDLLIMPORT set_like_collation_hook_type set_like_collation_hook;
 
-typedef Oid (*get_like_collation_hook_type) ();
+typedef Oid (*get_like_collation_hook_type) (void);
 extern PGDLLIMPORT get_like_collation_hook_type get_like_collation_hook;
 
 #endif							/* PG_COLLATION_H */

--- a/src/include/catalog/pg_collation.h
+++ b/src/include/catalog/pg_collation.h
@@ -111,4 +111,10 @@ extern PGDLLIMPORT PreCreateCollation_hook_type PreCreateCollation_hook;
 typedef const char * (*TranslateCollation_hook_type) (const char *collname, Oid collnamespace, int32 encoding);
 extern PGDLLIMPORT TranslateCollation_hook_type TranslateCollation_hook;
 
+typedef void (*set_like_collation_hook_type) (Oid collation);
+extern PGDLLIMPORT set_like_collation_hook_type set_like_collation_hook;
+
+typedef Oid (*get_like_collation_hook_type) ();
+extern PGDLLIMPORT get_like_collation_hook_type get_like_collation_hook;
+
 #endif							/* PG_COLLATION_H */


### PR DESCRIPTION
previously, like expression for bracket produce wrong result for :
1. [%, when there's no right bracket, % should not work as a wild character
2. the order range of character should not follow the ascii order but should follow the database natural order, for example : '='(ascii:62) should not between 0(ascii 48) to a(ascii 97)

Task: BABEL-4193'
Signed-off-by: Zhibai Song <szh@amazon.com>

### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
