### PR TITLE
[OSS ONLY] Add RPM spec file and Makefile logic to build Babelfish dump utils

### DIFF
--- a/.github/workflows/test_rpm.yml
+++ b/.github/workflows/test_rpm.yml
@@ -1,0 +1,34 @@
+name: BabelfishDump RPM Test
+on: [push, pull_request]
+
+jobs:
+  build-rpm:
+    name: Build BabelfishDump RPM
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        id: checkout
+
+      - name: Install Dependencies
+        id: install-dependencies
+        if: always()
+        run: |
+          sudo apt clean && sudo apt-get update --fix-missing -y
+          sudo apt-get install alien libossp-uuid-dev uuid-dev zlib1g-dev liblz4-dev libicu-dev libxml2-dev openssl libssl-dev libpq-dev pkg-config bison flex libkrb5-dev libpam-dev libreadline-dev
+
+      - name: Run RPM command
+        id: run-rpm-command
+        if: always() && steps.install-dependencies.outcome == 'success'
+        run: |
+          make NODEPS=1 rpm
+
+      - name: Install RPM
+        id: install-rpm
+        if: always() && steps.run-rpm-command.outcome == 'success'
+        run: |
+          cd build
+          # Install RPM package
+          sudo alien -i BabelfishDump-*
+          # Verify that utilites installed correctly
+          bbf_dumpall -V
+          bbf_dump -V

--- a/BabelfishDump.spec
+++ b/BabelfishDump.spec
@@ -1,0 +1,219 @@
+# This spec file and ancillary files are licensed in accordance with
+
+# The PostgreSQL license.
+
+
+# In this file you can find the default build package list macros.
+
+# These can be overridden by defining on the rpm command line:
+
+# rpm --define 'packagename 1' .... to force the package to build.
+
+# rpm --define 'packagename 0' .... to force the package NOT to build.
+
+
+%{!?external_libpq:%global external_libpq 0}
+
+
+%{!?ssl:%global ssl 1}
+
+%{!?icu:%global icu 1}
+
+%{!?kerberos:%global kerberos 1}
+
+
+%{!?uuid:%global uuid 1}
+
+%{!?xml:%global xml 1}
+
+# https://fedoraproject.org/wiki/Packaging:Guidelines#Packaging_of_Additional_RPM_Macros
+
+%global macrosdir %(d=%{_rpmconfigdir}/macros.d; [ -d $d ] || d=%{_sysconfdir}/rpm; echo $d)
+
+%undefine _missing_build_ids_terminate_build
+
+Summary: Postgresql dump utilities modified for Babelfish
+
+Name: BabelfishDump
+
+%global majorversion 15
+
+Version: %{majorversion}.3
+
+Release: 2%{?dist}
+
+License: PostgreSQL
+	
+Url: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish
+
+BuildArch: noarch
+
+
+BuildRequires: make
+
+BuildRequires: gcc
+
+#BuildRequires: perl(ExtUtils::MakeMaker) glibc-devel bison flex gawk
+	
+BuildRequires: readline-devel zlib-devel
+
+%if %external_libpq
+
+BuildRequires: libpq-devel >= %version
+
+%endif
+
+# postgresql-setup build requires
+
+BuildRequires: m4
+
+
+%if %ssl
+
+BuildRequires: openssl-devel
+
+%endif
+
+
+%if %kerberos
+
+BuildRequires: krb5-devel
+
+%endif
+
+
+%if %uuid
+
+BuildRequires: uuid-devel
+
+%endif
+
+
+%if %xml
+
+BuildRequires: libxml2-devel
+
+%endif
+
+%if %icu
+
+BuildRequires:	libicu-devel
+
+%endif
+
+
+Source: %{name}.tar.gz
+
+# https://bugzilla.redhat.com/1464368
+
+# and do not provide pkgconfig RPM provides (RHBZ#1980992) and #2121696
+
+%global __provides_exclude_from %{_libdir}/(pgsql|pkgconfig)
+
+
+%description
+
+This package provides utilities to dump a Babelfish database.
+
+
+Requires(post): glibc
+
+Requires(postun): glibc
+
+
+%prep
+
+%setup -q -n %{name}
+
+# Update binary versions
+sed -i "s/pg_dump (PostgreSQL)/bbf_dump (pg_dump compatible with Babelfish for PostgreSQL)/g" src/bin/pg_dump/pg_dump.c
+sed -i "s/pg_dumpall (PostgreSQL)/bbf_dumpall (pg_dumpall compatible with Babelfish for PostgreSQL)/g" src/bin/pg_dump/pg_dumpall.c
+
+%build
+
+# Building BabelfishDump
+
+# Fiddling with CFLAGS.
+
+
+CFLAGS="${CFLAGS:-%optflags}"
+
+# Strip out -ffast-math from CFLAGS....
+
+CFLAGS=`echo $CFLAGS|xargs -n 1|grep -v ffast-math|xargs -n 100`
+
+export CFLAGS
+
+
+common_configure_options='
+
+	--disable-rpath
+
+	--enable-debug
+
+	--enable-cassert
+
+%if %ssl
+	
+	--with-openssl
+
+	--with-ssl=libssl3
+	
+%endif
+
+	--with-zlib
+
+	--with-libxml
+
+	--with-readline
+
+%if %kerberos
+
+	--with-gssapi
+
+%endif
+
+%if %uuid
+
+	--with-ossp-uuid
+
+%endif
+
+%if %icu
+
+	--with-icu
+
+%endif
+'
+
+export LIBS="-lz -lc -lssl -lcrypto -lkrb5 -lcom_err -lgssapi_krb5 -lk5crypto -ldl -lkrb5support -lssl3"
+
+%configure $common_configure_options
+
+make -C src/backend generated-headers
+make -C src/bin/pg_dump -j4 pg_dump pg_dumpall
+
+
+%install
+
+make -C src/bin/pg_dump install DESTDIR=$RPM_BUILD_ROOT
+
+# We don't need pg_restore
+rm -f $RPM_BUILD_ROOT/usr/bin/pg_restore
+
+# Rename binaries to bbf_* equivalent
+mv $RPM_BUILD_ROOT/usr/bin/pg_dump $RPM_BUILD_ROOT/usr/bin/bbf_dump
+mv $RPM_BUILD_ROOT/usr/bin/pg_dumpall $RPM_BUILD_ROOT/usr/bin/bbf_dumpall
+
+%check
+$RPM_BUILD_ROOT/usr/bin/bbf_dumpall -V
+$RPM_BUILD_ROOT/usr/bin/bbf_dump -V
+
+# FILES sections.
+%files
+
+%{_bindir}/bbf_dump
+
+%{_bindir}/bbf_dumpall
+
+%changelog

