### PR TITLE
Support default as params for function and procedure

### DIFF
--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -4155,7 +4155,6 @@ replace_function_defaults(List *args, HeapTuple func_tuple, bool *need_replace)
 	List	   *defaults;
 	ListCell   *lc;
 	List       *ret = NIL;
-	int        i;
 	int			nargs = list_length(args);
 
 	*need_replace = false;

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -4154,7 +4154,7 @@ replace_function_defaults(List *args, HeapTuple func_tuple, bool *need_replace)
 	List	   *defaults;
 	ListCell   *lc;
 	List       *ret = NIL;
-	int        i;
+	int        i,j;
 	int			nargs = list_length(args);
 
 	*need_replace = false;
@@ -4196,8 +4196,15 @@ replace_function_defaults(List *args, HeapTuple func_tuple, bool *need_replace)
 			if(((FuncExpr*)lfirst(lc))->funcformat == COERCE_IMPLICIT_CAST &&
 				nodeTag(linitial(((FuncExpr*)lfirst(lc))->args)) == T_SetToDefault)
 			{
-				ret = lappend(ret, list_nth(defaults, i));
+				// We'll keep the implicit cast function when it needs implicit cast
+				FuncExpr *funcExpr = (FuncExpr*)lfirst(lc);
+				List *newArgs = NIL;
+				newArgs = lappend(newArgs, list_nth(defaults, i));
 				i++;
+				for (j = 1; j < list_length(funcExpr->args); ++j)
+					newArgs = lappend(newArgs, list_nth(funcExpr->args, j));
+				funcExpr->args = newArgs;
+				ret = lappend(ret, funcExpr);
 			}
 		}
 		else ret = lappend(ret, lfirst(lc));

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -3119,9 +3119,17 @@ transformCallStmt(ParseState *pstate, CallStmt *stmt)
 	targs = NIL;
 	foreach(lc, stmt->funccall->args)
 	{
-		targs = lappend(targs, transformExpr(pstate,
-											 (Node *) lfirst(lc),
-											 EXPR_KIND_CALL_ARGUMENT));
+		if (sql_dialect == SQL_DIALECT_TSQL && nodeTag((Node*)lfirst(lc)) == T_SetToDefault)
+		{
+			((SetToDefault *)lfirst(lc))->typeId = VOIDOID;
+			targs = lappend(targs, (Node *) lfirst(lc));
+		}
+		else
+		{
+			targs = lappend(targs, transformExpr(pstate,
+												(Node *) lfirst(lc),
+												EXPR_KIND_CALL_ARGUMENT));
+		}
 	}
 
 	node = ParseFuncOrColumn(pstate,

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -3121,7 +3121,9 @@ transformCallStmt(ParseState *pstate, CallStmt *stmt)
 	{
 		if (sql_dialect == SQL_DIALECT_TSQL && nodeTag((Node*)lfirst(lc)) == T_SetToDefault)
 		{
-			((SetToDefault *)lfirst(lc))->typeId = VOIDOID;
+			// For Tsql Default in function call, we set it to UNKNOWN in parser stage
+			// In analyzer it'll use other types to detect the right func candidate
+			((SetToDefault *)lfirst(lc))->typeId = UNKNOWNOID;
 			targs = lappend(targs, (Node *) lfirst(lc));
 		}
 		else

--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -176,6 +176,10 @@ coerce_type(ParseState *pstate, Node *node,
 		/* no conversion needed */
 		return node;
 	}
+	if (nodeTag((Node*)node) == T_SetToDefault)
+	{
+		return node;
+	}
 	if (targetTypeId == ANYOID ||
 		targetTypeId == ANYELEMENTOID ||
 		targetTypeId == ANYNONARRAYOID ||
@@ -674,6 +678,16 @@ can_coerce_type(int nargs, const Oid *input_typeids, const Oid *target_typeids,
 		if (targetTypeId == RECORDARRAYOID &&
 			is_complex_array(inputTypeId))
 			continue;
+
+		/*
+		 * We're using VOIDOID as representing default,
+		 * Since the function didn't pass the fargs as params
+		 */
+		if (inputTypeId == VOIDOID && sql_dialect == SQL_DIALECT_TSQL) 
+		{
+			inputTypeId = targetTypeId;
+			continue;
+		}
 
 		/*
 		 * If input is a class type that inherits from target, accept

--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -680,16 +680,6 @@ can_coerce_type(int nargs, const Oid *input_typeids, const Oid *target_typeids,
 			continue;
 
 		/*
-		 * We're using VOIDOID as representing default,
-		 * Since the function didn't pass the fargs as params
-		 */
-		if (inputTypeId == VOIDOID && sql_dialect == SQL_DIALECT_TSQL) 
-		{
-			inputTypeId = targetTypeId;
-			continue;
-		}
-
-		/*
 		 * If input is a class type that inherits from target, accept
 		 */
 		if (typeInheritsFrom(inputTypeId, targetTypeId)

--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -1489,8 +1489,16 @@ transformFuncCall(ParseState *pstate, FuncCall *fn)
 	targs = NIL;
 	foreach(args, fn->args)
 	{
-		targs = lappend(targs, transformExprRecurse(pstate,
+		if (sql_dialect == SQL_DIALECT_TSQL && nodeTag((Node*)lfirst(args)) == T_SetToDefault)
+		{
+			((SetToDefault *)lfirst(args))->typeId = VOIDOID;
+			targs = lappend(targs, (Node *) lfirst(args));
+		}
+		else
+		{
+			targs = lappend(targs, transformExprRecurse(pstate,
 													(Node *) lfirst(args)));
+		}
 	}
 
 	/*
@@ -1522,10 +1530,12 @@ transformFuncCall(ParseState *pstate, FuncCall *fn)
        */
 
       if (!schemaname || (strlen(schemaname) == 3 && strncmp(schemaname, "sys", 3) == 0))
-              if (strlen(functionname) == 8 &&
-                          strncmp(functionname, "checksum", 8) == 0 &&
-                          fn->agg_star == true)
-                      targs = ExpandChecksumStar(pstate, fn, fn->location);
+	{
+        if (strlen(functionname) == 8 &&
+            strncmp(functionname, "checksum", 8) == 0 &&
+                fn->agg_star == true)
+            targs = ExpandChecksumStar(pstate, fn, fn->location);
+	}
 
 	/* ... and hand off to ParseFuncOrColumn */
 	return ParseFuncOrColumn(pstate,

--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -1491,7 +1491,9 @@ transformFuncCall(ParseState *pstate, FuncCall *fn)
 	{
 		if (sql_dialect == SQL_DIALECT_TSQL && nodeTag((Node*)lfirst(args)) == T_SetToDefault)
 		{
-			((SetToDefault *)lfirst(args))->typeId = VOIDOID;
+			// For Tsql Default in function call, we set it to UNKNOWN in parser stage
+			// In analyzer it'll use other types to detect the right func candidate
+			((SetToDefault *)lfirst(args))->typeId = UNKNOWNOID;
 			targs = lappend(targs, (Node *) lfirst(args));
 		}
 		else

--- a/src/include/optimizer/clauses.h
+++ b/src/include/optimizer/clauses.h
@@ -59,4 +59,7 @@ extern Bitmapset *pull_paramids(Expr *expr);
 typedef void (*insert_pltsql_function_defaults_hook_type)(HeapTuple func_tuple, List *defaults, Node **argarray);
 extern PGDLLIMPORT insert_pltsql_function_defaults_hook_type insert_pltsql_function_defaults_hook;
 
+typedef List* (*replace_pltsql_function_defaults_hook_type)(HeapTuple func_tuple, List *defaults, List *fargs);
+extern PGDLLIMPORT replace_pltsql_function_defaults_hook_type replace_pltsql_function_defaults_hook;
+
 #endif							/* CLAUSES_H */


### PR DESCRIPTION
Previously when we call functions/procedures, we don't support default keyword usage like :

select foofunc(default);
or
exec fooproc default

This commit support to use default keyword as function or procedure param when the default value is previously defined in create proc/func

Task: BABEL-335

### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
