### PR TITLE
Create DB Performance improvements

### DIFF
--- a/src/backend/utils/adt/acl.c
+++ b/src/backend/utils/adt/acl.c
@@ -33,7 +33,6 @@
 #include "funcapi.h"
 #include "lib/qunique.h"
 #include "miscadmin.h"
-#include "parser/parser.h"
 #include "utils/acl.h"
 #include "utils/array.h"
 #include "utils/builtins.h"

--- a/src/backend/utils/adt/acl.c
+++ b/src/backend/utils/adt/acl.c
@@ -5120,14 +5120,8 @@ select_best_grantor(Oid roleId, AclMode privileges,
 		return;
 	}
 
-	/*
-	 * Otherwise we have to do a careful search to see if roleId has the
-	 * privileges of any suitable role.  Note: we can hang onto the result of
-	 * roles_is_member_of() throughout this loop, because aclmask_direct()
-	 * doesn't query any role memberships.
-	 */
-
-	if(roleId == get_role_oid("sysadmin", true))
+	if(sql_dialect == SQL_DIALECT_TSQL &&
+		roleId == get_role_oid("sysadmin", true))
 	{
 		AclMode		sysadmin_privs;
 
@@ -5142,6 +5136,12 @@ select_best_grantor(Oid roleId, AclMode privileges,
 		}
 	}
 
+	/*
+	 * Otherwise we have to do a careful search to see if roleId has the
+	 * privileges of any suitable role.  Note: we can hang onto the result of
+	 * roles_is_member_of() throughout this loop, because aclmask_direct()
+	 * doesn't query any role memberships.
+	 */
 	roles_list = roles_is_member_of(roleId, ROLERECURSE_PRIVS,
 									InvalidOid, NULL);
 

--- a/src/backend/utils/adt/acl.c
+++ b/src/backend/utils/adt/acl.c
@@ -5126,6 +5126,22 @@ select_best_grantor(Oid roleId, AclMode privileges,
 	 * roles_is_member_of() throughout this loop, because aclmask_direct()
 	 * doesn't query any role memberships.
 	 */
+
+	if(roleId == get_role_oid("sysadmin", true))
+	{
+		AclMode		sysadmin_privs;
+
+		sysadmin_privs = aclmask_direct(acl, roleId, ownerId,
+									needed_goptions, ACLMASK_ALL);
+		if (sysadmin_privs == needed_goptions)
+		{
+			/* Found a suitable grantor */
+			*grantorId = roleId;
+			*grantOptions = sysadmin_privs;
+			return;
+		}
+	}
+
 	roles_list = roles_is_member_of(roleId, ROLERECURSE_PRIVS,
 									InvalidOid, NULL);
 

--- a/src/backend/utils/adt/acl.c
+++ b/src/backend/utils/adt/acl.c
@@ -118,6 +118,8 @@ static AclResult pg_role_aclcheck(Oid role_oid, Oid roleid, AclMode mode);
 
 static void RoleMembershipCacheCallback(Datum arg, int cacheid, uint32 hashvalue);
 
+bbf_get_sysadmin_oid_hook_type bbf_get_sysadmin_oid_hook = NULL;
+
 
 /*
  * getid
@@ -5121,8 +5123,7 @@ select_best_grantor(Oid roleId, AclMode privileges,
 		return;
 	}
 
-	if(sql_dialect == SQL_DIALECT_TSQL &&
-		roleId == get_role_oid("sysadmin", true))
+	if(bbf_get_sysadmin_oid_hook && roleId == (*bbf_get_sysadmin_oid_hook)())
 	{
 		AclMode		sysadmin_privs;
 

--- a/src/backend/utils/adt/acl.c
+++ b/src/backend/utils/adt/acl.c
@@ -5123,12 +5123,12 @@ select_best_grantor(Oid roleId, AclMode privileges,
 		return;
 	}
 
-	if(bbf_get_sysadmin_oid_hook && roleId == (*bbf_get_sysadmin_oid_hook)())
+	if (bbf_get_sysadmin_oid_hook && roleId == (*bbf_get_sysadmin_oid_hook)())
 	{
 		AclMode		sysadmin_privs;
 
 		sysadmin_privs = aclmask_direct(acl, roleId, ownerId,
-									needed_goptions, ACLMASK_ALL);
+										needed_goptions, ACLMASK_ALL);
 		if (sysadmin_privs == needed_goptions)
 		{
 			/* Found a suitable grantor */

--- a/src/backend/utils/adt/acl.c
+++ b/src/backend/utils/adt/acl.c
@@ -33,6 +33,7 @@
 #include "funcapi.h"
 #include "lib/qunique.h"
 #include "miscadmin.h"
+#include "parser/parser.h"
 #include "utils/acl.h"
 #include "utils/array.h"
 #include "utils/builtins.h"

--- a/src/include/utils/acl.h
+++ b/src/include/utils/acl.h
@@ -333,4 +333,7 @@ extern bool has_bypassrls_privilege(Oid roleid);
 typedef bool (*tsql_has_linked_srv_permissions_hook_type) (Oid roleid);
 extern PGDLLIMPORT tsql_has_linked_srv_permissions_hook_type tsql_has_linked_srv_permissions_hook;
 
+typedef Oid (*bbf_get_sysadmin_oid_hook_type) (void);
+extern PGDLLIMPORT bbf_get_sysadmin_oid_hook_type bbf_get_sysadmin_oid_hook;
+
 #endif							/* ACL_H */


### PR DESCRIPTION
### Description

In Multi DB mode, as the number of databases increases, so does the time to create the next new DB.
This is because we create three internal roles for each new DB and internally when run the DB subcommands, multiple calls to roles_is_member_of("sysadmin") is made. Now that output of this list contains all the three roles of every db created. This is the major reason for the perfomance degradation of CREATE DB command.

We fix this in three different places.

1. getAvailDbid - this functions makes a call to nextval function, which by default checks for current user's permission and makes a call to roles_is_member_of. Instead we could call the **nextval_internal** which is the same function but with the additional option of check permissions flag which we will set to false. To double check we can just ensure that the current user is "sysadmin" when getAvailDbid is called. (Currently we only call this when user is sysadmin)

2. Set temporary user when creating schema - when we create the dbo and guest schema for the new database, the create schema function fetches all the roles that current role is member of (recursively) to check if if current role can actually become the target schema owner role. To bypass this we can **assume the newdb_dbo role** when creating these schemas. In this case all the roles that newdb_dbo is member of will be fetched, but this list is much smaller than sysadmin.

3. Select best grantor - Select best grantor first fetches the roles_list that sysadmin is member of and then start checking for permissions. But sysadmin is always the first to be checked. That is sysadmin is always top of the roles_list. 
We can add a quick check to this. That is, first check if current role is sysadmin and can it give us all the permission needed. If yes, simply return. Note** This does not change any behaviour since this will anyway be done in the first loop after fetching roles_list. We are instead running the first loop before fetching the whole list.

4. Set newdb_dbo user when creating sysdatabases view in new db

| Create DB              | After | Before |
| :----------------: | :------: | :----: |
| DBs10        |   2ms  | 5ms |
| DBs500     |   3ms   | 163ms |
| DBs1000    |  4ms   | 740ms |
| DBs3000   |  9ms   | NA(~18secs) |

#### Engine PR: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/234
#### Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1899
#### Extension PR: (cache sysadmin oid) https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1942

### Issues Resolved

[BABEL-3869](https://jira.rds.a2z.com/browse/BABEL-3869)


Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>


- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
