### PR TITLE
Result Types for Union

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -1941,7 +1941,7 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 										  false /* allow SQL92 rules */ );
 
 	if (post_transform_sort_clause_hook)
-		post_transform_sort_clause_hook(qry, leftmostQuery);
+		post_transform_sort_clause_hook(pstate, qry, leftmostQuery);
 
 	/* restore namespace, remove join RTE from rtable */
 	pstate->p_namespace = sv_namespace;

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -45,6 +45,7 @@
 #include "parser/parse_relation.h"
 #include "parser/parse_target.h"
 #include "parser/parse_type.h"
+#include "parser/parser.h"
 #include "parser/parsetree.h"
 #include "rewrite/rewriteManip.h"
 #include "utils/backend_status.h"
@@ -2275,26 +2276,29 @@ transformSetOperationTree(ParseState *pstate, SelectStmt *stmt,
 			 * it has to coerce the type, so failing now would just break
 			 * cases that might work.
 			 */
-			if (lcoltype != UNKNOWNOID)
-				lcolnode = coerce_to_common_type(pstate, lcolnode,
-												 rescoltype, context);
-			else if (IsA(lcolnode, Const) ||
-					 IsA(lcolnode, Param))
+			if(sql_dialect != SQL_DIALECT_TSQL)
 			{
-				lcolnode = coerce_to_common_type(pstate, lcolnode,
-												 rescoltype, context);
-				ltle->expr = (Expr *) lcolnode;
-			}
+				if (lcoltype != UNKNOWNOID)
+					lcolnode = coerce_to_common_type(pstate, lcolnode,
+													rescoltype, context);
+				else if (IsA(lcolnode, Const) ||
+						IsA(lcolnode, Param))
+				{
+					lcolnode = coerce_to_common_type(pstate, lcolnode,
+													rescoltype, context);
+					ltle->expr = (Expr *) lcolnode;
+				}
 
-			if (rcoltype != UNKNOWNOID)
-				rcolnode = coerce_to_common_type(pstate, rcolnode,
-												 rescoltype, context);
-			else if (IsA(rcolnode, Const) ||
-					 IsA(rcolnode, Param))
-			{
-				rcolnode = coerce_to_common_type(pstate, rcolnode,
-												 rescoltype, context);
-				rtle->expr = (Expr *) rcolnode;
+				if (rcoltype != UNKNOWNOID)
+					rcolnode = coerce_to_common_type(pstate, rcolnode,
+													rescoltype, context);
+				else if (IsA(rcolnode, Const) ||
+						IsA(rcolnode, Param))
+				{
+					rcolnode = coerce_to_common_type(pstate, rcolnode,
+													rescoltype, context);
+					rtle->expr = (Expr *) rcolnode;
+				}
 			}
 
 			rescoltypmod = select_common_typmod(pstate,

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -3433,7 +3433,7 @@ addTargetToGroupList(ParseState *pstate, TargetEntry *tle,
 	Oid			restype = exprType((Node *) tle->expr);
 
 	/* if tlist item is an UNKNOWN literal, change it to TEXT */
-	if (restype == UNKNOWNOID && sql_dialect != SQL_DIALECT_TSQL)
+	if (restype == UNKNOWNOID)
 	{
 		tle->expr = (Expr *) coerce_type(pstate, (Node *) tle->expr,
 										 restype, TEXTOID, -1,
@@ -3441,14 +3441,6 @@ addTargetToGroupList(ParseState *pstate, TargetEntry *tle,
 										 COERCE_IMPLICIT_CAST,
 										 -1);
 		restype = TEXTOID;
-	} else if (restype == UNKNOWNOID && sql_dialect == SQL_DIALECT_TSQL)
-	{
-		tle->expr = (Expr *) coerce_type(pstate, (Node *) tle->expr,
-									restype, INT4OID, -1,
-									COERCION_IMPLICIT,
-									COERCE_IMPLICIT_CAST,
-									-1);
-		restype = INT4OID;
 	}
 
 	/* avoid making duplicate grouplist entries */

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -3433,7 +3433,7 @@ addTargetToGroupList(ParseState *pstate, TargetEntry *tle,
 	Oid			restype = exprType((Node *) tle->expr);
 
 	/* if tlist item is an UNKNOWN literal, change it to TEXT */
-	if (restype == UNKNOWNOID)
+	if (restype == UNKNOWNOID && sql_dialect != SQL_DIALECT_TSQL)
 	{
 		tle->expr = (Expr *) coerce_type(pstate, (Node *) tle->expr,
 										 restype, TEXTOID, -1,
@@ -3441,6 +3441,14 @@ addTargetToGroupList(ParseState *pstate, TargetEntry *tle,
 										 COERCE_IMPLICIT_CAST,
 										 -1);
 		restype = TEXTOID;
+	} else if (restype == UNKNOWNOID && sql_dialect == SQL_DIALECT_TSQL)
+	{
+		tle->expr = (Expr *) coerce_type(pstate, (Node *) tle->expr,
+									restype, INT4OID, -1,
+									COERCION_IMPLICIT,
+									COERCE_IMPLICIT_CAST,
+									-1);
+		restype = INT4OID;
 	}
 
 	/* avoid making duplicate grouplist entries */

--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -37,6 +37,7 @@ find_coercion_pathway_hook_type find_coercion_pathway_hook = NULL;
 determine_datatype_precedence_hook_type determine_datatype_precedence_hook = NULL;
 coerce_string_literal_hook_type coerce_string_literal_hook = NULL;
 validate_implicit_conversion_from_string_literal_hook_type validate_implicit_conversion_from_string_literal_hook = NULL;
+select_common_type_hook_type select_common_type_hook = NULL;
 
 static Node *coerce_type_typmod(Node *node,
 								Oid targetTypeId, int32 targetTypMod,
@@ -1382,6 +1383,13 @@ select_common_type(ParseState *pstate, List *exprs, const char *context,
 	bool		pispreferred;
 	ListCell   *lc;
 	const char *dump_restore = GetConfigOption("babelfishpg_tsql.dump_restore", true, false);
+
+	if (sql_dialect == SQL_DIALECT_TSQL && select_common_type_hook)
+	{
+		Oid result = (*select_common_type_hook)(pstate, exprs, context, which_expr);
+		if (result != InvalidOid)
+			return result;
+	}
 
 	Assert(exprs != NIL);
 	pexpr = (Node *) linitial(exprs);

--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -38,6 +38,7 @@ determine_datatype_precedence_hook_type determine_datatype_precedence_hook = NUL
 coerce_string_literal_hook_type coerce_string_literal_hook = NULL;
 validate_implicit_conversion_from_string_literal_hook_type validate_implicit_conversion_from_string_literal_hook = NULL;
 select_common_type_hook_type select_common_type_hook = NULL;
+select_common_typmod_hook_type select_common_typmod_hook = NULL;
 
 static Node *coerce_type_typmod(Node *node,
 								Oid targetTypeId, int32 targetTypMod,
@@ -1725,6 +1726,13 @@ select_common_typmod(ParseState *pstate, List *exprs, Oid common_type)
 	ListCell   *lc;
 	bool		first = true;
 	int32		result = -1;
+
+	if (select_common_typmod_hook)
+	{
+		result = (*select_common_typmod_hook)(pstate, exprs, common_type);
+		if (result != -1)
+			return result;
+	}
 
 	foreach(lc, exprs)
 	{

--- a/src/include/parser/analyze.h
+++ b/src/include/parser/analyze.h
@@ -61,7 +61,7 @@ typedef void (*pre_transform_setop_tree_hook_type) (SelectStmt *stmt, SelectStmt
 extern PGDLLIMPORT pre_transform_setop_tree_hook_type pre_transform_setop_tree_hook;
 
 /* Hook for handle target table before transforming from clause */
-typedef void (*post_transform_sort_clause_hook_type) (Query *qry, Query *leftmostQuery);
+typedef void (*post_transform_sort_clause_hook_type) (ParseState *pstate, Query *qry, Query *leftmostQuery);
 extern PGDLLIMPORT post_transform_sort_clause_hook_type post_transform_sort_clause_hook;
 
 extern Query *parse_analyze_fixedparams(RawStmt *parseTree, const char *sourceText,

--- a/src/include/parser/parse_coerce.h
+++ b/src/include/parser/parse_coerce.h
@@ -129,4 +129,6 @@ typedef Node *(*coerce_string_literal_hook_type) (ParseCallbackState *pcbstate,
  */
 typedef void (*validate_implicit_conversion_from_string_literal_hook_type) (Const *newcon, const char *value);
 
+typedef Oid (*select_common_type_hook_type) (ParseState *pstate, List *exprs, const char *context, Node **which_expr);
+
 #endif							/* PARSE_COERCE_H */

--- a/src/include/parser/parse_coerce.h
+++ b/src/include/parser/parse_coerce.h
@@ -130,5 +130,6 @@ typedef Node *(*coerce_string_literal_hook_type) (ParseCallbackState *pcbstate,
 typedef void (*validate_implicit_conversion_from_string_literal_hook_type) (Const *newcon, const char *value);
 
 typedef Oid (*select_common_type_hook_type) (ParseState *pstate, List *exprs, const char *context, Node **which_expr);
+typedef int32 (*select_common_typmod_hook_type) (ParseState *pstate, List *exprs, Oid common_type);
 
 #endif							/* PARSE_COERCE_H */


### PR DESCRIPTION
### Description

Currently, babelfish gives an error when UNION is used with fixed-length types of different lengths or null. This change adds hooks to select_common_type and select_common_typmod. This allows CHAR, NCHAR, and BINARY types to have the correct output type and length with UNION.
 
### Issues Resolved

[BABEL-3392](https://jira.rds.a2z.com/browse/BABEL-3392), [BABEL-3348](https://jira.rds.a2z.com/browse/BABEL-3348)
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
