### PR TITLE
Loss of decimal digits when converting from REAL to DECIMAL

### DIFF
--- a/src/backend/utils/adt/numeric.c
+++ b/src/backend/utils/adt/numeric.c
@@ -103,6 +103,8 @@ typedef signed char NumericDigit;
 typedef int16 NumericDigit;
 #endif
 
+#define BABEL_MAX_PRECISION 38
+
 /*
  * The Numeric type as stored on disk.
  *
@@ -4535,7 +4537,10 @@ float4_numeric(PG_FUNCTION_ARGS)
 			PG_RETURN_NUMERIC(make_result(&const_pinf));
 	}
 
-	snprintf(buf, sizeof(buf), "%.*g", FLT_DIG, val);
+	if (sql_dialect == SQL_DIALECT_TSQL)
+		snprintf(buf, sizeof(buf), "%.*f", BABEL_MAX_PRECISION, val);
+	else
+		snprintf(buf, sizeof(buf), "%.*g", FLT_DIG, val);
 
 	init_var(&result);
 

--- a/src/backend/utils/adt/numeric.c
+++ b/src/backend/utils/adt/numeric.c
@@ -4538,7 +4538,7 @@ float4_numeric(PG_FUNCTION_ARGS)
 	}
 
 	if (sql_dialect == SQL_DIALECT_TSQL)
-		snprintf(buf, sizeof(buf), "%.*f", BABEL_MAX_PRECISION, val);
+		snprintf(buf, sizeof(buf), "%.*g", BABEL_MAX_PRECISION, val);
 	else
 		snprintf(buf, sizeof(buf), "%.*g", FLT_DIG, val);
 


### PR DESCRIPTION
### Description
Initially we were using "%.*g" to write to buffer. This can use scientific notation as well. Now, FLT_DIG decides the number of digits after decimal. The value of FLT_DIG is 6. Which simply means the precision is 6. That is the reason why we are not observing any digits after decimal if number of digits before decimal is >= 6. Added a new macro for TSQL dialect named BABEL_MAX_PRECISION which will allow to accept precision of 38.


 
### Issues Resolved

Task: BABEL-3066
 
### Check List

Signed-off-by: Shameem Ahmed [[shmeeh@amazon.com](mailto:shmeeh@amazon.com)]

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
