### PR TITLE
Handle different behavior with escape char('\') for BBF

### DIFF
--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -41,8 +41,6 @@
 #include "utils/timestamp.h"
 #include "utils/xml.h"
 
-#define TSQL_DEFAULT_ESCAPE "\357\277\277\0"
-
 /* GUC parameters */
 bool		Transform_null_equals = false;
 
@@ -1095,7 +1093,7 @@ transformAExprOp(ParseState *pstate, A_Expr *a)
 
         escape_node = makeNode(A_Const);
         escape_node->val.sval.type = T_String;
-        escape_node->val.sval.sval = TSQL_DEFAULT_ESCAPE;
+        escape_node->val.sval.sval = "\xFE";
         escape_node->location = -1;
 
         new_call = makeFuncCall(list_make2(makeString("pg_catalog"), makeString("like_escape")), 

--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -41,6 +41,8 @@
 #include "utils/timestamp.h"
 #include "utils/xml.h"
 
+#define TSQL_DEFAULT_ESCAPE "\357\277\277\0"
+
 /* GUC parameters */
 bool		Transform_null_equals = false;
 
@@ -1093,7 +1095,7 @@ transformAExprOp(ParseState *pstate, A_Expr *a)
 
         escape_node = makeNode(A_Const);
         escape_node->val.sval.type = T_String;
-        escape_node->val.sval.sval = "\xFE";
+        escape_node->val.sval.sval = TSQL_DEFAULT_ESCAPE;
         escape_node->location = -1;
 
         new_call = makeFuncCall(list_make2(makeString("pg_catalog"), makeString("like_escape")), 

--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -1078,6 +1078,38 @@ transformAExprOp(ParseState *pstate, A_Expr *a)
 										castNode(RowExpr, lexpr)->args,
 										castNode(RowExpr, rexpr)->args,
 										a->location);
+	}else if (sql_dialect == SQL_DIALECT_TSQL &&
+            (strcmp(strVal(linitial(a->name)), "~~") == 0 || strcmp(strVal(linitial(a->name)), "!~~") == 0) && 
+            !IsA(rexpr, FuncCall)){
+		/* 
+		 * Rewrite for tsql like expression without escape clause
+		 * postgres by default escapes '\\' but tsql doesn't. Adding a escape
+		 * clause of invalid UTF8 code and check it in do_like_escape can 
+		 * disable the default escape and making it behave similar to tsql
+		 */
+        A_Const    *escape_node;
+		FuncCall   *new_call;
+        Node       *last_srf = pstate->p_last_srf;
+
+        escape_node = makeNode(A_Const);
+        escape_node->val.sval.type = T_String;
+        escape_node->val.sval.sval = "\xFE";
+        escape_node->location = -1;
+
+        new_call = makeFuncCall(list_make2(makeString("pg_catalog"), makeString("like_escape")), 
+                                            list_make2(rexpr, escape_node), 
+                                            COERCE_EXPLICIT_CALL, 
+                                            -1);
+        
+        lexpr = transformExprRecurse(pstate, lexpr);
+        rexpr = transformFuncCall(pstate, new_call);
+        
+        result = (Node *) make_op(pstate,
+                                  a->name,
+                                  lexpr,
+                                  rexpr,
+                                  last_srf,
+                                  a->location);
 	}
 	else
 	{

--- a/src/backend/utils/adt/like_match.c
+++ b/src/backend/utils/adt/like_match.c
@@ -76,8 +76,6 @@
 #define GETCHAR(t) (t)
 #endif
 
-#define TSQL_DEFAULT_ESCAPE "\357\277\277\0"
-
 static int
 MatchText(const char *t, int tlen, const char *p, int plen,
 		  pg_locale_t locale, bool locale_is_c)
@@ -350,7 +348,8 @@ do_like_escape(text *pat, text *esc)
 	result = (text *) palloc(plen * 2 + VARHDRSZ);
 	r = VARDATA(result);
 	
-	if (elen == 0 && sql_dialect != SQL_DIALECT_TSQL)
+	if ((elen == 0 && sql_dialect != SQL_DIALECT_TSQL) || 
+		(elen == 1 && sql_dialect == SQL_DIALECT_TSQL && *e == '\xFE'))
 	{
 		/*
 		 * No escape character is wanted.  Double any backslashes in the

--- a/src/backend/utils/adt/like_match.c
+++ b/src/backend/utils/adt/like_match.c
@@ -347,19 +347,9 @@ do_like_escape(text *pat, text *esc)
 	 */
 	result = (text *) palloc(plen * 2 + VARHDRSZ);
 	r = VARDATA(result);
-
-	if (elen==0 && sql_dialect == SQL_DIALECT_TSQL)
-	{
-		/*
-		 * Escape string is empty, just throw the error.
-		 */
-		ereport(ERROR,
-				(errcode(ERRCODE_INVALID_ESCAPE_SEQUENCE),
-				errmsg("The invalid escape character \"\" was specified in a LIKE predicate."),
-				errhint("Escape string must be null or one character.")));
-	}
-
-	if (elen == 0)
+	
+	if ((elen == 0 && sql_dialect != SQL_DIALECT_TSQL) || 
+		(elen == 1 && sql_dialect == SQL_DIALECT_TSQL && *e == '\xFE'))
 	{
 		/*
 		 * No escape character is wanted.  Double any backslashes in the
@@ -371,6 +361,16 @@ do_like_escape(text *pat, text *esc)
 				*r++ = '\\';
 			CopyAdvChar(r, p, plen);
 		}
+	}
+	else if (elen==0 && sql_dialect == SQL_DIALECT_TSQL)
+	{
+		/*
+		 * Escape string is empty, just throw the error.
+		 */
+		ereport(ERROR,
+				(errcode(ERRCODE_INVALID_ESCAPE_SEQUENCE),
+				errmsg("The invalid escape character \"\" was specified in a LIKE predicate."),
+				errhint("Escape string must be null or one character.")));
 	}
 	else
 	{

--- a/src/backend/utils/adt/like_match.c
+++ b/src/backend/utils/adt/like_match.c
@@ -76,6 +76,8 @@
 #define GETCHAR(t) (t)
 #endif
 
+#define TSQL_DEFAULT_ESCAPE "\357\277\277\0"
+
 static int
 MatchText(const char *t, int tlen, const char *p, int plen,
 		  pg_locale_t locale, bool locale_is_c)
@@ -348,8 +350,7 @@ do_like_escape(text *pat, text *esc)
 	result = (text *) palloc(plen * 2 + VARHDRSZ);
 	r = VARDATA(result);
 	
-	if ((elen == 0 && sql_dialect != SQL_DIALECT_TSQL) || 
-		(elen == 1 && sql_dialect == SQL_DIALECT_TSQL && *e == '\xFE'))
+	if (elen == 0 && sql_dialect != SQL_DIALECT_TSQL)
 	{
 		/*
 		 * No escape character is wanted.  Double any backslashes in the

--- a/src/backend/utils/adt/like_support.c
+++ b/src/backend/utils/adt/like_support.c
@@ -1069,7 +1069,8 @@ like_fixed_prefix(Const *patt_const, bool case_insensitive, Oid collation,
 			break;
 
 		/* Backslash escapes the next character */
-		if (patt[pos] == '\\')
+		/* Default escape '\\' is disabled in babelfish */
+		if (patt[pos] == '\\' && sql_dialect == SQL_DIALECT_PG)
 		{
 			pos++;
 			if (pos >= pattlen)


### PR DESCRIPTION
### Description
Postgres by default use '\' as escape character whereas tsql doesn't have any default escape character. This commit disabled default escape character in babelfish and aligned its behavior with tsql.
 
### Issues Resolved

resolved default escape character '\' in BBF
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
