### PR TITLE
Sort ENR before deletion to avoid dependency issues

### DIFF
--- a/src/backend/catalog/dependency.c
+++ b/src/backend/catalog/dependency.c
@@ -76,7 +76,6 @@
 #include "commands/typecmds.h"
 #include "funcapi.h"
 #include "nodes/nodeFuncs.h"
-#include "parser/parser.h"
 #include "parser/parsetree.h"
 #include "rewrite/rewriteRemove.h"
 #include "storage/lmgr.h"

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -955,40 +955,37 @@ ENRDropTempTables(QueryEnvironment *queryEnv)
 {
 	ListCell   *lc = NULL;
 	ObjectAddress object;
+	ObjectAddresses *objects;
 
 	if (!queryEnv)
 		return;
 
-	object.classId = RelationRelationId;
-	object.objectSubId = 0;
+	objects = new_object_addresses();
 
 	/*
 	 * Loop through the registered ENRs to drop temp tables.
 	 */
-	while (lc || (lc = list_head(queryEnv->namedRelList)))
+	foreach(lc, queryEnv->namedRelList)
 	{
-		EphemeralNamedRelation enr;
+		EphemeralNamedRelation enr = (EphemeralNamedRelation) lfirst(lc);
 
-		enr = (EphemeralNamedRelation) lfirst(lc);
+		if (enr->md.enrtype != ENR_TSQL_TEMP)
+			continue;
 
-		if (enr->md.enrtype != ENR_TSQL_TEMP) {
-			lc = lnext(queryEnv->namedRelList, lc);
-			if (!lc)
-				break;
-			else
-				continue;
-		}
-
-		/*
-		 * performDeletion() will remove the table AND the ENR entry, so no
-		 * need to remove the entry afterwards.
-		 */
+		object.classId = RelationRelationId;
+		object.objectSubId = 0;
 		object.objectId = enr->md.reliddesc;
-		performDeletion(&object, DROP_CASCADE, PERFORM_DELETION_INTERNAL | PERFORM_DELETION_QUIETLY);
-
-		/* Reset lc so we can read the head of the list */
-		lc = NULL;
+		add_exact_object_address(&object, objects);
 	}
+
+	/*
+	 * performMultipleDeletions() will remove the table AND the ENR entry,
+	 * so no need to remove the entry afterwards. Sort addresses beforehand
+	 * so that we don't run into dependency issues when dropping objects.
+	 */
+	sort_object_addresses(objects);
+	performMultipleDeletions(objects, DROP_CASCADE, PERFORM_DELETION_INTERNAL | PERFORM_DELETION_QUIETLY);
+	free_object_addresses(objects);
 }
 
 /*

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -980,10 +980,9 @@ ENRDropTempTables(QueryEnvironment *queryEnv)
 
 	/*
 	 * performMultipleDeletions() will remove the table AND the ENR entry,
-	 * so no need to remove the entry afterwards. Sort addresses beforehand
-	 * so that we don't run into dependency issues when dropping objects.
+	 * so no need to remove the entry afterwards. It also takes care of
+	 * proper object drop order, to prevent dependency issues.
 	 */
-	sort_object_addresses(objects);
 	performMultipleDeletions(objects, DROP_CASCADE, PERFORM_DELETION_INTERNAL | PERFORM_DELETION_QUIETLY);
 	free_object_addresses(objects);
 }


### PR DESCRIPTION
### Description

Sort ENR, similar to findDependentObjects, before deletion. This avoids situations where ENR objects are cleaned up in the wrong order, which will throw an error in some cases. For example, in this case: 

```
1> create procedure p
2> as
3> begin
4>      create table #t (id int identity(1,1))
5>      --drop table #t  -- when uncommenting this line, no error is raised
6> end
7> go
1>
2> exec p
3> go
Msg 3723, Level 16, State 1, Server BABELFISH, Line 1
cannot drop sequence "#t_id_seq" because column id of table "#t" requires it
```

An error is thrown due to ENRDropTempTables attempting to drop the sequence #t_id_seq before dropping table #t. In findDependentObjects, dependent objects are sorted into a stable visitation order, so we should do the same in ENRDropTempTables. 
 
### Issues Resolved

BABEL-3168 - Implicit drop in procedure of #tmp table with IDENTITY column raises error
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
