### PR TITLE
Support for Instead of Trigger On Views in Babelfish

### DIFF
--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -489,12 +489,6 @@ CreateTriggerFiringOn(CreateTrigStmt *stmt, const char *queryString,
 								RelationGetRelationName(rel)),
 						 errdetail("Triggers on foreign tables cannot have transition tables.")));
 
-			if (rel->rd_rel->relkind == RELKIND_VIEW)
-				ereport(ERROR,
-						(errcode(ERRCODE_WRONG_OBJECT_TYPE),
-						 errmsg("\"%s\" is a view",
-								RelationGetRelationName(rel)),
-						 errdetail("Triggers on views cannot have transition tables.")));
 
 			/*
 			 * We currently don't allow row-level triggers with transition

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -489,6 +489,12 @@ CreateTriggerFiringOn(CreateTrigStmt *stmt, const char *queryString,
 								RelationGetRelationName(rel)),
 						 errdetail("Triggers on foreign tables cannot have transition tables.")));
 
+			if (rel->rd_rel->relkind == RELKIND_VIEW && sql_dialect != SQL_DIALECT_TSQL)
+				ereport(ERROR,
+						(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+						 errmsg("\"%s\" is a view",
+								RelationGetRelationName(rel)),
+						 errdetail("Triggers on views cannot have transition tables.")));
 
 			/*
 			 * We currently don't allow row-level triggers with transition

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -54,6 +54,7 @@
 #include "jit/jit.h"
 #include "mb/pg_wchar.h"
 #include "miscadmin.h"
+#include "parser/parser.h" 
 #include "parser/parsetree.h"
 #include "storage/bufmgr.h"
 #include "storage/lmgr.h"
@@ -1029,7 +1030,7 @@ CheckValidResultRel(ResultRelInfo *resultRelInfo, CmdType operation)
 			switch (operation)
 			{
 				case CMD_INSERT:
-					if (!trigDesc || !trigDesc->trig_insert_instead_row)
+					if (!trigDesc || (!trigDesc->trig_insert_instead_row && (sql_dialect == SQL_DIALECT_TSQL && !trigDesc->trig_insert_instead_statement)))
 						ereport(ERROR,
 								(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 								 errmsg("cannot insert into view \"%s\"",
@@ -1037,7 +1038,7 @@ CheckValidResultRel(ResultRelInfo *resultRelInfo, CmdType operation)
 								 errhint("To enable inserting into the view, provide an INSTEAD OF INSERT trigger or an unconditional ON INSERT DO INSTEAD rule.")));
 					break;
 				case CMD_UPDATE:
-					if (!trigDesc || !trigDesc->trig_update_instead_row)
+					if (!trigDesc || (!trigDesc->trig_update_instead_row && (sql_dialect == SQL_DIALECT_TSQL && !trigDesc->trig_update_instead_statement)))
 						ereport(ERROR,
 								(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 								 errmsg("cannot update view \"%s\"",
@@ -1045,7 +1046,7 @@ CheckValidResultRel(ResultRelInfo *resultRelInfo, CmdType operation)
 								 errhint("To enable updating the view, provide an INSTEAD OF UPDATE trigger or an unconditional ON UPDATE DO INSTEAD rule.")));
 					break;
 				case CMD_DELETE:
-					if (!trigDesc || !trigDesc->trig_delete_instead_row)
+					if (!trigDesc || (!trigDesc->trig_delete_instead_row && (sql_dialect == SQL_DIALECT_TSQL && !trigDesc->trig_delete_instead_statement)))
 						ereport(ERROR,
 								(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 								 errmsg("cannot delete from view \"%s\"",

--- a/src/backend/rewrite/rewriteHandler.c
+++ b/src/backend/rewrite/rewriteHandler.c
@@ -46,7 +46,7 @@
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
 
-ViewInsteadStmtTrigger_hook_type ViewInsteadStmtTrigger_hook = NULL;
+bbfViewHasInsteadofTrigger_hook_type bbfViewHasInsteadofTrigger_hook = NULL; /** BBF Hook to check Instead Of trigger on View */
 
 /* We use a list of these to detect recursion in RewriteQuery */
 typedef struct rewrite_event
