### PR TITLE
BABEL-4411 set transaction isolation cmd change

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -12263,16 +12263,10 @@ assign_default_transaction_isolation(int newval, void *extra)
 	if (guc_newval_hook)
 	{
 		char		*s;
-		A_Const		*t;
 		s = transaction_isolation_to_string(newval);
-		t = makeNode(A_Const);;
-		t->val.sval.type = T_String;
-		t->val.sval.sval = s;
-		t->location = -1;
-		if( newval != XactIsoLevel )
-			SetPGVariable("transaction_isolation", list_make1(t), true);
+		set_config_option("transaction_isolation", s, PGC_USERSET,
+							PGC_S_SESSION, GUC_ACTION_LOCAL, true, 0, false);
 		(*guc_newval_hook)("default_transaction_isolation", false, NULL, newval);
-		pfree(t);
 	}
 }
 

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -12264,8 +12264,8 @@ assign_default_transaction_isolation(int newval, void *extra)
 	{
 		char		*s;
 		s = transaction_isolation_to_string(newval);
-		set_config_option("transaction_isolation", s, PGC_USERSET,
-							PGC_S_SESSION, GUC_ACTION_LOCAL, true, 0, false);
+		SetConfigOption("transaction_isolation", s,
+							PGC_USERSET, PGC_S_SESSION);
 		(*guc_newval_hook)("default_transaction_isolation", false, NULL, newval);
 	}
 }

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -245,6 +245,8 @@ static bool check_recovery_target_lsn(char **newval, void **extra, GucSource sou
 static void assign_recovery_target_lsn(const char *newval, void *extra);
 static bool check_primary_slot_name(char **newval, void **extra, GucSource source);
 static bool check_default_with_oids(bool *newval, void **extra, GucSource source);
+static char *transaction_isolation_to_string(int v);
+static bool check_default_transaction_isolation(int *newval, void **extra, GucSource source);
 
 /* Private functions in guc-file.l that need to be called from guc.c */
 static ConfigVariable *ProcessConfigFileInternal(GucContext context,
@@ -4815,7 +4817,7 @@ static struct config_enum ConfigureNamesEnum[] =
 		},
 		&DefaultXactIsoLevel,
 		XACT_READ_COMMITTED, isolation_level_options,
-		NULL, assign_default_transaction_isolation, NULL
+		check_default_transaction_isolation, assign_default_transaction_isolation, NULL
 	},
 
 	{
@@ -12259,7 +12261,19 @@ static void
 assign_default_transaction_isolation(int newval, void *extra)
 {
 	if (guc_newval_hook)
+	{
+		char		*s;
+		A_Const		*t;
+		s = transaction_isolation_to_string(newval);
+		t = makeNode(A_Const);;
+		t->val.sval.type = T_String;
+		t->val.sval.sval = s;
+		t->location = -1;
+		if( newval != XactIsoLevel )
+			SetPGVariable("transaction_isolation", list_make1(t), true);
 		(*guc_newval_hook)("default_transaction_isolation", false, NULL, newval);
+		pfree(t);
+	}
 }
 
 static void
@@ -13073,6 +13087,53 @@ void
 guc_set_stack_value(struct config_generic *gconf, config_var_value *val)
 {
 	set_stack_value(gconf,  val);
+}
+
+static char*
+transaction_isolation_to_string(int v)
+{
+	switch (v)
+	{
+		case XACT_SERIALIZABLE:
+			return "serializable";
+		case XACT_REPEATABLE_READ:
+			return "repeatable read";
+		case XACT_READ_COMMITTED:
+			return "read committed";
+		case XACT_READ_UNCOMMITTED:
+			return "read uncommitted";
+	}
+	return "(unrecognized)";
+}
+
+static bool
+check_default_transaction_isolation(int *newval, void **extra, GucSource source)
+{
+	if (guc_newval_hook)
+	{	
+		int			newXactIsoLevel = *newval;
+		const char*		ignore_isolation;
+
+		if ( newXactIsoLevel != XactIsoLevel && IsTransactionState() )
+		{
+			if( FirstSnapshotSet || IsSubTransaction() || (newXactIsoLevel == XACT_SERIALIZABLE && RecoveryInProgress()))
+			{
+				ignore_isolation = GetConfigOption("babelfishpg_tsql.escape_hatch_set_transaction_isolation_level", false, false);
+
+				if(ignore_isolation && !strcmp(ignore_isolation, "ignore"))
+				{
+					*newval = XactIsoLevel;
+					return true;
+				}
+				else
+				{
+					GUC_check_errmsg("SET TRANSACTION ISOLATION failed because of setting from invalid state, set escape hatch to silently ignore");
+					return false;
+				}
+			}
+		}
+	}	
+	return true;
 }
 
 #include "guc-file.c"


### PR DESCRIPTION
### Description
Currently babelfish transactions start with session default isolation level. Users can not change this isolation level after transaction has started. On running the set transaction isolation inside a transaction, current transaction isolation does not change but all subsequent transaction will pick up this new isolation level.

Changes in this PR:

Allow changing the current transaction isolation level if no DML query has been run inside transaction.
Abort the transaction if set transaction isolation level is run after a DML query in a transaction block unless the new isolation level is same as current isolation level.
Introduce an escape hatch to ignore any invalid set transaction isolation level stmt so that transaction does not abort.

#### Engine Change:
Add check hook to guc default_transaction_isolation (all errors should be taken care here, that is assign hook should never fail)
If the conditions for setting isolation level are true returns true
If conditions are false and escape hatch is not set (strict - default value) - abort transaction with error
but if escape hatch is set to ignore for same situation - we simply ignore the set tran isolation command by setting the new isolation level to current isolation level. Which is apparently the same as ignoring the cmd.

#### Extension Change:
Introduce escape hatch for set transaction isolation 
New attribute in PLtsql_stmt_execsql structure. This attribute is needed to identify if the stmt is set transaction isolation during initialisation of internal savepoint and if set, we skip the internal save point for the current stmt.
This needs to be done since postgres does not allow setting isolation level inside a save point.

#### Engine PR : https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/217
#### Extension PR : https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1847

### Issues Resolved

BABEL-4411

#### Sign Off : Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
