### PR TITLE
Fix UNION ORDER BY issue with multiple joins

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -85,7 +85,7 @@ set_target_table_alternative_hook_type set_target_table_alternative_hook = NULL;
 pre_transform_setop_tree_hook_type pre_transform_setop_tree_hook = NULL;
 
 /* Hook to reset a query's targetlist after modification in pre_transfrom_sort_clause */
-post_transform_sort_clause_hook_type post_transform_sort_clause_hook = NULL;
+post_transform_sort_clause_hook2_type post_transform_sort_clause_hook2 = NULL;
 
 static Query *transformOptionalSelectInto(ParseState *pstate, Node *parseTree);
 static Query *transformDeleteStmt(ParseState *pstate, DeleteStmt *stmt);
@@ -1940,8 +1940,8 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 										  EXPR_KIND_ORDER_BY,
 										  false /* allow SQL92 rules */ );
 
-	if (post_transform_sort_clause_hook)
-		post_transform_sort_clause_hook(qry, leftmostQuery);
+	if (post_transform_sort_clause_hook2)
+		post_transform_sort_clause_hook2(qry, leftmostQuery);
 
 	/* restore namespace, remove join RTE from rtable */
 	pstate->p_namespace = sv_namespace;

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -85,7 +85,7 @@ set_target_table_alternative_hook_type set_target_table_alternative_hook = NULL;
 pre_transform_setop_tree_hook_type pre_transform_setop_tree_hook = NULL;
 
 /* Hook to reset a query's targetlist after modification in pre_transfrom_sort_clause */
-post_transform_sort_clause_hook2_type post_transform_sort_clause_hook2 = NULL;
+post_transform_sort_clause_hook_type post_transform_sort_clause_hook = NULL;
 
 static Query *transformOptionalSelectInto(ParseState *pstate, Node *parseTree);
 static Query *transformDeleteStmt(ParseState *pstate, DeleteStmt *stmt);
@@ -1940,8 +1940,8 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 										  EXPR_KIND_ORDER_BY,
 										  false /* allow SQL92 rules */ );
 
-	if (post_transform_sort_clause_hook2)
-		post_transform_sort_clause_hook2(qry, leftmostQuery);
+	if (post_transform_sort_clause_hook)
+		post_transform_sort_clause_hook(qry, leftmostQuery);
 
 	/* restore namespace, remove join RTE from rtable */
 	pstate->p_namespace = sv_namespace;

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -45,7 +45,6 @@
 #include "parser/parse_relation.h"
 #include "parser/parse_target.h"
 #include "parser/parse_type.h"
-#include "parser/parser.h"
 #include "parser/parsetree.h"
 #include "rewrite/rewriteManip.h"
 #include "utils/backend_status.h"
@@ -1936,10 +1935,10 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 	tllen = list_length(qry->targetList);
 
 	qry->sortClause = transformSortClause(pstate,
-										sortClause,
-										&qry->targetList,
-										EXPR_KIND_ORDER_BY,
-										false /* allow SQL92 rules */ );
+										  sortClause,
+										  &qry->targetList,
+										  EXPR_KIND_ORDER_BY,
+										  false /* allow SQL92 rules */ );
 
 	if (post_transform_sort_clause_hook)
 		post_transform_sort_clause_hook(qry, leftmostQuery);

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -53,7 +53,6 @@
 #include "utils/syscache.h"
 
 tle_name_comparison_hook_type  tle_name_comparison_hook = NULL;
-post_transform_from_clause_hook_type  post_transform_from_clause_hook = NULL;
 
 sortby_nulls_hook_type  sortby_nulls_hook = NULL;
 
@@ -154,13 +153,6 @@ transformFromClause(ParseState *pstate, List *frmList)
 	 * but those should have been that way already.
 	 */
 	setNamespaceLateralState(pstate->p_namespace, false, true);
-
-	/* 
-	 * Save the namespace -- tsql needs the leftmost select's namespace to
-	 * resolve some ORDER BY clauses used with set operations (i.e. UNION) 
-	 */
-	if (post_transform_from_clause_hook)
-		post_transform_from_clause_hook(pstate);
 }
 
 /*

--- a/src/include/parser/analyze.h
+++ b/src/include/parser/analyze.h
@@ -61,10 +61,6 @@ typedef void (*pre_transform_setop_tree_hook_type) (SelectStmt *stmt, SelectStmt
 extern PGDLLIMPORT pre_transform_setop_tree_hook_type pre_transform_setop_tree_hook;
 
 /* Hook for handle target table before transforming from clause */
