### PR TITLE
Add Index to ENR when used on temp tables, prevent temp table index recreation issue 

### DIFF
--- a/src/backend/catalog/dependency.c
+++ b/src/backend/catalog/dependency.c
@@ -951,6 +951,7 @@ findDependentObjects(const ObjectAddress *object,
 		dependentObjects[numDependentObjects].subflags = subflags;
 		numDependentObjects++;
 	}
+
 	systable_endscan(scan);
 
 	/*

--- a/src/backend/catalog/dependency.c
+++ b/src/backend/catalog/dependency.c
@@ -497,7 +497,6 @@ findDependentObjects(const ObjectAddress *object,
 	int			maxDependentObjects;
 	ObjectAddressStack mystack;
 	ObjectAddressExtra extra;
-	bool is_enr;
 
 	/*
 	 * If the target object is already being visited in an outer recursion
@@ -952,84 +951,7 @@ findDependentObjects(const ObjectAddress *object,
 		dependentObjects[numDependentObjects].subflags = subflags;
 		numDependentObjects++;
 	}
-	is_enr = scan->enr;
 	systable_endscan(scan);
-
-	/* Indices for temp tables will leave metadata in pg_catalog, so we should clean them up here. */
-	if (is_enr)
-	{
-		/* This will force a non-ENR scan */
-		sql_dialect = SQL_DIALECT_PG;
-		scan = systable_beginscan(*depRel, DependReferenceIndexId, true,
-								NULL, nkeys, key);
-		sql_dialect = SQL_DIALECT_TSQL;
-		
-		while (HeapTupleIsValid(tup = systable_getnext(scan)))
-		{
-			Form_pg_depend foundDep = (Form_pg_depend) GETSTRUCT(tup);
-			int			subflags;
-
-			otherObject.classId = foundDep->classid;
-			otherObject.objectId = foundDep->objid;
-			otherObject.objectSubId = foundDep->objsubid;
-
-			if (otherObject.classId == object->classId &&
-				otherObject.objectId == object->objectId &&
-				object->objectSubId == 0)
-				continue;
-
-			AcquireDeletionLock(&otherObject, 0);
-
-			if (!systable_recheck_tuple(scan, tup))
-			{
-				ReleaseDeletionLock(&otherObject);
-				continue;
-			}
-
-			switch (foundDep->deptype)
-			{
-				case DEPENDENCY_NORMAL:
-					subflags = DEPFLAG_NORMAL;
-					break;
-				case DEPENDENCY_AUTO:
-				case DEPENDENCY_AUTO_EXTENSION:
-					subflags = DEPFLAG_AUTO;
-					break;
-				case DEPENDENCY_INTERNAL:
-					subflags = DEPFLAG_INTERNAL;
-					break;
-				case DEPENDENCY_PARTITION_PRI:
-				case DEPENDENCY_PARTITION_SEC:
-					subflags = DEPFLAG_PARTITION;
-					break;
-				case DEPENDENCY_EXTENSION:
-					subflags = DEPFLAG_EXTENSION;
-					break;
-				default:
-					elog(ERROR, "unrecognized dependency type '%c' for %s",
-						foundDep->deptype, getObjectDescription(object, false));
-					subflags = 0;
-					break;
-			}
-
-			if (numDependentObjects >= maxDependentObjects)
-			{
-				maxDependentObjects *= 2;
-				dependentObjects = (ObjectAddressAndFlags *)
-					repalloc(dependentObjects,
-							maxDependentObjects * sizeof(ObjectAddressAndFlags));
-			}
-
-			dependentObjects[numDependentObjects].obj = otherObject;
-			dependentObjects[numDependentObjects].subflags = subflags;
-			numDependentObjects++;
-		}
-		
-
-		systable_endscan(scan);
-		
-	}
-	
 
 	/*
 	 * Now we can sort the dependent objects into a stable visitation order.

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1070,7 +1070,7 @@ AddNewRelationType(const char *typeName,
 }
 
 /* -------------------------------
- *      CheckTempTableDependencies
+ *      CheckTempTableHasDependencies
  *
  *		User-defined types in TSQL will have typacl set. Types created during
  *		Babelfish initialization such as nvarchar will not, so we can use typacl
@@ -1079,7 +1079,7 @@ AddNewRelationType(const char *typeName,
  *      Returns true if there are dependencies on
  *		- User defined data types
  */
-static bool CheckTempTableHasDependencies(TupleDesc tupdesc)
+bool CheckTempTableHasDependencies(TupleDesc tupdesc)
 {
 	int i;
 	int	natts = tupdesc->natts;

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -22,7 +22,6 @@
 #include "postgres.h"
 
 #include <unistd.h>
-#include <string.h>
 
 #include "access/amapi.h"
 #include "access/heapam.h"
@@ -754,8 +753,7 @@ index_create(Relation heapRelation,
 		 * PRIMARY KEYs and/or CONSTRAINTs.
 		 */
 		is_enr = (indexRelationName && strlen(indexRelationName) > 0 &&
-			(indexRelationName[0] == '@' || (strchr(indexRelationName, '#') != NULL
-			&& get_ENR_withoid(currentQueryEnv, heapRelationId, ENR_TSQL_TEMP))));
+			(indexRelationName[0] == '@' || get_ENR_withoid(currentQueryEnv, heapRelationId, ENR_TSQL_TEMP)));
 	}
 
 	relkind = partitioned ? RELKIND_PARTITIONED_INDEX : RELKIND_INDEX;

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -750,8 +750,10 @@ index_create(Relation heapRelation,
  		 * Index of Table Variables should also be in ENR and the index
 		 * can only be created as part of DECLARE @[name] TABLE;
 		 * when specifying PRIMARY KEYs and/or CONSTRAINTs.
+		 *
+		 * Indexes of temp tables should be in enr as well, to prevent cache issues.
 		 */
-		is_enr = (indexRelationName && strlen(indexRelationName) > 0 && indexRelationName[0] == '@');
+		is_enr = (indexRelationName && strlen(indexRelationName) > 0 && (indexRelationName[0] == '@' || indexRelationName[0] == '#'));
 	}
 
 	relkind = partitioned ? RELKIND_PARTITIONED_INDEX : RELKIND_INDEX;

--- a/src/include/catalog/heap.h
+++ b/src/include/catalog/heap.h
@@ -145,6 +145,8 @@ extern void CheckAttributeType(const char *attname,
 							   List *containing_rowtypes,
 							   int flags);
 
+extern bool CheckTempTableHasDependencies(TupleDesc tupdesc);
+
 /* pg_partitioned_table catalog manipulation functions */
 extern void StorePartitionKey(Relation rel,
 							  char strategy,


### PR DESCRIPTION
### Description

With this change, we add newly created indexes to ENR when used on temp tables, to match Table Variable behavior in these cases.

In addition, we add an extra scan in findDependentObjects to properly clean up index objects left in catalog when used with temp tables. Previously, entries would be left in pg_catalog, which would prevent recreating the same table with the same index name. This change also prevents rare cases of dangling catalog entries in cases where we aren't able to clean up properly, such as in a crash.
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