@@ -1475,7 +1475,7 @@ rewriteValuesRTE(Query *parsetree, RangeTblEntry *rte, int rti,
 	isAutoUpdatableView = false;
 	if (target_relation->rd_rel->relkind == RELKIND_VIEW &&
 		(!view_has_instead_trigger(target_relation, CMD_INSERT) &&
-			!(sql_dialect == SQL_DIALECT_TSQL && ViewInsteadStmtTrigger_hook && (ViewInsteadStmtTrigger_hook)(target_relation, CMD_INSERT))))
+			!(sql_dialect == SQL_DIALECT_TSQL && bbfViewHasInsteadofTrigger_hook && (bbfViewHasInsteadofTrigger_hook)(target_relation, CMD_INSERT))))
 	{
 		List	   *locks;
 		bool		hasUpdate;
@@ -3957,7 +3957,7 @@ RewriteQuery(Query *parsetree, List *rewrite_events, int orig_rt_length)
 		if (!instead &&
 			rt_entry_relation->rd_rel->relkind == RELKIND_VIEW &&
 			(!view_has_instead_trigger(rt_entry_relation, event) 
-			&& !(sql_dialect == SQL_DIALECT_TSQL && ViewInsteadStmtTrigger_hook && (ViewInsteadStmtTrigger_hook)(rt_entry_relation, event))))
+			&& !(sql_dialect == SQL_DIALECT_TSQL && bbfViewHasInsteadofTrigger_hook && (bbfViewHasInsteadofTrigger_hook)(rt_entry_relation, event))))
 		{
 			/*
 			 * If there were any qualified INSTEAD rules, don't allow the view

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -87,6 +87,9 @@ extern PGDLLIMPORT ExecutorCheckPerms_hook_type ExecutorCheckPerms_hook;
 typedef bool (*TriggerRecuresiveCheck_hook_type) (ResultRelInfo *resultRelInfo);
 extern PGDLLIMPORT TriggerRecuresiveCheck_hook_type TriggerRecuresiveCheck_hook;
 
+typedef bool (*ViewInsteadStmtTrigger_hook_type) (Relation view, CmdType event);
+extern PGDLLIMPORT ViewInsteadStmtTrigger_hook_type ViewInsteadStmtTrigger_hook;
+
 typedef bool (*check_rowcount_hook_type) (int es_processed);
 extern PGDLLIMPORT check_rowcount_hook_type check_rowcount_hook;
 

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -87,8 +87,8 @@ extern PGDLLIMPORT ExecutorCheckPerms_hook_type ExecutorCheckPerms_hook;
 typedef bool (*TriggerRecuresiveCheck_hook_type) (ResultRelInfo *resultRelInfo);
 extern PGDLLIMPORT TriggerRecuresiveCheck_hook_type TriggerRecuresiveCheck_hook;
 
-typedef bool (*ViewInsteadStmtTrigger_hook_type) (Relation view, CmdType event);
-extern PGDLLIMPORT ViewInsteadStmtTrigger_hook_type ViewInsteadStmtTrigger_hook;
+typedef bool (*bbfViewHasInsteadofTrigger_hook_type) (Relation view, CmdType event);
+extern PGDLLIMPORT bbfViewHasInsteadofTrigger_hook_type bbfViewHasInsteadofTrigger_hook;
 
 typedef bool (*check_rowcount_hook_type) (int es_processed);
 extern PGDLLIMPORT check_rowcount_hook_type check_rowcount_hook;


### PR DESCRIPTION
### Description
Currently Postgres does not support Instead of Trigger On Views for DML queries.

On running such a query on VIEW, query rewriting substitutes view with underlying base table.
Added a hook for skipping the substitution for DML query on the VIEW.

This change will add support for Instaed of Triggers for DML queries when using Babelfish.

Task: BABEL-2170

Signed-off-by: Deepakshi Mittal <depakshi@amazon.com>

- [] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
