### PR TITLE
Check the dialect before firing INSTEAD OF EACH STATEMENT triggers

### DIFF
--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -2575,7 +2575,7 @@ ExecModifyTable(PlanState *pstate)
 	 * 
 	 * IOT should be fired after execution is done
 	 */
-	if (node->fireISTriggers == IOT_NOT_FIRED)
+	if (node->fireISTriggers == IOT_NOT_FIRED && sql_dialect == SQL_DIALECT_TSQL)
 	{
 		node->fireISTriggers = fireISTriggers(node);
 	}


### PR DESCRIPTION
### Description

With this commit, We are checking dialect before executing/firing INSTEAD OF EACH STATEMENT triggers. This helps us reducing the high backend's memory context being taken by CurTransactionContext.
 
Task: MANFRED-18681
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
