### PR TITLE
[draft][BABEL-4270] handle different behavior with escape character

### DIFF
--- a/src/backend/utils/adt/like_support.c
+++ b/src/backend/utils/adt/like_support.c
@@ -1069,7 +1069,7 @@ like_fixed_prefix(Const *patt_const, bool case_insensitive, Oid collation,
 			break;
 
 		/* Backslash escapes the next character */
-		if (patt[pos] == '\\')
+		if (patt[pos] == '\\' && sql_dialect != SQL_DIALECT_TSQL)
 		{
 			pos++;
 			if (pos >= pattlen)


### PR DESCRIPTION
Babel should handle the difference between the default escape char '\' In PostgreSQL, '\' always is the default escape char while in Sql server ther's no such thing as default escape char unless a escape expression explicit shows the escape char.

