### PR TITLE
Fix the bug: like expression will error out unexpectly

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -1220,6 +1220,9 @@ preprocess_qual_conditions(PlannerInfo *root, Node *jtnode)
 		preprocess_qual_conditions(root, j->larg);
 		preprocess_qual_conditions(root, j->rarg);
 
+		if(planner_node_transformer_hook)
+			j->quals = planner_node_transformer_hook(root, j->quals, EXPRKIND_QUAL);
+
 		j->quals = preprocess_expression(root, j->quals, EXPRKIND_QUAL);
 	}
 	else


### PR DESCRIPTION
Previously, like expression unexpectly error out in certain cases:
1. Like expression inside Join on condition
2. Like expression inside one of the multiple case whens
3. Like expression as one of the sublink condition in sublink query

This fix has solved those three issues by adding corresponding Like collation change transform into Like expression node.

Task: BABEL-4046

### Description

[Describe what this change achieves]
 
### Issues Resolved

[List any issues this PR will resolve]
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
