### PR TITLE
Handle different behaviour with like ESCAPE null and LIKE ESCAPE ' '

### DIFF
--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -941,6 +941,17 @@ rewrite_scope_identity_call(ParseState *pstate, Node **lexpr, Node **rexpr)
 		col_expr = (Var*) *rexpr;
 		func_expr = (FuncExpr*) *lexpr;
 	}
+	else if (IsA(*rexpr, FuncExpr) &&
+            strstr(get_func_name(((FuncExpr*) (*rexpr))->funcid), "like_escape") != NULL &&  
+            IsA((Node *) (((FuncExpr *) (*rexpr))->args->elements[1]).ptr_value, Const) && 
+            ((Const *) (((FuncExpr *) (*rexpr))->args->elements[1]).ptr_value)->constisnull == true)
+    {
+		/*
+		* This condition deals with ESCAPE null, means no ESCAPE char used
+		*/
+        *rexpr = (Node *)(((FuncExpr *) (*rexpr) )->args->elements[0]).ptr_value;
+        return;
+    }
 	else
 		return;
 

--- a/src/backend/utils/adt/like_match.c
+++ b/src/backend/utils/adt/like_match.c
@@ -378,16 +378,6 @@ do_like_escape(text *pat, text *esc)
 	else
 	{
 		/*
-			* No escape character is wanted.  Double any backslashes in the
-			* pattern to make them act like ordinary characters.
-			*/
-			while (plen > 0)
-			{
-				if (*p == '\\')
-					*r++ = '\\';
-				CopyAdvChar(r, p, plen);
-			}
-		/*
 		 * The specified escape must be only a single character.
 		 */
 		NextChar(e, elen);

--- a/src/backend/utils/adt/like_match.c
+++ b/src/backend/utils/adt/like_match.c
@@ -350,19 +350,43 @@ do_like_escape(text *pat, text *esc)
 
 	if (elen == 0)
 	{
-		/*
-		 * No escape character is wanted.  Double any backslashes in the
-		 * pattern to make them act like ordinary characters.
-		 */
-		while (plen > 0)
-		{
-			if (*p == '\\')
-				*r++ = '\\';
-			CopyAdvChar(r, p, plen);
+		
+		if (sql_dialect == SQL_DIALECT_TSQL){
+			/*
+			* Escape string is empty, just show the error.
+			*/
+			ereport(ERROR,
+					(errcode(ERRCODE_INVALID_ESCAPE_SEQUENCE),
+					errmsg("The invalid escape character \"\" was specified in a LIKE predicate."),
+					errhint("Escape string must null or one character.")));
+
+		}
+		else{
+			/*
+			* No escape character is wanted.  Double any backslashes in the
+			* pattern to make them act like ordinary characters.
+			*/
+			while (plen > 0)
+			{
+				if (*p == '\\')
+					*r++ = '\\';
+				CopyAdvChar(r, p, plen);
+			}
+			
 		}
 	}
 	else
 	{
+		/*
+			* No escape character is wanted.  Double any backslashes in the
+			* pattern to make them act like ordinary characters.
+			*/
+			while (plen > 0)
+			{
+				if (*p == '\\')
+					*r++ = '\\';
+				CopyAdvChar(r, p, plen);
+			}
 		/*
 		 * The specified escape must be only a single character.
 		 */


### PR DESCRIPTION
### Description

When query `select 1 where 'ABCD' LIKE 'AB[C]D' ESCAPE ''` executes on babelfish, it should return an error as expected according to SQL server. But it was not throwing error, this is actually there was no condition added to return error in case of empty ESCAPE char. So i added a condition to return error for this case.
Another query is `select 1 where 'ABCD' LIKE 'AB[C]D' ESCAPE null`. This should return 1 row as expected SQL server behaviour and before this fix, this query returned 0 row on execution on babelfish. So i added one condition to capture this case and revert the behaviour as expected. (Behaviour same as no ESCAPE char used - as per Rob's comment on Jira).
 
### Issues Resolved

BABEL-4271

### Test Scenerios Covered
* Use case based - Added the new tests for both the queries
* Boundary conditions 
* Arbitrary inputs 
* Negative test cases
* Minor version upgrade tests
* Major version upgrade tests
* Performance tests
* Tooling impact
* Client tests


 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
