### PR TITLE
Redoing unquoted string handling

### DIFF
--- a/src/backend/commands/functioncmds.c
+++ b/src/backend/commands/functioncmds.c
@@ -82,8 +82,6 @@
 
 check_lang_as_clause_hook_type check_lang_as_clause_hook = NULL;
 write_stored_proc_probin_hook_type write_stored_proc_probin_hook = NULL;
-declare_parameter_unquoted_string_hook_type declare_parameter_unquoted_string_hook = NULL;
-declare_parameter_unquoted_string_reset_hook_type declare_parameter_unquoted_string_reset_hook = NULL;
 
 /*
  *	 Examine the RETURNS clause of the CREATE FUNCTION statement
@@ -412,23 +410,14 @@ interpret_function_parameter_list(ParseState *pstate,
 		if (fp->defexpr)
 		{
 			Node *def;
-			Node *paramDft;
 
 			if (!isinput)
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_FUNCTION_DEFINITION),
 						 errmsg("only input parameters can have default values")));
 
-			paramDft = fp->defexpr;
-			if (declare_parameter_unquoted_string_hook) 
-				declare_parameter_unquoted_string_hook(paramDft, objtype);  
-
-			def = transformExpr(pstate, 
-								paramDft,
-								EXPR_KIND_FUNCTION_DEFAULT);
-								
-			if (declare_parameter_unquoted_string_reset_hook) 
-				declare_parameter_unquoted_string_reset_hook(paramDft);  		
+			def = transformExpr(pstate, fp->defexpr,
+					    EXPR_KIND_FUNCTION_DEFAULT);
 								
 			def = coerce_to_specific_type(pstate, def, toid, "DEFAULT");
 			assign_expr_collations(pstate, def);

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -88,10 +88,6 @@ pre_transform_setop_tree_hook_type pre_transform_setop_tree_hook = NULL;
 /* Hook to reset a query's targetlist after modification in pre_transfrom_sort_clause */
 pre_transform_setop_sort_clause_hook_type pre_transform_setop_sort_clause_hook = NULL;
 
-/* Hooks for handling unquoted string argumentss in T-SQL procedure calls */
-call_argument_unquoted_string_hook_type call_argument_unquoted_string_hook = NULL;
-call_argument_unquoted_string_reset_hook_type call_argument_unquoted_string_reset_hook = NULL;
-
 static Query *transformOptionalSelectInto(ParseState *pstate, Node *parseTree);
 static Query *transformDeleteStmt(ParseState *pstate, DeleteStmt *stmt);
 static Query *transformInsertStmt(ParseState *pstate, InsertStmt *stmt);
