### PR TITLE
Schema Resolution for multiple functions in single stmt

### DIFF
--- a/src/backend/utils/fmgr/fmgr.c
+++ b/src/backend/utils/fmgr/fmgr.c
@@ -708,7 +708,7 @@ fmgr_security_definer(PG_FUNCTION_ARGS)
 	int			non_tsql_proc_count = 0;
 	void	   *newextra = NULL;
 	char 	   *cacheTupleProcname = NULL;
-	char	   *old_search_path = false;
+	char	   *old_search_path = NULL;
 
 	if (!fcinfo->flinfo->fn_extra)
 	{
@@ -895,7 +895,6 @@ fmgr_security_definer(PG_FUNCTION_ARGS)
 			if(sql_dialect == tsql_dialect && old_search_path)
 			{
 				namespace_search_path = old_search_path;
-				elog(LOG, "-------------> %s", old_search_path);
 				assign_search_path(old_search_path, newextra);
 			}
 			sql_dialect = sql_dialect_value_old;
@@ -913,7 +912,6 @@ fmgr_security_definer(PG_FUNCTION_ARGS)
 		if(sql_dialect == tsql_dialect && old_search_path)
 		{
 			namespace_search_path = old_search_path;
-			elog(LOG, "-------------> %s", old_search_path);
 			assign_search_path(old_search_path, newextra);
 		}
 

--- a/src/backend/utils/fmgr/fmgr.c
+++ b/src/backend/utils/fmgr/fmgr.c
@@ -752,10 +752,13 @@ fmgr_security_definer(PG_FUNCTION_ARGS)
 		if (set_local_schema_for_func_hook)
 		{
 			char 	*new_search_path;
+			
+			oldcxt = MemoryContextSwitchTo(fcinfo->flinfo->fn_mcxt);
 			new_search_path = (*set_local_schema_for_func_hook)(procedureStruct->oid);
 			if (new_search_path)
 				fcache->proconfig = GUCArrayAdd(fcache->proconfig, "search_path",
 													new_search_path);
+			MemoryContextSwitchTo(oldcxt);
 		}
 		ReleaseSysCache(tuple);
 

--- a/src/backend/utils/fmgr/fmgr.c
+++ b/src/backend/utils/fmgr/fmgr.c
@@ -45,7 +45,7 @@ PGDLLIMPORT fmgr_hook_type fmgr_hook = NULL;
 PGDLLIMPORT non_tsql_proc_entry_hook_type non_tsql_proc_entry_hook = NULL;
 PGDLLIMPORT get_func_language_oids_hook_type get_func_language_oids_hook = NULL;
 PGDLLIMPORT pgstat_function_wrapper_hook_type pgstat_function_wrapper_hook = NULL;
-set_local_schema_for_func_hookType set_local_schema_for_func_hook;
+set_local_schema_for_func_hook_type set_local_schema_for_func_hook;
 
 /*
  * Hashtable for fast lookup of external C functions
@@ -719,7 +719,6 @@ fmgr_security_definer(PG_FUNCTION_ARGS)
 		pltsql_validator_oid = InvalidOid;
 	}
 
-	// get_language_procs("pltsql", &pltsql_lang_oid, &pltsql_validator_oid);
 	set_sql_dialect = pltsql_lang_oid != InvalidOid;
 
 	if (!fcinfo->flinfo->fn_extra)
@@ -804,9 +803,9 @@ fmgr_security_definer(PG_FUNCTION_ARGS)
 
 	if (fcache->prosearchpath)
 	{
-			old_search_path = namespace_search_path;
-			namespace_search_path = fcache->prosearchpath;
-			assign_search_path(fcache->prosearchpath, newextra);
+		old_search_path = namespace_search_path;
+		namespace_search_path = fcache->prosearchpath;
+		assign_search_path(fcache->prosearchpath, newextra);
 	}
 
 	if (set_sql_dialect && IsTransactionState())
@@ -917,7 +916,7 @@ fmgr_security_definer(PG_FUNCTION_ARGS)
 
 	fcinfo->flinfo = save_flinfo;
 
-	if(old_search_path)
+	if (old_search_path)
 	{
 		namespace_search_path = old_search_path;
 		assign_search_path(old_search_path, newextra);

--- a/src/backend/utils/fmgr/fmgr.c
+++ b/src/backend/utils/fmgr/fmgr.c
@@ -899,6 +899,12 @@ fmgr_security_definer(PG_FUNCTION_ARGS)
 		 * inside procedures. Fix it as part of larger interoperability
 		 * design for PG vs TSQL procedures.
 		 */
+		if (set_sql_dialect)
+		{
+			sql_dialect = sql_dialect_value_old;
+			assign_sql_dialect(sql_dialect_value_old, newextra);
+		}
+		
 		if (old_search_path)
 		{
 			namespace_search_path = old_search_path;

--- a/src/include/fmgr.h
+++ b/src/include/fmgr.h
@@ -778,8 +778,8 @@ typedef void (*non_tsql_proc_entry_hook_type) (int, int);
 
 typedef void (*get_func_language_oids_hook_type)(Oid *, Oid *);
 
-typedef char *(*set_local_schema_for_func_hookType) (Oid proc_nsp_oid);
-extern set_local_schema_for_func_hookType set_local_schema_for_func_hook;
+typedef char *(*set_local_schema_for_func_hook_type) (Oid proc_nsp_oid);
+extern set_local_schema_for_func_hook_type set_local_schema_for_func_hook;
 
 extern PGDLLIMPORT needs_fmgr_hook_type needs_fmgr_hook;
 extern PGDLLIMPORT fmgr_hook_type fmgr_hook;

--- a/src/include/fmgr.h
+++ b/src/include/fmgr.h
@@ -778,7 +778,7 @@ typedef void (*non_tsql_proc_entry_hook_type) (int, int);
 
 typedef void (*get_func_language_oids_hook_type)(Oid *, Oid *);
 
-typedef char *(*set_local_schema_for_func_hookType) (Oid proc_oid);
+typedef char *(*set_local_schema_for_func_hookType) (Oid proc_nsp_oid);
 extern set_local_schema_for_func_hookType set_local_schema_for_func_hook;
 
 extern PGDLLIMPORT needs_fmgr_hook_type needs_fmgr_hook;

--- a/src/include/fmgr.h
+++ b/src/include/fmgr.h
@@ -778,6 +778,9 @@ typedef void (*non_tsql_proc_entry_hook_type) (int, int);
 
 typedef void (*get_func_language_oids_hook_type)(Oid *, Oid *);
 
+typedef char *(*set_local_schema_for_func_hookType) (Oid proc_oid);
+extern set_local_schema_for_func_hookType set_local_schema_for_func_hook;
+
 extern PGDLLIMPORT needs_fmgr_hook_type needs_fmgr_hook;
 extern PGDLLIMPORT fmgr_hook_type fmgr_hook;
 extern PGDLLIMPORT non_tsql_proc_entry_hook_type non_tsql_proc_entry_hook;


### PR DESCRIPTION
### Description

In SQL Server the default schema inside  functions is same as functions schema, followed by the actual query default schema. We previously handled this behaviour on a statement level which worked correctly when only one schema & one function was used in the statement. When multiple functions and schemas are specified or the schema is specified with some other object along with a non schema specified function, this approach becomes ineffective, since we would resolve everything to the one schema.

To solve this we must resolve the schema (pg search path) at function execution level. We should only do this for user defined functions. All procedures & triggers will be excluded from the change since their schema resolution follows different strategy and is already implemented else where in the code. Cross DB functions call are not allowed in babelfish, so need not to look at those cases. System defined functions (sys, pg_catalog, ...) should be excluded from this change since they are expected to run in postgres environment.

The implementation uses the SET option available for PG function definitions. This SET cmd is picked up from PG catalog and locally set at run time(only for function execution). We do not store this information in the catalog itself. Instead we search the function owner schema and call the SET command during function initialisation.
But instead of adding the new search path to proconfig attribute of functions, we set it directly using the search_path global variable, to avoid performance drop.

We also store the new search path in fcache->prosearchpath to avoid multiple calls.
And we skip setting search path if language is not pltsql 

ex: Select s2.f();

s2.f() {
   -- first we search objects in s2
   -- then we search in database default schema s2.dbo
}

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

#### Engine PR: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/227
#### Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1885

### Issues Resolved

[BABEL-4442]
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