--- a/BabelfishDump.spec
+++ b/BabelfishDump.spec
@@ -1,128 +1,74 @@
 # This spec file and ancillary files are licensed in accordance with
-
 # The PostgreSQL license.
 
-
 # In this file you can find the default build package list macros.
-
 # These can be overridden by defining on the rpm command line:
-
 # rpm --define 'packagename 1' .... to force the package to build.
-
 # rpm --define 'packagename 0' .... to force the package NOT to build.
 
-
 %{!?external_libpq:%global external_libpq 0}
-
-
 %{!?ssl:%global ssl 1}
-
 %{!?icu:%global icu 1}
-
 %{!?kerberos:%global kerberos 1}
-
-
 %{!?uuid:%global uuid 1}
-
 %{!?xml:%global xml 1}
+%{!?pam:%global pam 1}
 
 # https://fedoraproject.org/wiki/Packaging:Guidelines#Packaging_of_Additional_RPM_Macros
-
 %global macrosdir %(d=%{_rpmconfigdir}/macros.d; [ -d $d ] || d=%{_sysconfdir}/rpm; echo $d)
 
 %undefine _missing_build_ids_terminate_build
 
-Summary: Postgresql dump utilities modified for Babelfish
-
 Name: BabelfishDump
-
-%global majorversion 15
-
-Version: %{majorversion}.3
-
-Release: 2%{?dist}
-
-License: PostgreSQL
-	
+Summary: Postgresql dump utilities modified for Babelfish
+Version: 15.latest
+Release: 1%{?dist}
+License: PostgreSQL Global Development Group
 Url: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish
 
-BuildArch: noarch
-
-
 BuildRequires: make
-
+BuildRequires: lz4-devel
 BuildRequires: gcc
-
-#BuildRequires: perl(ExtUtils::MakeMaker) glibc-devel bison flex gawk
-	
+BuildRequires: glibc-devel bison flex
 BuildRequires: readline-devel zlib-devel
-
 %if %external_libpq
-
 BuildRequires: libpq-devel >= %version
-
 %endif
-
-# postgresql-setup build requires
-
-BuildRequires: m4
-
 
 %if %ssl
-
 BuildRequires: openssl-devel
-
 %endif
