### PR TITLE
Check that db is selected before loading babelfishpg_tsql

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,13 +11,17 @@ jobs:
     steps:
       - name: clone-repository
         uses: actions/checkout@v2
+      - name: install-dependencies
+        run: |
+          sudo apt update --fix-missing -y
+          sudo apt install -y libipc-run-perl
       - name: build-postgres
         run: |
-          ./configure
-          make world-bin -j8 COPT='-Werror'
+          ./configure --with-icu --enable-cassert --enable-tap-tests
+          make world-bin -j8 COPT='-Werror -Wno-error=maybe-uninitialized'
       - name: run-tests
         run: |
-          make check -j8
+          make check-world
       - name: upload-test-summary
         if: failure()
         uses: actions/upload-artifact@v2

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -4270,7 +4270,7 @@ PostgresMain(const char *dbname, const char *username)
 	 */
 	start_xact_command();
 	PushActiveSnapshot(GetTransactionSnapshot());
-	if (get_extension_oid(pgtsql_library_name, true) != InvalidOid)
+	if (OidIsValid(MyDatabaseId) && OidIsValid(get_extension_oid(pgtsql_library_name, true)))
 	{
 		/*
 		 * babelfishpg_tsql extension depends on babelfishpg_common, so


### PR DESCRIPTION
### Description

When `babelfishpg_tsql` [is being loaded on backend init](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/dce7212f5eff7d149620bf00225b6fba496b886d/src/backend/tcop/postgres.c#L4259) there is a check for extension OID. It appeared that `get_extension_oid` that performs the check can [fail hard](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/dce7212f5eff7d149620bf00225b6fba496b886d/src/backend/utils/cache/relcache.c#L352) with:

```
cannot read pg_class without having selected a database
```

This patch adds a check that DB is selected before calling to `get_extension_oid`.

References:
 - [upstream discussion of a similar problem](https://www.postgresql.org/message-id/4EDAA3B0.1010707%40fuzzy.cz)
 - [similar problem in TimescaleDB extension](https://github.com/timescale/timescaledb/issues/1847)

### Issues Resolved

[#1665](https://github.com/babelfish-for-postgresql/babelfish_extensions/issues/1665)
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
