### PR TITLE
Block cross version and cross migration mode dump/restore

### DIFF
--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -226,7 +226,7 @@ dumpBabelRestoreChecks(Archive *fout)
 					  "\n    SELECT INTO target_server_version setting from pg_settings"
 					  "\n        WHERE name = 'server_version';"
 					  "\n    IF target_server_version::VARCHAR != '%s' THEN"
-					  "\n        RAISE 'Backup and restore across different Postgres versions is not yet supported.';" 
+					  "\n        RAISE 'Dump and restore across different Postgres versions is not yet supported.';"
 					  "\n    END IF;"
 					  "\nEND$$;\n\n"
 					  , source_server_version);
@@ -247,7 +247,7 @@ dumpBabelRestoreChecks(Archive *fout)
 					  "\n    SELECT INTO target_migration_mode setting from pg_settings"
 					  "\n        WHERE name = 'babelfishpg_tsql.migration_mode';"
 					  "\n    IF target_migration_mode::VARCHAR != '%s' THEN"
-					  "\n        RAISE 'Backup and restore across different migration modes is not yet supported.';" 
+					  "\n        RAISE 'Dump and restore across different migration modes is not yet supported.';"
 					  "\n    END IF;"
 					  "\nEND$$;\n\n"
 					  , source_migration_mode);

--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -52,5 +52,6 @@ extern void castSqlvariantToBasetype(PGresult *res,
                                     int row,
                                     int field,
                                     int sqlvariant_pos);
+extern void dumpBabelRestoreChecks(Archive *fout);
 
 #endif

--- a/src/bin/pg_dump/dumpall_babel_utils.c
+++ b/src/bin/pg_dump/dumpall_babel_utils.c
@@ -23,6 +23,8 @@
 #include "pg_dump.h"
 #include "pqexpbuffer.h"
 
+#define exit_nicely(code) exit(code)
+
 /* Babelfish virtual database to dump */
 char *bbf_db_name = NULL;
 
@@ -32,6 +34,29 @@ typedef enum {
 } babelfish_status;
 
 static babelfish_status bbf_status = NONE;