-
 
 %if %kerberos
-
 BuildRequires: krb5-devel
-
 %endif
-
 
 %if %uuid
-
 BuildRequires: uuid-devel
-
 %endif
 
-
 %if %xml
-
 BuildRequires: libxml2-devel
-
 %endif
 
 %if %icu
-
 BuildRequires:	libicu-devel
-
 %endif
 
+%if %pam
+BuildRequires: pam-devel
+%endif
 
 Source: %{name}.tar.gz
 
 # https://bugzilla.redhat.com/1464368
-
 # and do not provide pkgconfig RPM provides (RHBZ#1980992) and #2121696
-
 %global __provides_exclude_from %{_libdir}/(pgsql|pkgconfig)
 
-
 %description
-
 This package provides utilities to dump a Babelfish database.
 
-
-Requires(post): glibc
-
-Requires(postun): glibc
-
-
 %prep
-
 %setup -q -n %{name}
 
 # Update binary versions
@@ -130,90 +76,61 @@ sed -i "s/pg_dump (PostgreSQL)/bbf_dump (pg_dump compatible with Babelfish for P
 sed -i "s/pg_dumpall (PostgreSQL)/bbf_dumpall (pg_dumpall compatible with Babelfish for PostgreSQL)/g" src/bin/pg_dump/pg_dumpall.c
 
 %build
-
 # Building BabelfishDump
 
 # Fiddling with CFLAGS.
-
-
 CFLAGS="${CFLAGS:-%optflags}"
 
 # Strip out -ffast-math from CFLAGS....
-
 CFLAGS=`echo $CFLAGS|xargs -n 1|grep -v ffast-math|xargs -n 100`
-
 export CFLAGS
 
-
 common_configure_options='
-
 	--disable-rpath
-
-	--enable-debug
-
-	--enable-cassert
-
 %if %ssl
-	
 	--with-openssl
-
-	--with-ssl=libssl3
-	
 %endif
-
-	--with-zlib
-
+%if %xml
 	--with-libxml
-
-	--with-readline
-
+%endif
 %if %kerberos
-
 	--with-gssapi
-
 %endif
-
 %if %uuid
-
 	--with-ossp-uuid
-
 %endif
-
 %if %icu
-
 	--with-icu
-
 %endif
+%if %pam
+	--with-pam
+%endif
+	--with-lz4
+	--with-readline
 '
-
-export LIBS="-lz -lc -lssl -lcrypto -lkrb5 -lcom_err -lgssapi_krb5 -lk5crypto -ldl -lkrb5support -lssl3"
 
 %configure $common_configure_options
 
 make -C src/backend generated-headers
-make -C src/bin/pg_dump -j4 pg_dump pg_dumpall
-
+export NO_GENERATED_HEADERS=1
+make -C src/bin/pg_dump pg_dump pg_dumpall
 
 %install
-
 make -C src/bin/pg_dump install DESTDIR=$RPM_BUILD_ROOT
 
 # We don't need pg_restore
 rm -f $RPM_BUILD_ROOT/usr/bin/pg_restore
-
 # Rename binaries to bbf_* equivalent
 mv $RPM_BUILD_ROOT/usr/bin/pg_dump $RPM_BUILD_ROOT/usr/bin/bbf_dump
 mv $RPM_BUILD_ROOT/usr/bin/pg_dumpall $RPM_BUILD_ROOT/usr/bin/bbf_dumpall
 
 %check
-$RPM_BUILD_ROOT/usr/bin/bbf_dumpall -V
-$RPM_BUILD_ROOT/usr/bin/bbf_dump -V
+LD_LIBRARY_PATH=%{_builddir}/%{name}/src/interfaces/libpq $RPM_BUILD_ROOT/usr/bin/bbf_dumpall -V
+LD_LIBRARY_PATH=%{_builddir}/%{name}/src/interfaces/libpq $RPM_BUILD_ROOT/usr/bin/bbf_dump -V
 
 # FILES sections.
 %files
-
 %{_bindir}/bbf_dump
-
 %{_bindir}/bbf_dumpall
 
 %changelog

--- a/BabelfishDump.spec
+++ b/BabelfishDump.spec
@@ -1,5 +1,7 @@
 # This spec file and ancillary files are licensed in accordance with
 # The PostgreSQL license.
+# This spec file bundles the Babelfish dump utilities (bbf_dump/bbf_dumpall)
+# into an RPM.
 
 # In this file you can find the default build package list macros.
 # These can be overridden by defining on the rpm command line:

