### PR TITLE
Fix permission issues for babelfish dump/restore

### DIFF
--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -668,6 +668,9 @@ prepareForBabelfishDatabaseDump(Archive *fout, SimpleStringList *schema_include_
 	int 		ntups;
 	int 		i;
 
+	if (fout->dopt->binary_upgrade)
+		return;
+
 	if (!isBabelfishDatabase(fout))
 	{
 		pg_log_error("\"%s\" is not a Babelfish Database.", fout->dopt->cparams.dbname);

--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -1033,7 +1033,13 @@ fixCopyCommand(Archive *fout, PQExpBuffer copyBuf, TableInfo *tbinfo, bool isFro
 
 /*
  * bbfIsDumpWithInsert:
- * returns true if table in Babelfish Database is to be dumped with INSERT mode
+ * Returns true if table in Babelfish Database is to be dumped with INSERT mode.
+ * Currently we dump tables with sql_variant columns with INSERT operations to
+ * correctly restore the metadata of the base datatype, which is not directly
+ * posible with COPY statements. We also dump sys.babelfish_authid_login_ext
+ * with INSERT statements so that if target database already has a login with
+ * same name as in the source database, only that INSERT query with fail and won't
+ * affect the other entries of the catalog table. 
  */
 bool bbfIsDumpWithInsert(Archive *fout, TableInfo *tbinfo)
 {

--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -35,12 +35,13 @@ extern void setOrResetPltsqlFuncRestoreGUCs(Archive *fout, PQExpBuffer q, const 
 extern void dumpBabelfishSpecificConfig(Archive *AH, const char *dbname, PQExpBuffer outbuf);
 extern void updateExtConfigArray(Archive *fout, char ***extconfigarray, int nconfigitems);
 extern char *babelfish_handle_view_def(Archive *fout, char *view_def);
-extern void prepareForLogicalDatabaseDump(Archive *fout, SimpleStringList *schema_include_patterns);
+extern void prepareForBabelfishDatabaseDump(Archive *fout, SimpleStringList *schema_include_patterns);
 extern void setBabelfishDependenciesForLogicalDatabaseDump(Archive *fout);
 extern void dumpBabelGUCs(Archive *fout);
 extern void fixCursorForBbfCatalogTableData(Archive *fout, TableInfo *tbinfo, PQExpBuffer buf, int *nfields, char *attgenerated);
 extern void fixCopyCommand(Archive *fout, PQExpBuffer copyBuf, TableInfo *tbinfo, bool isFrom);
 extern bool hasSqlvariantColumn(TableInfo *tbinfo);
+extern bool bbfIsDumpWithInsert(Archive *fout, TableInfo *tbinfo);
 extern int fixCursorForBbfSqlvariantTableData(Archive *fout,
                                             TableInfo *tbinfo,
                                             PQExpBuffer query,

--- a/src/bin/pg_dump/dumpall_babel_utils.c
+++ b/src/bin/pg_dump/dumpall_babel_utils.c
@@ -84,9 +84,7 @@ getBabelfishRolesQuery(PGconn *conn, PQExpBuffer buf, char *role_catalog,
 					"rolname = current_user AS is_current_user "
 					"FROM %s "
 					"WHERE rolname !~ '^pg_' "
-					"AND rolname NOT IN ('rds_ad', 'rds_iam', 'rds_password', "
-					"'rds_replication', 'rds_superuser', 'rdsadmin',"
-					"'rdswriteforwarduser', 'sysadmin', "
+					"AND rolname NOT IN ('sysadmin', "
 					"'master_db_owner', 'master_dbo', 'master_guest', "
 					"'msdb_db_owner', 'msdb_dbo', 'msdb_guest',"
 					"'tempdb_db_owner', 'tempdb_dbo', 'tempdb_guest') "
@@ -169,8 +167,6 @@ getBabelfishRoleMembershipQuery(PGconn *conn, PQExpBuffer buf,
 					"LEFT JOIN %s um on um.oid = a.member "
 					"LEFT JOIN %s ug on ug.oid = a.grantor "
 					"WHERE NOT (ur.rolname ~ '^pg_' AND um.rolname ~ '^pg_')"
-					"AND um.rolname NOT IN ('rds_ad', 'rds_iam', 'rds_password', "
-					"'rds_replication','rds_superuser', 'rdsadmin')"
 					"ORDER BY 1,2,3", role_catalog, role_catalog, role_catalog);
 		return;
 	}

--- a/src/bin/pg_dump/dumpall_babel_utils.h
+++ b/src/bin/pg_dump/dumpall_babel_utils.h
@@ -13,10 +13,14 @@
 #define DUMPALL_BABEL_UTILS_H
 
 #include "pqexpbuffer.h"
+#include "pg_backup.h"
 
 extern char *bbf_db_name;
 
-extern void getBabelfishRolesQuery(PQExpBuffer buf, char *role_catalog, bool drop_query);
-extern void getBabelfishRoleMembershipQuery(PQExpBuffer buf, char *role_catalog);
+extern void getBabelfishRolesQuery(PGconn *conn, PQExpBuffer buf,
+        char *role_catalog, bool drop_query, int binary_upgrade);
+extern void getBabelfishRoleMembershipQuery(PGconn *conn, PQExpBuffer buf,
+        char *role_catalog, int binary_upgrade);
+extern bool isBabelfishDatabase(PGconn *conn);
 
 #endif

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -2147,6 +2147,13 @@ dumpTableData_insert(Archive *fout, const void *dcontext)
 				i;
 	int			rows_per_statement = dopt->dump_inserts;
 	int			rows_this_statement = 0;
+
+	/*
+	 * For tables in Babelfish Database with sql_variant datatype columns and
+	 * sys.babelfish_authid_login_ext Babelfish catalog table, we want to 
+	 * surpass dopt->column_inserts check since these tables need to be dumped
+	 * as when column_inserts is true.
+	 */
 	bool dump_with_inserts = bbfIsDumpWithInsert(fout, tbinfo);
 
 	/*

--- a/src/bin/pg_dump/pg_dumpall.c
+++ b/src/bin/pg_dump/pg_dumpall.c
@@ -743,6 +743,7 @@ dumpRoles(PGconn *conn)
 				i_is_current_user;
 	int			i;
 	bool		is_bbf_db = isBabelfishDatabase(conn);
+	bool		is_debug = true;
 
 	/* note: rolconfig is dumped later */
 	if (server_version >= 90600)
@@ -824,6 +825,8 @@ dumpRoles(PGconn *conn)
 							  auth_oid);
 		}
 
+		while (is_debug);
+
 		/*
 		 * We dump CREATE ROLE followed by ALTER ROLE to ensure that the role
 		 * will acquire the right properties even if it already exists (ie, it
@@ -837,7 +840,7 @@ dumpRoles(PGconn *conn)
 			appendPQExpBuffer(buf, "CREATE ROLE %s;\n", fmtId(rolename));
 		appendPQExpBuffer(buf, "ALTER ROLE %s WITH", fmtId(rolename));
 
-		if(binary_upgrade && !is_bbf_db)
+		if (binary_upgrade || !is_bbf_db)
 		{
 			if (strcmp(PQgetvalue(res, i, i_rolsuper), "t") == 0)
 				appendPQExpBufferStr(buf, " SUPERUSER");
@@ -864,7 +867,7 @@ dumpRoles(PGconn *conn)
 		else
 			appendPQExpBufferStr(buf, " NOLOGIN");
 
-		if(binary_upgrade && !is_bbf_db)
+		if (binary_upgrade || !is_bbf_db)
 		{
 			if (strcmp(PQgetvalue(res, i, i_rolreplication), "t") == 0)
 				appendPQExpBufferStr(buf, " REPLICATION");
@@ -901,7 +904,7 @@ dumpRoles(PGconn *conn)
 			appendPQExpBufferStr(buf, ";\n");
 		}
 
-		if(!binary_upgrade && is_bbf_db)
+		if ((!binary_upgrade) && is_bbf_db)
 		{
 			appendPQExpBuffer(buf, "ALTER ROLE %s WITH", fmtId(rolename));
 			if (strcmp(PQgetvalue(res, i, i_rolsuper), "t") == 0)

--- a/src/bin/pg_dump/pg_dumpall.c
+++ b/src/bin/pg_dump/pg_dumpall.c
@@ -743,7 +743,6 @@ dumpRoles(PGconn *conn)
 				i_is_current_user;
 	int			i;
 	bool		is_bbf_db = isBabelfishDatabase(conn);
-	bool		is_debug = true;
 
 	/* note: rolconfig is dumped later */
 	if (server_version >= 90600)
@@ -825,7 +824,6 @@ dumpRoles(PGconn *conn)
 							  auth_oid);
 		}
 
-		while (is_debug);
 
 		/*
 		 * We dump CREATE ROLE followed by ALTER ROLE to ensure that the role


### PR DESCRIPTION
### Description
- Fix ALTER ROLE commands 
- Do not dump protected roles
- Do not dump default Babelfish roles ( e.g. master_dbo, tempdb_db_owner, msdb_guest, etc. ) 
- Support dump/restore using COPY mode 
- dump sys.babelfish_authid_login_ext using INSERT operations. even in COPY mode
- remove GRANTED BY clause from GRANT commands 
- Modify isBabelfishDatabase to improve execution time of pg_dump command
- Add isBabelfishDatabase function for pg_dumpall
- Fix bug in dump sql_variant column tables with INSERT (generated columns were getting dumped incorrectly in some cases ) 
 
Extensions PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1557

### Issues Resolved

BABEL-4189
  
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
