### PR TITLE
Handle different behaviour with like escape null and like escape ''

### DIFF
--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -941,6 +941,23 @@ rewrite_scope_identity_call(ParseState *pstate, Node **lexpr, Node **rexpr)
 		col_expr = (Var*) *rexpr;
 		func_expr = (FuncExpr*) *lexpr;
 	}
+	else if (IsA(*rexpr, FuncExpr) &&
+            strstr(get_func_name(((FuncExpr*) (*rexpr))->funcid), "like_escape") != NULL)
+    {
+        FuncExpr *func = (FuncExpr *) (*rexpr);
+        if((func->args)->length==2){
+            Node *node = lsecond(func->args);
+            if (IsA(node,Const) && ((Const *)(lsecond(func->args)))->constisnull)
+            {
+                /*
+                * This condition deals with ESCAPE null, means no ESCAPE char used
+                */
+                *rexpr = (Node *)(((FuncExpr *) (*rexpr) )->args->elements[0]).ptr_value;
+                return;
+            }
+        }
+		return;
+    }
 	else
 		return;
 

--- a/src/backend/utils/adt/like_match.c
+++ b/src/backend/utils/adt/like_match.c
@@ -350,15 +350,26 @@ do_like_escape(text *pat, text *esc)
 
 	if (elen == 0)
 	{
-		/*
-		 * No escape character is wanted.  Double any backslashes in the
-		 * pattern to make them act like ordinary characters.
-		 */
-		while (plen > 0)
-		{
-			if (*p == '\\')
-				*r++ = '\\';
-			CopyAdvChar(r, p, plen);
+		if (sql_dialect == SQL_DIALECT_TSQL){
+            /*
+            * Escape string is empty, just show the error.
+            */
+            ereport(ERROR,
+                    (errcode(ERRCODE_INVALID_ESCAPE_SEQUENCE),
+                    errmsg("The invalid escape character \"\" was specified in a LIKE predicate."),
+                    errhint("Escape string must null or one character.")));
+        }
+		else{
+			/*
+			* No escape character is wanted.  Double any backslashes in the
+			* pattern to make them act like ordinary characters.
+			*/
+			while (plen > 0)
+			{
+				if (*p == '\\')
+					*r++ = '\\';
+				CopyAdvChar(r, p, plen);
+			}
 		}
 	}
 	else

--- a/src/backend/utils/adt/like_match.c
+++ b/src/backend/utils/adt/like_match.c
@@ -348,28 +348,29 @@ do_like_escape(text *pat, text *esc)
 	result = (text *) palloc(plen * 2 + VARHDRSZ);
 	r = VARDATA(result);
 
+	if (elen==0 && sql_dialect == SQL_DIALECT_TSQL)
+	{
+		/*
+		 * Escape string is empty, just throw the error.
+		 */
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_ESCAPE_SEQUENCE),
+				errmsg("The invalid escape character \"\" was specified in a LIKE predicate."),
+				errhint("Escape string must be null or one character.")));
+		return;
+	}
+
 	if (elen == 0)
 	{
-		if (sql_dialect == SQL_DIALECT_TSQL){
-            /*
-            * Escape string is empty, just show the error.
-            */
-            ereport(ERROR,
-                    (errcode(ERRCODE_INVALID_ESCAPE_SEQUENCE),
-                    errmsg("The invalid escape character \"\" was specified in a LIKE predicate."),
-                    errhint("Escape string must null or one character.")));
-        }
-		else{
-			/*
-			* No escape character is wanted.  Double any backslashes in the
-			* pattern to make them act like ordinary characters.
-			*/
-			while (plen > 0)
-			{
-				if (*p == '\\')
-					*r++ = '\\';
-				CopyAdvChar(r, p, plen);
-			}
+		/*
+		 * No escape character is wanted.  Double any backslashes in the
+		 * pattern to make them act like ordinary characters.
+		 */
+		while (plen > 0)
+		{
+			if (*p == '\\')
+				*r++ = '\\';
+			CopyAdvChar(r, p, plen);
 		}
 	}
 	else

--- a/src/backend/utils/adt/like_match.c
+++ b/src/backend/utils/adt/like_match.c
@@ -357,7 +357,6 @@ do_like_escape(text *pat, text *esc)
 				(errcode(ERRCODE_INVALID_ESCAPE_SEQUENCE),
 				errmsg("The invalid escape character \"\" was specified in a LIKE predicate."),
 				errhint("Escape string must be null or one character.")));
-		return;
 	}
 
 	if (elen == 0)


### PR DESCRIPTION
### Description

When query `select 1 where 'ABCD' LIKE 'AB[C]D' ESCAPE'' ` executes on babelfish, it should return an error as expected behaviour. But it was not throwing error, this is actually there was no condition added to return error in case of empty ESCAPE char. So i added a condition to return error for this case.
Another query is `select 1 where 'ABCD' LIKE 'AB[C]D' ESCAPE null`. This should return 1 row as expected behaviour and before this fix, this query returned 0 row on execution on babelfish. So i added one condition to capture this case and revert the behaviour as expected. (Behaviour same as no ESCAPE char used - as per Rob's comment on Jira).

Task: BABEL-4271
Authored-by: Vikash Prajapati [vikasprj@amazon.com](mailto:vikasprj@amazon.com)
Signed-off-by: Vikash Prajapati [vikasprj@amazon.com](mailto:vikasprj@amazon.com)


### Issues Resolved

BABEL-4271
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