--- a/Makefile
+++ b/Makefile
@@ -45,3 +45,40 @@ all check install installdirs installcheck installcheck-parallel uninstall clean
 	   echo "You must use GNU make to build PostgreSQL." ; \
 	   false; \
 	 fi
+
+PACKAGE_NAME = BabelfishDump
+SOURCE_TARBALL = $(PACKAGE_NAME).tar.gz
+SPECFILE = $(PACKAGE_NAME).spec
+BUILD_DIR = build/rpmbuild
+
+.PHONY: rpm-clean
+rpm-clean:
+	rm -rf $(BUILD_DIR)
+	rm -rf $(PACKAGE_NAME)
+	rm -f $(SOURCE_TARBALL)
+
+.PHONY: tarball
+tarball: rpm-clean
+	mkdir -p $(PACKAGE_NAME)
+
+	cp -p aclocal.m4 $(PACKAGE_NAME)
+	cp -p configure* $(PACKAGE_NAME)
+	cp -p GNUmakefile* $(PACKAGE_NAME)
+	cp -p Makefile $(PACKAGE_NAME)
+	cp -rp config src $(PACKAGE_NAME)
+
+	tar -czf $(SOURCE_TARBALL) $(PACKAGE_NAME)/*
+
+.PHONY: sources
+sources: tarball
+
+.PHONY: rpm-only
+rpm-only:
+	mkdir -p $(BUILD_DIR)/{SPECS,COORD_SOURCES,DATA_SOURCES,BUILD,RPMS,SOURCES,SRPMS}
+	cp $(SPECFILE) $(BUILD_DIR)/SPECS
+	cp $(SOURCE_TARBALL) $(BUILD_DIR)/SOURCES
+	rpmbuild -ba --define "_topdir `pwd`/$(BUILD_DIR)" $(BUILD_DIR)/SPECS/$(SPECFILE)
+	cp $(BUILD_DIR)/RPMS/*/*rpm build
+
+.PHONY: rpm
+rpm: sources rpm-only

--- a/Makefile
+++ b/Makefile
@@ -46,10 +46,13 @@ all check install installdirs installcheck installcheck-parallel uninstall clean
 	   false; \
 	 fi
 
+# Targets in the portion below can be used to generate source tarball
+# and RPM containing Babelfish dump utilities (bbf_dump/bbf_dumpall).
 PACKAGE_NAME = BabelfishDump
 SOURCE_TARBALL = $(PACKAGE_NAME).tar.gz
 SPECFILE = $(PACKAGE_NAME).spec
 BUILD_DIR = build/rpmbuild
+DIRS = 'SPECS' 'COORD_SOURCES' 'DATA_SOURCES' 'BUILD' 'RPMS' 'SOURCES' 'SRPMS'
 
 .PHONY: rpm-clean
 rpm-clean:
@@ -72,12 +75,18 @@ tarball: rpm-clean
 .PHONY: sources
 sources: tarball
 
+ifdef NODEPS
+RPMOPT = -ba -v --nodeps
+else
+RPMOPT = -ba -v
+endif
+
 .PHONY: rpm-only
 rpm-only:
-	mkdir -p $(BUILD_DIR)/{SPECS,COORD_SOURCES,DATA_SOURCES,BUILD,RPMS,SOURCES,SRPMS}
+	mkdir -p $(addprefix $(BUILD_DIR)/,$(DIRS))
 	cp $(SPECFILE) $(BUILD_DIR)/SPECS
 	cp $(SOURCE_TARBALL) $(BUILD_DIR)/SOURCES
-	rpmbuild -ba --define "_topdir `pwd`/$(BUILD_DIR)" $(BUILD_DIR)/SPECS/$(SPECFILE)
+	rpmbuild $(RPMOPT) --define "_topdir `pwd`/$(BUILD_DIR)" $(BUILD_DIR)/SPECS/$(SPECFILE)
 	cp $(BUILD_DIR)/RPMS/*/*rpm build
 
 .PHONY: rpm


### PR DESCRIPTION
### Description
This commit adds a spec file which can be used to create RPM
containing Babelfish dump utilities (bbf_dump/bbf_dumpall).
The commit also introduces few new Makefile targets described below:
* **sources:** Bundles the repository source into a tarball.
* **rpm-only:** creates an RPM using given RPM spec file.
* **rpm:** Combines both of the above steps.
Additionally, added a github action to verify the RPM build and utilites
generated afterwards.

Task: BABEL-4412
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
