### PR TITLE
Support IDENTITY() function in SELECT-INTO

### DIFF
--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -77,6 +77,7 @@
 /* Hook for plugins to get control in ProcessUtility() */
 ProcessUtility_hook_type ProcessUtility_hook = NULL;
 bbfCustomProcessUtility_hook_type bbfCustomProcessUtility_hook = NULL;
+bbfSelectIntoUtility_hook_type bbfSelectIntoUtility_hook = NULL;
 
 /* local function declarations */
 static int	ClassifyUtilityCommandAsReadOnly(Node *parsetree);
@@ -1681,8 +1682,14 @@ ProcessUtilitySlow(ParseState *pstate,
 				break;
 
 			case T_CreateTableAsStmt:
-				address = ExecCreateTableAs(pstate, (CreateTableAsStmt *) parsetree,
-											params, queryEnv, qc);
+				{
+					if(sql_dialect == SQL_DIALECT_TSQL && bbfSelectIntoUtility_hook)
+						(*bbfSelectIntoUtility_hook)(pstate, pstmt, queryString, NULL, params, qc);
+					else{
+						address = ExecCreateTableAs(pstate, (CreateTableAsStmt *) parsetree,
+									params, queryEnv, qc);
+					}
+				}
 				break;
 
 			case T_RefreshMatViewStmt:

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -117,6 +117,8 @@ typedef struct IntoClause
 	char	   *tableSpaceName; /* table space to use, or NULL */
 	Node	   *viewQuery;		/* materialized view's SELECT query */
 	bool		skipData;		/* true for WITH NO DATA */
+	char       *identityName;	/* resname for Identity Column*/
+	char       *identityType; 	/* pg type for Identity Column*/
 } IntoClause;
 
 

--- a/src/include/tcop/utility.h
+++ b/src/include/tcop/utility.h
@@ -111,5 +111,11 @@ extern bool CommandIsReadOnly(PlannedStmt *pstmt);
 typedef bool (*bbfCustomProcessUtility_hook_type)(struct ParseState *pstate, PlannedStmt *pstmt, const char *queryString, ProcessUtilityContext context, 
 						  ParamListInfo params, QueryCompletion *qc);
 extern PGDLLIMPORT bbfCustomProcessUtility_hook_type bbfCustomProcessUtility_hook;
+typedef void (*bbfSelectIntoUtility_hook_type)(struct ParseState *pstate, PlannedStmt *pstmt, const char *queryString, QueryEnvironment *queryEnv, 
+						  ParamListInfo params, QueryCompletion *qc);
+extern PGDLLIMPORT bbfSelectIntoUtility_hook_type bbfSelectIntoUtility_hook;
+
+typedef void (*bbfSelectIntoAddIdentity_hook_type)(IntoClause *into, List *tableElts);
+extern PGDLLIMPORT bbfSelectIntoAddIdentity_hook_type bbfSelectIntoAddIdentity_hook;
 
 #endif							/* UTILITY_H */


### PR DESCRIPTION
Engine changes for Identity support
Added hooks for identity
Added fields in into clause to pass information about identity column

Task : BABEL-539

 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