-typedef void (*pre_transform_sort_clause_hook_type) (ParseState *pstate, Query *qry, Query *leftmostQuery);
-extern PGDLLIMPORT pre_transform_sort_clause_hook_type pre_transform_sort_clause_hook;
-
-/* Hook for handle target table before transforming from clause */
 typedef void (*post_transform_sort_clause_hook_type) (Query *qry, Query *leftmostQuery);
 extern PGDLLIMPORT post_transform_sort_clause_hook_type post_transform_sort_clause_hook;
 

--- a/src/include/parser/analyze.h
+++ b/src/include/parser/analyze.h
@@ -57,15 +57,15 @@ typedef int (*set_target_table_alternative_hook_type) (ParseState *pstate, Node 
 extern PGDLLIMPORT set_target_table_alternative_hook_type set_target_table_alternative_hook;
 
 /* Hook for handle target table before transforming from clause */
-typedef void (*push_namespace_stack_hook_type) ();
-extern PGDLLIMPORT push_namespace_stack_hook_type push_namespace_stack_hook;
+typedef void (*pre_transform_setop_tree_hook_type) (SelectStmt *stmt, SelectStmt *leftmostSelect);
+extern PGDLLIMPORT pre_transform_setop_tree_hook_type pre_transform_setop_tree_hook;
 
 /* Hook for handle target table before transforming from clause */
 typedef void (*pre_transform_sort_clause_hook_type) (ParseState *pstate, Query *qry, Query *leftmostQuery);
 extern PGDLLIMPORT pre_transform_sort_clause_hook_type pre_transform_sort_clause_hook;
 
 /* Hook for handle target table before transforming from clause */
-typedef void (*post_transform_sort_clause_hook_type) (Query *qry);
+typedef void (*post_transform_sort_clause_hook_type) (Query *qry, Query *leftmostQuery);
 extern PGDLLIMPORT post_transform_sort_clause_hook_type post_transform_sort_clause_hook;
 
 extern Query *parse_analyze_fixedparams(RawStmt *parseTree, const char *sourceText,

--- a/src/include/parser/analyze.h
+++ b/src/include/parser/analyze.h
@@ -56,13 +56,21 @@ extern PGDLLIMPORT post_transform_insert_row_hook_type post_transform_insert_row
 typedef int (*set_target_table_alternative_hook_type) (ParseState *pstate, Node *stmt, CmdType command);
 extern PGDLLIMPORT set_target_table_alternative_hook_type set_target_table_alternative_hook;
 
-/* Hook for handle target table before transforming from clause */
+typedef void (*push_namespace_stack_hook_type) ();
+extern PGDLLIMPORT push_namespace_stack_hook_type push_namespace_stack_hook;
+
+typedef void (*pre_transform_sort_clause_hook_type) (ParseState *pstate, Query *qry, Query *leftmostQuery);
+extern PGDLLIMPORT pre_transform_sort_clause_hook_type pre_transform_sort_clause_hook;
+
+typedef void (*post_transform_sort_clause_hook_type) (Query *qry);
+extern PGDLLIMPORT post_transform_sort_clause_hook_type post_transform_sort_clause_hook;
+
 typedef void (*pre_transform_setop_tree_hook_type) (SelectStmt *stmt, SelectStmt *leftmostSelect);
 extern PGDLLIMPORT pre_transform_setop_tree_hook_type pre_transform_setop_tree_hook;
 
 /* Hook for handle target table before transforming from clause */
-typedef void (*post_transform_sort_clause_hook_type) (Query *qry, Query *leftmostQuery);
-extern PGDLLIMPORT post_transform_sort_clause_hook_type post_transform_sort_clause_hook;
+typedef void (*post_transform_sort_clause_hook2_type) (Query *qry, Query *leftmostQuery);
+extern PGDLLIMPORT post_transform_sort_clause_hook2_type post_transform_sort_clause_hook2;
 
 extern Query *parse_analyze_fixedparams(RawStmt *parseTree, const char *sourceText,
 										const Oid *paramTypes, int numParams, QueryEnvironment *queryEnv);

--- a/src/include/parser/analyze.h
+++ b/src/include/parser/analyze.h
@@ -56,21 +56,13 @@ extern PGDLLIMPORT post_transform_insert_row_hook_type post_transform_insert_row
 typedef int (*set_target_table_alternative_hook_type) (ParseState *pstate, Node *stmt, CmdType command);
 extern PGDLLIMPORT set_target_table_alternative_hook_type set_target_table_alternative_hook;
 
-typedef void (*push_namespace_stack_hook_type) ();
-extern PGDLLIMPORT push_namespace_stack_hook_type push_namespace_stack_hook;
-
-typedef void (*pre_transform_sort_clause_hook_type) (ParseState *pstate, Query *qry, Query *leftmostQuery);
-extern PGDLLIMPORT pre_transform_sort_clause_hook_type pre_transform_sort_clause_hook;
-
-typedef void (*post_transform_sort_clause_hook_type) (Query *qry);
-extern PGDLLIMPORT post_transform_sort_clause_hook_type post_transform_sort_clause_hook;
-
+/* Hook for handle target table before transforming from clause */
 typedef void (*pre_transform_setop_tree_hook_type) (SelectStmt *stmt, SelectStmt *leftmostSelect);
 extern PGDLLIMPORT pre_transform_setop_tree_hook_type pre_transform_setop_tree_hook;
 
 /* Hook for handle target table before transforming from clause */
-typedef void (*post_transform_sort_clause_hook2_type) (Query *qry, Query *leftmostQuery);
-extern PGDLLIMPORT post_transform_sort_clause_hook2_type post_transform_sort_clause_hook2;
+typedef void (*post_transform_sort_clause_hook_type) (Query *qry, Query *leftmostQuery);
+extern PGDLLIMPORT post_transform_sort_clause_hook_type post_transform_sort_clause_hook;
 
 extern Query *parse_analyze_fixedparams(RawStmt *parseTree, const char *sourceText,
 										const Oid *paramTypes, int numParams, QueryEnvironment *queryEnv);

--- a/src/include/parser/parse_clause.h
+++ b/src/include/parser/parse_clause.h
@@ -54,6 +54,9 @@ extern bool targetIsInSortList(TargetEntry *tle, Oid sortop, List *sortList);
 typedef bool (*tle_name_comparison_hook_type)(const char *tlename, const char *identifier);
 extern PGDLLIMPORT tle_name_comparison_hook_type tle_name_comparison_hook;
 
+typedef void (*post_transform_from_clause_hook_type)(ParseState *pstate);
+extern PGDLLIMPORT post_transform_from_clause_hook_type post_transform_from_clause_hook;
+
 typedef void (*sortby_nulls_hook_type)(SortGroupClause *sortcl, bool reverse);
 extern PGDLLIMPORT sortby_nulls_hook_type sortby_nulls_hook;
 

--- a/src/include/parser/parse_clause.h
+++ b/src/include/parser/parse_clause.h
@@ -54,9 +54,6 @@ extern bool targetIsInSortList(TargetEntry *tle, Oid sortop, List *sortList);
 typedef bool (*tle_name_comparison_hook_type)(const char *tlename, const char *identifier);
 extern PGDLLIMPORT tle_name_comparison_hook_type tle_name_comparison_hook;
 
-typedef void (*post_transform_from_clause_hook_type)(ParseState *pstate);
-extern PGDLLIMPORT post_transform_from_clause_hook_type post_transform_from_clause_hook;
-
 typedef void (*sortby_nulls_hook_type)(SortGroupClause *sortcl, bool reverse);
 extern PGDLLIMPORT sortby_nulls_hook_type sortby_nulls_hook;
 


### PR DESCRIPTION
### Description

When performing a set operation, specifying a ORDER BY clause with a two-part table name could cause crashes when that table was the 3rd or later joined table. This change fixes that issue by modifying previous work related to supporting UNION ORDER BY. ORDER BY clauses are now passed to the leftmost select statement for analysis.
 
### Issues Resolved

BABEL-4210
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
