### PR TITLE
[Rel13] Check if dialect is SQL_DIALECT_TSQL before applying T-SQL specific logic

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -15086,7 +15086,7 @@ qualified_name:
 				{
 					$$ = makeRangeVar(NULL, $1, @1);
 					/* TSQL temp table names */
-					if (strncmp($1, "#", 1) == 0 || strncmp($1, "##", 2) == 0)
+					if (sql_dialect == SQL_DIALECT_TSQL && (strncmp($1, "#", 1) == 0 || strncmp($1, "##", 2) == 0))
 						$$->relpersistence = RELPERSISTENCE_TEMP;
 				}
 			| ColId indirection
@@ -15099,7 +15099,7 @@ qualified_name:
 							$$->catalogname = NULL;
 							$$->schemaname = downcaseIfTsqlAndCaseInsensitive($1);
 							/* TSQL temp table names. Schema name is allowed but ignored for temp tables.*/
-							if (strncmp(strVal(linitial($2)), "#", 1) == 0 || strncmp(strVal(linitial($2)), "##", 2) == 0)
+							if (sql_dialect == SQL_DIALECT_TSQL && (strncmp(strVal(linitial($2)), "#", 1) == 0 || strncmp(strVal(linitial($2)), "##", 2) == 0))
 							{
 								$$->relpersistence = RELPERSISTENCE_TEMP;
 								$$->schemaname = NULL;
@@ -15110,7 +15110,7 @@ qualified_name:
 							$$->catalogname = downcaseIfTsqlAndCaseInsensitive($1);
 							$$->schemaname = downcaseIfTsqlAndCaseInsensitive(strVal(linitial($2)));
 							/* TSQL temp table names. Catalog and schema names allowed but ignored for temp tables.*/
-							if (strncmp(strVal(lsecond($2)), "#", 1) == 0 || strncmp(strVal(lsecond($2)), "##", 2) == 0)
+							if (sql_dialect == SQL_DIALECT_TSQL && (strncmp(strVal(lsecond($2)), "#", 1) == 0 || strncmp(strVal(lsecond($2)), "##", 2) == 0))
 							{
 								$$->relpersistence = RELPERSISTENCE_TEMP;
 								$$->catalogname = NULL;


### PR DESCRIPTION
Previously, we were applying TSQL specific logic for temp table without checking dialect which may cause issue for regular table being created from PG endpoint and table name starting with '#'. We have also seen case of failed MVU due to this mis-handling of temp table.

This commit fixes this issue by appropriately checking dialect before applying T-SQL specific logic. Please note that this is temporary fix and we will work to provide long term fix.

Task: BABEL-4329

### Description

[Describe what this change achieves]
 
### Issues Resolved

[List any issues this PR will resolve]
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
