### PR TITLE
[OSS ONLY] Update RPM spec file to rename pg_dump/pg_dumpall binaries

### DIFF
--- a/BabelfishDump.spec
+++ b/BabelfishDump.spec
@@ -73,9 +73,11 @@ This package provides utilities to dump a Babelfish database.
 %prep
 %setup -q -n %{name}
 
-# Update binary versions
+# Change binary names
+sed -i "s/pg_dump/bbf_dump/g" src/bin/pg_dump/pg_dumpall.c
 sed -i "s/pg_dump (PostgreSQL)/bbf_dump (pg_dump compatible with Babelfish for PostgreSQL)/g" src/bin/pg_dump/pg_dump.c
-sed -i "s/pg_dumpall (PostgreSQL)/bbf_dumpall (pg_dumpall compatible with Babelfish for PostgreSQL)/g" src/bin/pg_dump/pg_dumpall.c
+sed -i "s/bbf_dump (PostgreSQL)/bbf_dump (pg_dump compatible with Babelfish for PostgreSQL)/g" src/bin/pg_dump/pg_dumpall.c
+sed -i "s/bbf_dumpall (PostgreSQL)/bbf_dumpall (pg_dumpall compatible with Babelfish for PostgreSQL)/g" src/bin/pg_dump/pg_dumpall.c
 
 %build
 # Building BabelfishDump


### PR DESCRIPTION
### Description
This commit makes the following changes:
1. Updates the logic to rename the names of pg_dump/pg_dumpall binaries.
2. Newer version string:
```
bbf_dumpall (pg_dumpall compatible with Babelfish for PostgreSQL) 15.4
bbf_dump (pg_dump compatible with Babelfish for PostgreSQL) 15.4
```
3. bbf_dumpall will reference bbf_dump instead of pg_dump binary.

Task: 
OSS ONLY

Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>

### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
