### PR TITLE
Add Index to ENR when used on temp tables, prevent temp table index r…

### DIFF
--- a/src/backend/catalog/dependency.c
+++ b/src/backend/catalog/dependency.c
@@ -76,6 +76,7 @@
 #include "commands/typecmds.h"
 #include "funcapi.h"
 #include "nodes/nodeFuncs.h"
+#include "parser/parser.h"
 #include "parser/parsetree.h"
 #include "rewrite/rewriteRemove.h"
 #include "storage/lmgr.h"

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1069,7 +1069,7 @@ AddNewRelationType(const char *typeName,
 }
 
 /* -------------------------------
- *      CheckTempTableDependencies
+ *      CheckTempTableHasDependencies
  *
  *		User-defined types in TSQL will have typacl set. Types created during
  *		Babelfish initialization such as nvarchar will not, so we can use typacl
@@ -1078,7 +1078,7 @@ AddNewRelationType(const char *typeName,
  *      Returns true if there are dependencies on
  *		- User defined data types
  */
-static bool CheckTempTableHasDependencies(TupleDesc tupdesc)
+bool CheckTempTableHasDependencies(TupleDesc tupdesc)
 {
 	int i;
 	int	natts = tupdesc->natts;

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -747,11 +747,13 @@ index_create(Relation heapRelation,
 	if (sql_dialect == SQL_DIALECT_TSQL && heapRelation->rd_rel->relpersistence == RELPERSISTENCE_TEMP)
 	{
 		/*
- 		 * Index of Table Variables should also be in ENR and the index
-		 * can only be created as part of DECLARE @[name] TABLE;
-		 * when specifying PRIMARY KEYs and/or CONSTRAINTs.
+		 * Index of temp objects in ENR should also be in ENR.
+		 * For table variables, index can only be created as
+		 * part of DECLARE @[name] TABLE; when specifying
+		 * PRIMARY KEYs and/or CONSTRAINTs.
 		 */
-		is_enr = (indexRelationName && strlen(indexRelationName) > 0 && indexRelationName[0] == '@');
+		is_enr = (indexRelationName && strlen(indexRelationName) > 0 &&
+			(indexRelationName[0] == '@' || get_ENR_withoid(currentQueryEnv, heapRelationId, ENR_TSQL_TEMP)));
 	}
 
 	relkind = partitioned ? RELKIND_PARTITIONED_INDEX : RELKIND_INDEX;

--- a/src/include/catalog/heap.h
+++ b/src/include/catalog/heap.h
@@ -145,6 +145,8 @@ extern void CheckAttributeType(const char *attname,
 							   List *containing_rowtypes,
 							   int flags);
 
+extern bool CheckTempTableHasDependencies(TupleDesc tupdesc);
+
 /* pg_partitioned_table catalog manipulation functions */
 extern void StorePartitionKey(Relation rel,
 							  char strategy,


### PR DESCRIPTION
…ecreation issue  (#151)

* Enable index in ENR for temp tables; fix recreation issue with indexed temp tables

* Remove extra scan, add all indexes to temp tables, check for dependencies

* Use get_ENR_withoid instead of CheckTempTableHasDependencies.

* Remove unnecessary strchr call

### Description

[Describe what this change achieves]
 
### Issues Resolved

[List any issues this PR will resolve]
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
