### PR TITLE
Updated AlterTableCmd node definition to also contain an attribute for schemaname

### DIFF
--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -2031,6 +2031,7 @@ typedef struct AlterTableCmd	/* one subcommand of an ALTER TABLE */
 	DropBehavior behavior;		/* RESTRICT or CASCADE for DROP cases */
 	bool		missing_ok;		/* skip error if missing? */
 	bool		recurse;		/* exec-time recursion */
+	char	   *schemaname;
 } AlterTableCmd;
 
 


### PR DESCRIPTION
### Description
This PR will add an attribute `schemaname` in `AlterTableCmd` Node. This will be used to store schema name of trigger in Enable/Disable Trigger related queries. 
Ref: [PR in babelfish_extensions - Added Support for Enable/Disable of DML Triggers.](https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1799)

Authored-by: Rohit Bhagat [rohitbgt@amazon.com](mailto:rohitbgt@amazon.com)
Signed-off-by: Rohit Bhagat [rohitbgt@amazon.com](mailto:rohitbgt@amazon.com)

### Issues Resolved
BABEL-3326
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