@@ -3123,17 +3119,9 @@ transformCallStmt(ParseState *pstate, CallStmt *stmt)
 	targs = NIL;
 	foreach(lc, stmt->funccall->args)
 	{
-		Node *colref_arg = NULL; 
-		Node *arg = lfirst(lc);
-		if (call_argument_unquoted_string_hook) 
-			colref_arg = (*call_argument_unquoted_string_hook)(arg);
-
 		targs = lappend(targs, transformExpr(pstate,
-											 arg,
+											 (Node *) lfirst(lc),
 											 EXPR_KIND_CALL_ARGUMENT));
-
-		if (call_argument_unquoted_string_reset_hook) 
-			call_argument_unquoted_string_reset_hook(colref_arg);
 	}
 
 	node = ParseFuncOrColumn(pstate,

--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -125,40 +125,6 @@ transformExprRecurse(ParseState *pstate, Node *expr)
 
 	switch (nodeTag(expr))
 	{
-		case T_TSQL_UnquotedString:
-			Assert(sql_dialect == SQL_DIALECT_TSQL);
-			{
-				/* 
-				 * This means the node is an unquoted string argument in a T-SQL procedure 
-				 * call or in a parameter default declaration in a T-SQL CREATE PROCEDURE/
-				 * CREATE FUNCTION statement.
-				 * Such arguments show up in the parse tree as T_ColumnRef nodes, which 
-				 * are intercepted in transformCallStmt() and interpret_function_parameter_list()
-				 * and temporarily changed to node type T_TSQL_UnquotedString.
-				 * Below, a constant T_String node is created for this argument instead 
-				 * of a ColumnRef node, which means it will be processed as a string -- as is
-				 * the T-SQL semantic.
-				 */
-				A_Const newConst;
-
-				/* 
-				 * Get the string argument, which is pretending to be a column name at this point.
-				 */
-				ColumnRef *cref = (ColumnRef *) expr;
-				Node *colnameField = (Node *) linitial(cref->fields);			
-				char *colname = strVal(colnameField);
-
-				/*
-				 * Create a new node of type string
-				 */
-				newConst.type = T_String;
-				newConst.isnull = false;
-				newConst.location = cref->location;
-				newConst.val.sval = *(makeString(colname));
-				result = (Node *) make_const(pstate, &newConst);
-			}
-			break;
-
 		case T_ColumnRef:
 			result = transformColumnRef(pstate, (ColumnRef *) expr);
 			break;

--- a/src/include/commands/defrem.h
+++ b/src/include/commands/defrem.h
@@ -80,11 +80,6 @@ typedef void (*write_stored_proc_probin_hook_type)(CreateFunctionStmt *stmt, Oid
 extern PGDLLIMPORT check_lang_as_clause_hook_type check_lang_as_clause_hook;
 extern PGDLLIMPORT write_stored_proc_probin_hook_type write_stored_proc_probin_hook;
 
-typedef void (*declare_parameter_unquoted_string_hook_type)(Node *paramDft, ObjectType objtype);
-extern PGDLLIMPORT declare_parameter_unquoted_string_hook_type declare_parameter_unquoted_string_hook;
-typedef void (*declare_parameter_unquoted_string_reset_hook_type)(Node *paramDft);
-extern PGDLLIMPORT declare_parameter_unquoted_string_reset_hook_type declare_parameter_unquoted_string_reset_hook;
-
 /* commands/operatorcmds.c */
 extern ObjectAddress DefineOperator(List *names, List *parameters);
 extern void RemoveOperatorById(Oid operOid);

--- a/src/include/nodes/nodes.h
+++ b/src/include/nodes/nodes.h
@@ -538,12 +538,7 @@ typedef enum NodeTag
 	/*
 	 * Additional TAG FOR VALUE NODES (value.h)
 	 */
-	T_TSQL_HexString,
-
-	/*
-	 * Additional tag for handling unquoted TSQL strings
-	 */
-	T_TSQL_UnquotedString
+	T_TSQL_HexString
 
 } NodeTag;
 

--- a/src/include/parser/analyze.h
+++ b/src/include/parser/analyze.h
@@ -64,14 +64,6 @@ extern PGDLLIMPORT pre_transform_setop_tree_hook_type pre_transform_setop_tree_h
 typedef void (*pre_transform_setop_sort_clause_hook_type) (ParseState *pstate, Query *qry, List *sortClause, Query *leftmostQuery);
 extern PGDLLIMPORT pre_transform_setop_sort_clause_hook_type pre_transform_setop_sort_clause_hook;
 
-/* Hooks for handling unquoted string argumentss in T-SQL procedure calls */
-typedef Node* (*call_argument_unquoted_string_hook_type)(Node *arg);
-extern PGDLLIMPORT call_argument_unquoted_string_hook_type call_argument_unquoted_string_hook;
-
-typedef void (*call_argument_unquoted_string_reset_hook_type)(Node *colref_arg);
-extern PGDLLIMPORT call_argument_unquoted_string_reset_hook_type call_argument_unquoted_string_reset_hook;
-
-
 extern Query *parse_analyze_fixedparams(RawStmt *parseTree, const char *sourceText,
 										const Oid *paramTypes, int numParams, QueryEnvironment *queryEnv);
 extern Query *parse_analyze(RawStmt *parseTree, const char *sourceText,


### PR DESCRIPTION
### Description

Re-implements unquoted string handling, as the previous fix (https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/206 , https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1821) did not address all use cases, notably strings longer than 63 characters; also all unquoted strings were downcased. 
This fix rolls back the previous code changes and implements the the unquoted string handling fully in the Babelfish extension (`tsqlIface.cpp`).

Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/1900

Signed-off-by: Rob Verschoor [rcv@amazon.com](mailto:rcv@amazon.com)
 
### Issues Resolved

BABEL-334 Support unquoted string parameter values in procedure calls/declarations
BABEL-2883 Error raised when invoking sproc w string parameter using argument in square brackets
BABEL-4452 Incorrect results with long unquoted string parameter values in procedure calls/declarations
 
## Test Scenarios Covered

- Use case based - Yes

- Boundary conditions - Yes

- Arbitrary inputs - N/A

- Negative test cases - Yes

- Minor version upgrade tests - N/A

- Major version upgrade tests - N/A

- Performance tests - N/A

- Tooling impact - N/A

- Client tests - N/A


### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
