### PR TITLE
Add pg_sequence into ENR for BBF table variables and Temp tables (#170)

### DIFF
--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -2156,9 +2156,6 @@ heap_drop_with_catalog(Oid relid)
 	 */
 	DeleteRelationTuple(relid);
 
-	/* Try drop ENR entry, will skip internally if it's not an ENR.*/
-	ENRDropEntry(relid);
-
 	if (OidIsValid(parentOid))
 	{
 		/*

--- a/src/backend/catalog/namespace.c
+++ b/src/backend/catalog/namespace.c
@@ -4170,7 +4170,7 @@ InitTempTableNamespace(void)
 		/* Advance command counter to make namespace visible */
 		CommandCounterIncrement();
 	}
-	else if (sql_dialect == SQL_DIALECT_TSQL && get_namedRelList() != NIL)
+	else if (sql_dialect == SQL_DIALECT_TSQL && has_existing_enr_relations())
 	{
 		/* Cannot wipe out any ENR relations if any */
 		;

--- a/src/backend/commands/sequence.c
+++ b/src/backend/commands/sequence.c
@@ -549,7 +549,8 @@ DeleteSequenceTuple(Oid relid)
 	if (!HeapTupleIsValid(tuple))
 		elog(ERROR, "cache lookup failed for sequence %u", relid);
 
-	CatalogTupleDelete(rel, &tuple->t_self);
+	if (!ENRdropTuple(rel, tuple))
+		CatalogTupleDelete(rel, &tuple->t_self);
 
 	ReleaseSysCache(tuple);
 	table_close(rel, RowExclusiveLock);

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -35,6 +35,7 @@
 #include "catalog/pg_statistic_ext.h"
 #include "catalog/pg_type.h"
 #include "catalog/pg_depend.h"
+#include "catalog/pg_sequence.h"
 #include "catalog/pg_shdepend.h"
 #include "catalog/pg_index_d.h"
 #include "parser/parser.h"      /* only needed for GUC variables */
@@ -169,6 +170,21 @@ List *get_namedRelList()
 	return currentQueryEnv->namedRelList;
 }
 
+bool has_existing_enr_relations()
+{
+	QueryEnvironment *queryEnv = currentQueryEnv;
+
+	while (queryEnv)
+	{
+		if (queryEnv->namedRelList != NIL)
+			return true;
+
+		queryEnv = queryEnv->parentEnv;
+	}
+
+	return false;
+}
+
 /*
  * This returns an ENR if there is a name match in the given collection.  It
  * must quietly return NULL if no match is found.
@@ -255,15 +271,31 @@ ENRMetadataGetTupDesc(EphemeralNamedRelationMetadata enrmd)
 bool ENRgetSystableScan(Relation rel, Oid indexId, int nkeys, ScanKey key, List **tuplist, int *tuplist_i, int *tuplist_flags)
 {
 	QueryEnvironment *queryEnv = currentQueryEnv;
-	Oid reloid;
 	bool found = false;
 	int index = 0;
 	Datum v1 = 0, v2 = 0, v3 = 0, v4 = 0;
+	Oid pltsql_lang_oid = InvalidOid;
+	Oid pltsql_validator_oid = InvalidOid;
+
+	Oid reloid = RelationGetRelid(rel);
 
 	if (sql_dialect != SQL_DIALECT_TSQL)
-		return false;
+	{
+		/*
+		* We cannot return false right away when sql_dialect is not TSQL.
+		* There are cases when sql_dialect is temporarily set to PG when
+		* executing PG functions such as nextval_internal() in the case of
+		* identity sequence.
+		*/
+		if (reloid != SequenceRelationId)
+			return false;
 
-	reloid = RelationGetRelid(rel);
+		if (get_func_language_oids_hook)
+			get_func_language_oids_hook(&pltsql_lang_oid, &pltsql_validator_oid);
+
+		if (pltsql_lang_oid == InvalidOid)
+			return false;
+	}
 
 	if (reloid != RelationRelationId &&
 		reloid != TypeRelationId &&
@@ -273,7 +305,8 @@ bool ENRgetSystableScan(Relation rel, Oid indexId, int nkeys, ScanKey key, List 
 		reloid != StatisticExtRelationId &&
 		reloid != DependRelationId &&
 		reloid != SharedDependRelationId &&
-		reloid != IndexRelationId)
+		reloid != IndexRelationId &&
+		reloid != SequenceRelationId)
 		return false;
 
 	switch (nkeys) {
@@ -545,6 +578,15 @@ bool ENRgetSystableScan(Relation rel, Oid indexId, int nkeys, ScanKey key, List 
 					}
 				}
 			}
+			else if (reloid == SequenceRelationId) {
+				if (indexId == SequenceRelidIndexId) {
+					if (enr->md.reliddesc == (Oid)v1) {
+						*tuplist = enr->md.cattups[ENR_CATTUP_SEQUENCE];
+						*tuplist_i = 0;
+						return true;
+					}
+				}
+			}
 		}
 		queryEnv = queryEnv->parentEnv;
 	}
@@ -643,7 +685,6 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 			case DependRelationId:
 				{
 					Form_pg_depend tf1 = (Form_pg_depend) GETSTRUCT((HeapTuple)tup);
-					//if ((enr = find_enr(tf1->classid, tf1->objid, tf1->objsubid))) {
 					if ((enr = find_enr(tf1))) {
 						ListCell *curlc;
 						Form_pg_depend tf2; /* tuple forms*/
@@ -812,6 +853,14 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 							break;
 						}
 					}
+					ret = true;
+				}
+				break;
+			case SequenceRelationId:
+				rel_oid = ((Form_pg_sequence) GETSTRUCT(tup))->seqrelid;
+				if ((enr = get_ENR_withoid(queryEnv, rel_oid, ENR_TSQL_TEMP))) {
+					list_ptr = &enr->md.cattups[ENR_CATTUP_SEQUENCE];
+					lc = list_head(enr->md.cattups[ENR_CATTUP_SEQUENCE]);
 					ret = true;
 				}
 				break;

--- a/src/include/utils/queryenvironment.h
+++ b/src/include/utils/queryenvironment.h
@@ -40,6 +40,7 @@ typedef enum ENRCatalogTupleType
 	ENR_CATTUP_DEPEND,
 	ENR_CATTUP_SHDEPEND,
 	ENR_CATTUP_INDEX,
+	ENR_CATTUP_SEQUENCE,
 	ENR_CATTUP_END
 } ENRCatalogTupleType;
 
@@ -105,5 +106,6 @@ extern bool ENRgetSystableScan(Relation rel, Oid indexoid, int nkeys, ScanKey ke
 extern void ENRDropTempTables(QueryEnvironment *queryEnv);
 extern void ENRDropEntry(Oid id);
 extern void ENRDropCatalogEntry(Relation catalog_relation, Oid relid);
+extern bool has_existing_enr_relations(void);
 
 #endif							/* QUERYENVIRONMENT_H */


### PR DESCRIPTION
Table Variables and Temp Tables can have identity columns which adds entries to pg_sequence. If the table is in ENR, then pg_sequence entry should also be in ENR otherwise we would have catalog inconsistency.

Also, do not drop temp schema if there exists ENR relations

Task: BABEL-4267, BABEL-4263



- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
