### PR TITLE
Use SysCache for BBF USER EXT extended catalog

### DIFF
--- a/src/include/utils/syscache.h
+++ b/src/include/utils/syscache.h
@@ -121,10 +121,11 @@ enum SysCacheIdentifier
 	 */
 	SYSDATABASEOID,
 	SYSDATABASENAME,
-	PROCNSPSIGNATURE
+	PROCNSPSIGNATURE,
+	ROLNAMEMAP
 
 #define SysCacheNoExtensionSize (USERMAPPINGUSERSERVER+ 1)
-#define SysCacheSize (PROCNSPSIGNATURE + 1)
+#define SysCacheSize (ROLNAMEMAP+ 1)
 };
 
 /*


### PR DESCRIPTION
### Description

Extended catalog table 'babelfish_authid_user_ext' is heavily used is different functionalities. Currently we do a simple heap scan for fetching tuples from this table which does not show significant slow down incase of small number of databases. But as we grow in size this affects the performance.

It would be wise to use syscache on extended catalog wherever possible and avoid scanning the whole relation. Going forward as we increase the catalog size, this would significantly help with performance.

For syscahe we need an index on columns same as the keys that will be used for searching sys cache.

#### Engine PR: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/222

#### Exten. PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1867

### Issues Resolved

BABEL-4416

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
