### PR TITLE
Fixed handling of input arguments for ISNULL() (#193)

### DIFF
--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -37,6 +37,7 @@ find_coercion_pathway_hook_type find_coercion_pathway_hook = NULL;
 determine_datatype_precedence_hook_type determine_datatype_precedence_hook = NULL;
 coerce_string_literal_hook_type coerce_string_literal_hook = NULL;
 validate_implicit_conversion_from_string_literal_hook_type validate_implicit_conversion_from_string_literal_hook = NULL;
+select_common_type_hook_type select_common_type_hook = NULL;
 
 static Node *coerce_type_typmod(Node *node,
 								Oid targetTypeId, int32 targetTypMod,

--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -2262,7 +2262,10 @@ transformCoalesceExpr(ParseState *pstate, CoalesceExpr *c)
 		newargs = lappend(newargs, newe);
 	}
 
-	newc->coalescetype = select_common_type(pstate, newargs, "COALESCE", NULL);
+	if (sql_dialect == SQL_DIALECT_TSQL && select_common_type_hook && c->tsql_is_null)
+		newc->coalescetype = (*select_common_type_hook)(pstate, newargs);
+	else
+		newc->coalescetype = select_common_type(pstate, newargs, "COALESCE", NULL);
 	/* coalescecollid will be set by parse_collate.c */
 
 	/* Convert arguments if necessary */

--- a/src/include/parser/parse_coerce.h
+++ b/src/include/parser/parse_coerce.h
@@ -129,4 +129,8 @@ typedef Node *(*coerce_string_literal_hook_type) (ParseCallbackState *pcbstate,
  */
 typedef void (*validate_implicit_conversion_from_string_literal_hook_type) (Const *newcon, const char *value);
 
+/* Generic hook to override the behavior of select_common_type(...) */
+typedef Oid (*select_common_type_hook_type) (ParseState *pstate, List *exprs);
+extern PGDLLIMPORT select_common_type_hook_type select_common_type_hook;
+
 #endif							/* PARSE_COERCE_H */


### PR DESCRIPTION
Previously, we were handling ISNULL using COALESCE semantics which is not right thing to do because return datatype of T-SQL ISNULL function is not same as COALESCE in all the cases. So this commit fixes this issue by appropriately calling hook to select the common type or say return type for ISNULL. Hook is implemented in babelfishpg_tsql function via PR: babelfish-for-postgresql/babelfish_extensions#1709

BABEL-917
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>


### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
