### PR TITLE
Fixed segmentation fault occuring due to already freed AfterTriggersTableData

### DIFF
--- a/src/include/commands/trigger.h
+++ b/src/include/commands/trigger.h
@@ -306,4 +306,7 @@ extern void EndCompositeTriggers(bool error);
 
 extern bool TsqlRecuresiveCheck(ResultRelInfo *resultRelInfo);
 
+typedef bool (*check_pltsql_support_tsql_transactions_hook_type) (void);
+extern PGDLLIMPORT check_pltsql_support_tsql_transactions_hook_type check_pltsql_support_tsql_transactions_hook;
+
 #endif							/* TRIGGER_H */


### PR DESCRIPTION
Recently, we discovered a crash which was happening due to double freeing of AfterTriggersTableData (composite trigger data). Crash was due to freeing AfterTriggersTableData at incorrect query_depth in case of error raised during execution of PG trigger defined on TSQL table and then we are trying to clean up the same data during AfterTriggerEndSubXact which is causing segmentation fault. This commit fixes this crash by appropriately checking query_depth before attempting to clean up AfterTriggersTableData.

Additionally, this commit also blocks executing T-SQL trigger when there is any Postgres' function, procedure or trigger is in the call stack.

Testing: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1572

Task: BABEL-4220
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>


- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
