### PR TITLE
Revert "Fix SELECT DISTINCT NULL result type"

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -1941,7 +1941,7 @@ transformSetOperationStmt(ParseState *pstate, SelectStmt *stmt)
 										  false /* allow SQL92 rules */ );
 
 	if (post_transform_sort_clause_hook)
-		post_transform_sort_clause_hook(pstate, qry, leftmostQuery);
+		post_transform_sort_clause_hook(qry, leftmostQuery);
 
 	/* restore namespace, remove join RTE from rtable */
 	pstate->p_namespace = sv_namespace;

--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -37,8 +37,6 @@ find_coercion_pathway_hook_type find_coercion_pathway_hook = NULL;
 determine_datatype_precedence_hook_type determine_datatype_precedence_hook = NULL;
 coerce_string_literal_hook_type coerce_string_literal_hook = NULL;
 validate_implicit_conversion_from_string_literal_hook_type validate_implicit_conversion_from_string_literal_hook = NULL;
-select_common_type_hook_type select_common_type_hook = NULL;
-select_common_typmod_hook_type select_common_typmod_hook = NULL;
 
 static Node *coerce_type_typmod(Node *node,
 								Oid targetTypeId, int32 targetTypMod,
@@ -1385,13 +1383,6 @@ select_common_type(ParseState *pstate, List *exprs, const char *context,
 	ListCell   *lc;
 	const char *dump_restore = GetConfigOption("babelfishpg_tsql.dump_restore", true, false);
 
-	if (sql_dialect == SQL_DIALECT_TSQL && select_common_type_hook)
-	{
-		Oid result = (*select_common_type_hook)(pstate, exprs, context, which_expr);
-		if (result != InvalidOid)
-			return result;
-	}
-
 	Assert(exprs != NIL);
 	pexpr = (Node *) linitial(exprs);
 	lc = list_second_cell(exprs);
@@ -1726,13 +1717,6 @@ select_common_typmod(ParseState *pstate, List *exprs, Oid common_type)
 	ListCell   *lc;
 	bool		first = true;
 	int32		result = -1;
-
-	if (select_common_typmod_hook)
-	{
-		result = (*select_common_typmod_hook)(pstate, exprs, common_type);
-		if (result != -1)
-			return result;
-	}
 
 	foreach(lc, exprs)
 	{

--- a/src/include/parser/analyze.h
+++ b/src/include/parser/analyze.h
@@ -61,7 +61,7 @@ typedef void (*pre_transform_setop_tree_hook_type) (SelectStmt *stmt, SelectStmt
 extern PGDLLIMPORT pre_transform_setop_tree_hook_type pre_transform_setop_tree_hook;
 
 /* Hook for handle target table before transforming from clause */
-typedef void (*post_transform_sort_clause_hook_type) (ParseState *pstate, Query *qry, Query *leftmostQuery);
+typedef void (*post_transform_sort_clause_hook_type) (Query *qry, Query *leftmostQuery);
 extern PGDLLIMPORT post_transform_sort_clause_hook_type post_transform_sort_clause_hook;
 
 extern Query *parse_analyze_fixedparams(RawStmt *parseTree, const char *sourceText,

--- a/src/include/parser/parse_coerce.h
+++ b/src/include/parser/parse_coerce.h
@@ -129,7 +129,4 @@ typedef Node *(*coerce_string_literal_hook_type) (ParseCallbackState *pcbstate,
  */
 typedef void (*validate_implicit_conversion_from_string_literal_hook_type) (Const *newcon, const char *value);
 
-typedef Oid (*select_common_type_hook_type) (ParseState *pstate, List *exprs, const char *context, Node **which_expr);
-typedef int32 (*select_common_typmod_hook_type) (ParseState *pstate, List *exprs, Oid common_type);
-
 #endif							/* PARSE_COERCE_H */


### PR DESCRIPTION
This reverts commit 19aac1a175aa99e967ed6e480002ccf01b20b17a.

### Description

Delay this fix to allow additional time for testing and stabilization. 
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