+
+/*
+ * Run a query, return the results, exit program on failure.
+ */
+static PGresult *
+executeQuery(PGconn *conn, const char *query)
+{
+	PGresult   *res;
+
+	pg_log_info("executing %s", query);
+
+	res = PQexec(conn, query);
+	if (!res ||
+		PQresultStatus(res) != PGRES_TUPLES_OK)
+	{
+		pg_log_error("query failed: %s", PQerrorMessage(conn));
+		pg_log_error_detail("Query was: %s", query);
+		PQfinish(conn);
+		exit_nicely(1);
+	}
+
+	return res;
+}
 
 /*
  * isBabelfishDatabase:
@@ -45,7 +70,7 @@ isBabelfishDatabase(PGconn *conn)
 	{
 		PGresult *res;
 		int		 ntups;
-		res = PQexec(conn, "SELECT extname FROM pg_extension WHERE extname = 'babelfishpg_tsql';");
+		res = executeQuery(conn, "SELECT extname FROM pg_extension WHERE extname = 'babelfishpg_tsql';");
 		ntups = PQntuples(res);
 		if (ntups != 0)
 			bbf_status = ON;
@@ -54,6 +79,82 @@ isBabelfishDatabase(PGconn *conn)
 		PQclear(res);
 	}
 	return (bbf_status == ON);
+}
+
+/*
+ * dumpBabelRestoreChecks:
+ * Dumps Babelfish specific pre-checks which get executed at the
+ * beginning of restore to validate if restore can be performed
+ * or not.
+ */
+void
+dumpBabelRestoreChecks(FILE *OPF, PGconn *conn, int binary_upgrade)
+{
+	PGresult	*res;
+	char		*source_server_version;
+	char		*source_migration_mode;
+	PQExpBuffer	qry;
+
+	/* Skip if not Babelfish database or binary upgrade */
+	if (!isBabelfishDatabase(conn) || binary_upgrade)
+		return;
+
+	/*
+	 * Cross version Babelfish dump/restore is not yet supported so
+	 * store the current server's version in the below procedure and
+	 * add logic to fail the restore if the target server version
+	 * differs from source server version.
+	 */
+	qry = createPQExpBuffer();
+	res = executeQuery(conn, "SHOW server_version");
+	source_server_version = pstrdup(PQgetvalue(res, 0, 0));
+
+	/*
+	 * Temporarily enable ON_ERROR_STOP so that whole restore script
+	 * execution fails if the following do block raises an error.
+	 */
+	appendPQExpBufferStr(qry, "\\set ON_ERROR_STOP on\n\n");
+	appendPQExpBuffer(qry,
+					  "DO $$"
+					  "\nDECLARE"
+					  "\n    target_server_version VARCHAR;"
+					  "\nBEGIN"
+					  "\n    SELECT INTO target_server_version setting from pg_settings"
+					  "\n        WHERE name = 'server_version';"
+					  "\n    IF target_server_version::VARCHAR != '%s' THEN"
+					  "\n        RAISE 'Backup and restore across different Postgres versions is not yet supported.';" 
+					  "\n    END IF;"
+					  "\nEND$$;\n\n"
+					  , source_server_version);
+	PQclear(res);
+
+	/*
+	 * Similar to the above, cross migration mode Babelfish dump/restore
+	 * is also not yet supported so store the current server's migration mode
+	 * in the below procedure and add logic to fail the restore if the target
+	 * server's migration mode differs from source server migration mode.
+	 */
+	res =  executeQuery(conn, "SHOW babelfishpg_tsql.migration_mode");
+	source_migration_mode = pstrdup(PQgetvalue(res, 0, 0));
+	appendPQExpBuffer(qry, "DO $$"
+					  "\nDECLARE"
+					  "\n    target_migration_mode VARCHAR;"
+					  "\nBEGIN"
+					  "\n    SELECT INTO target_migration_mode setting from pg_settings"
+					  "\n        WHERE name = 'babelfishpg_tsql.migration_mode';"
+					  "\n    IF target_migration_mode::VARCHAR != '%s' THEN"
+					  "\n        RAISE 'Backup and restore across different migration modes is not yet supported.';" 
+					  "\n    END IF;"
+					  "\nEND$$;\n\n"
+					  , source_migration_mode);
+	appendPQExpBufferStr(qry, "\\set ON_ERROR_STOP off\n");
+	PQclear(res);
+
+	fprintf(OPF, "%s", qry->data);
+
+	destroyPQExpBuffer(qry);
+	pfree(source_server_version);
+	pfree(source_migration_mode);
 }
 
 /*

--- a/src/bin/pg_dump/dumpall_babel_utils.c
+++ b/src/bin/pg_dump/dumpall_babel_utils.c
@@ -122,7 +122,7 @@ dumpBabelRestoreChecks(FILE *OPF, PGconn *conn, int binary_upgrade)
 					  "\n    SELECT INTO target_server_version setting from pg_settings"
 					  "\n        WHERE name = 'server_version';"
 					  "\n    IF target_server_version::VARCHAR != '%s' THEN"
-					  "\n        RAISE 'Backup and restore across different Postgres versions is not yet supported.';" 
+					  "\n        RAISE 'Dump and restore across different Postgres versions is not yet supported.';"
 					  "\n    END IF;"
 					  "\nEND$$;\n\n"
 					  , source_server_version);
@@ -143,7 +143,7 @@ dumpBabelRestoreChecks(FILE *OPF, PGconn *conn, int binary_upgrade)
 					  "\n    SELECT INTO target_migration_mode setting from pg_settings"
 					  "\n        WHERE name = 'babelfishpg_tsql.migration_mode';"
 					  "\n    IF target_migration_mode::VARCHAR != '%s' THEN"
-					  "\n        RAISE 'Backup and restore across different migration modes is not yet supported.';" 
+					  "\n        RAISE 'Dump and restore across different migration modes is not yet supported.';"
 					  "\n    END IF;"
 					  "\nEND$$;\n\n"
 					  , source_migration_mode);

--- a/src/bin/pg_dump/dumpall_babel_utils.h
+++ b/src/bin/pg_dump/dumpall_babel_utils.h
@@ -22,5 +22,6 @@ extern void getBabelfishRolesQuery(PGconn *conn, PQExpBuffer buf,
 extern void getBabelfishRoleMembershipQuery(PGconn *conn, PQExpBuffer buf,
         char *role_catalog, int binary_upgrade);
 extern bool isBabelfishDatabase(PGconn *conn);
+extern void dumpBabelRestoreChecks(FILE *OPF, PGconn *conn, int binary_upgrade);
 
 #endif

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -919,7 +919,7 @@ main(int argc, char **argv)
 		dumpDatabase(fout);
 
 	dumpBabelGUCs(fout);
-
+	dumpBabelRestoreChecks(fout);
 	/* Now the rearrangeable objects. */
 	for (i = 0; i < numObjs; i++)
 		dumpDumpableObject(fout, dobjs[i]);

--- a/src/bin/pg_dump/pg_dumpall.c
+++ b/src/bin/pg_dump/pg_dumpall.c
@@ -540,6 +540,8 @@ main(int argc, char *argv[])
 		fprintf(OPF, "SET escape_string_warning = off;\n");
 	fprintf(OPF, "\n");
 
+	dumpBabelRestoreChecks(OPF, conn, binary_upgrade);
+
 	if (!data_only)
 	{
 		/*


### PR DESCRIPTION
### Description
Babelfish currently only supports dump and restore from databases with
same migration mode ( i.e. either singledb->singledb or multidb->multidb)
and same versions. This commit adds logic to dump a precheck so that the
restore process stops execution if the migration mode or version in the target
server is different than the one from which the dump file was created.

Task: BABEL-4055
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>
 
Extensions PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1798
### Check List

- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
