### PR TITLE
This pull request reverts wrong calls to HeapTupleSatisfiesVisibility

### DIFF
--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -2928,7 +2928,7 @@ l1:
 	if (crosscheck != InvalidSnapshot && result == TM_Ok)
 	{
 		/* Perform additional check for transaction-snapshot mode RI updates */
-		if (HeapTupleSatisfiesVisibility(relation, &tp, crosscheck, buffer))
+		if (!HeapTupleSatisfiesVisibility(relation, &tp, crosscheck, buffer))
 			result = TM_Updated;
 	}
 
@@ -3573,7 +3573,7 @@ l2:
 	if (crosscheck != InvalidSnapshot && result == TM_Ok)
 	{
 		/* Perform additional check for transaction-snapshot mode RI updates */
-		if (HeapTupleSatisfiesVisibility(relation, &oldtup, crosscheck, buffer))
+		if (!HeapTupleSatisfiesVisibility(relation, &oldtup, crosscheck, buffer))
 		{
 			result = TM_Updated;
 			Assert(!ItemPointerEquals(&oldtup.t_self, &oldtup.t_data->t_ctid));


### PR DESCRIPTION
### Description


### Description

This pull request reverts wrong calls to HeapTupleSatisfiesVisibility


commit 2f805dd41c93892a0733df6656da6ecafad5b0fa
Author: Kristian Lejao <1741885+lejaokri@users.noreply.github.com>
Date:   Mon May 1 14:56:22 2023 -0700

    Table Variable rework (#138)

```
@@ -2922,7 +2928,7 @@ l1:
        if (crosscheck != InvalidSnapshot && result == TM_Ok)
        {
                /* Perform additional check for transaction-snapshot mode RI updates */
-               if (!HeapTupleSatisfiesVisibility(&tp, crosscheck, buffer))
+               if (HeapTupleSatisfiesVisibility(relation, &tp, crosscheck, buffer))
                        result = TM_Updated;
```

```
@@ -3567,7 +3573,7 @@ l2:
        if (crosscheck != InvalidSnapshot && result == TM_Ok)
        {
                /* Perform additional check for transaction-snapshot mode RI updates */
-               if (!HeapTupleSatisfiesVisibility(&oldtup, crosscheck, buffer))
+               if (HeapTupleSatisfiesVisibility(relation, &oldtup, crosscheck, buffer))
```

 
 

 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
