### PR TITLE
Fixed segmentation fault occuring due to already freed AfterTriggersTableData

### DIFF
--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -5575,7 +5575,7 @@ AfterTriggerFreeQuery(AfterTriggersQueryData *qs, bool free_tables)
 		tuplestore_end(ts);
 
 	/* Babelfish triggers will remove transition tables later */
-	if (!free_tables)
+	if (!free_tables && afterTriggers.query_depth >= compositeTriggers.triggers->query_depth)
 	{
 		qs->tables = NIL;
 		return;
@@ -7371,7 +7371,7 @@ void EndCompositeTriggers(bool error)
 		 * to avoid seg fault issues.
 		 */ 
 		if (afterTriggers.query_depth < afterTriggers.maxquerydepth && afterTriggers.query_depth >= triggers->query_depth)
-			afterTriggers.query_stack[afterTriggers.query_depth].tables = NIL;
+			afterTriggers.query_stack[triggers->query_depth].tables = NIL;
 
 		pfree(triggers);
 	}

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -7370,7 +7370,8 @@ void EndCompositeTriggers(bool error)
 		 * So, setting reference to AfterTriggersTableData to the NIL explicitly here 
 		 * to avoid seg fault issues.
 		 */ 
-		afterTriggers.query_stack[triggers->query_depth].tables = NIL;
+		if (afterTriggers.query_depth > -1)
+			afterTriggers.query_stack[triggers->query_depth].tables = NIL;
 
 		pfree(triggers);
 	}

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -7370,7 +7370,7 @@ void EndCompositeTriggers(bool error)
 		 * So, setting reference to AfterTriggersTableData to the NIL explicitly here 
 		 * to avoid seg fault issues.
 		 */ 
-		if (afterTriggers.query_depth > -1)
+		if (afterTriggers.query_depth < afterTriggers.maxquerydepth && afterTriggers.query_depth >= triggers->query_depth)
 			afterTriggers.query_stack[triggers->query_depth].tables = NIL;
 
 		pfree(triggers);

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -7370,8 +7370,7 @@ void EndCompositeTriggers(bool error)
 		 * So, setting reference to AfterTriggersTableData to the NIL explicitly here 
 		 * to avoid seg fault issues.
 		 */ 
-		if (afterTriggers.query_depth < afterTriggers.maxquerydepth && afterTriggers.query_depth >= triggers->query_depth)
-			afterTriggers.query_stack[triggers->query_depth].tables = NIL;
+		afterTriggers.query_stack[triggers->query_depth].tables = NIL;
 
 		pfree(triggers);
 	}

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -7304,7 +7304,7 @@ bool FreeTriggerTable(int query_depth)
 static
 void AddCompositeTriggerLevelData(void)
 {
-	/* Check if this trigger is being added as part of any of postgres' function, procedure or trigger in the stack.*/
+	/* Check if this trigger is being added as part of any of postgres' function, procedure or trigger in the stack */
 	if (check_pltsql_support_tsql_transactions_hook && !(*check_pltsql_support_tsql_transactions_hook)())
 	{
 		ereport(ERROR,

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -7291,8 +7291,7 @@ bool IsCompositeTriggerActive(void)
 static
 bool FreeTriggerTable(int query_depth)
 {
-	return (!IsCompositeTriggerActive() && 
-			(compositeTriggers.triggers && compositeTriggers.triggers->query_depth == query_depth));
+	return (!IsCompositeTriggerActive() || compositeTriggers.triggers->query_depth != query_depth);
 }
 
 

--- a/src/include/commands/trigger.h
+++ b/src/include/commands/trigger.h
@@ -334,4 +334,7 @@ extern void EndCompositeTriggers(bool error);
 
 extern bool TsqlRecuresiveCheck(ResultRelInfo *resultRelInfo);
 
+typedef bool (*check_pltsql_support_tsql_transactions_hook_type) (void);
+extern PGDLLIMPORT check_pltsql_support_tsql_transactions_hook_type check_pltsql_support_tsql_transactions_hook;
+
 #endif							/* TRIGGER_H */


### PR DESCRIPTION
### Description
Recently, we discovered a crash which was happening due to double freeing of AfterTriggersTableData (composite trigger data). Crash was due to freeing AfterTriggersTableData at incorrect query_depth in case of error raised during execution of PG trigger defined on TSQL table and then we are trying to clean up the same data during AfterTriggerEndSubXact which is causing segmentation fault. This commit fixes this crash by appropriately checking query_depth before attempting to clean up AfterTriggersTableData. 

Additionally, this commit also blocks executing T-SQL trigger when there is any Postgres' function, procedure or trigger is in the call stack.

Testing: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1572

Task: BABEL-4220
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>

### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
