### PR TITLE
Introduce drop_relation_refcnt_hook to be called during drop table

### DIFF
--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -78,6 +78,7 @@
 
 InvokePreAddConstraintsHook_type InvokePreAddConstraintsHook = NULL;
 transform_check_constraint_expr_hook_type transform_check_constraint_expr_hook = NULL;
+drop_relation_refcnt_hook_type drop_relation_refcnt_hook = NULL;
 
 /* Potentially set by pg_upgrade_support functions */
 Oid			binary_upgrade_next_heap_pg_class_oid = InvalidOid;
@@ -1904,6 +1905,9 @@ heap_drop_with_catalog(Oid relid)
 	 * Open and lock the relation.
 	 */
 	rel = relation_open(relid, AccessExclusiveLock);
+
+	if (drop_relation_refcnt_hook)
+		drop_relation_refcnt_hook(rel);
 
 	/*
 	 * There can no longer be anyone *else* touching the relation, but we

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -2199,6 +2199,9 @@ index_drop(Oid indexId, bool concurrent, bool concurrent_lock_mode)
 	userHeapRelation = table_open(heapId, lockmode);
 	userIndexRelation = index_open(indexId, lockmode);
 
+	if (drop_relation_refcnt_hook)
+		drop_relation_refcnt_hook(userIndexRelation);
+
 	/*
 	 * We might still have open queries using it in our own session, which the
 	 * above locking won't prevent, so test explicitly.

--- a/src/include/catalog/heap.h
+++ b/src/include/catalog/heap.h
@@ -161,4 +161,7 @@ extern void StorePartitionBound(Relation rel, Relation parent,
 typedef Node* (*transform_check_constraint_expr_hook_type) (Node *node);
 extern PGDLLIMPORT transform_check_constraint_expr_hook_type transform_check_constraint_expr_hook;
 
+typedef void (*drop_relation_refcnt_hook_type) (Relation rel);
+extern PGDLLIMPORT drop_relation_refcnt_hook_type drop_relation_refcnt_hook;
+
 #endif							/* HEAP_H */


### PR DESCRIPTION
Introduce drop_relation_refcnt_hook to be called during drop table variable when BBF error handling does not properly close table variables

There were three options discussed 

1. Integrate a new hook function in heap_drop_with_catalog() and index_drop() to decrement refcnt before dropping. This is the preferred one and the cleanest approach.

2. As part of error handling, open relation in pltsql_clean_table_variables and pltsql_remove_current_query_env and decrement refcount there. The reason this was rejected is because for each relation, it needs to open all index and toast tables and decrement their refcounts as well. The code would become a bit complicated and long.

3. Skip table variable cleanup if an error is encountered inside a function let caller do it, that way caller will call rollback and issue will not arise. The reason this was rejected is because we would go out of scope and would not be able to cleanup the table variable once we exit the function.

extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1569

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
