### PR TITLE
Correctly dump permissions for a Babelfish logical database

### DIFF
--- a/src/bin/pg_dump/dumpall_babel_utils.c
+++ b/src/bin/pg_dump/dumpall_babel_utils.c
@@ -315,7 +315,7 @@ getBabelfishRoleMembershipQuery(PGconn *conn, PQExpBuffer buf,
 						 "FROM pg_auth_members a "
 						 "INNER JOIN bbf_roles ur on ur.oid = a.roleid "
 						 "INNER JOIN bbf_roles um on um.oid = a.member "
-						 "INNER JOIN bbf_roles ug on ug.oid = a.grantor "
+						 "LEFT JOIN bbf_roles ug on ug.oid = a.grantor "
 						 "WHERE NOT (ur.rolname ~ '^pg_' AND um.rolname ~ '^pg_') "
 						 "ORDER BY 1,2,3");
 }


### PR DESCRIPTION
### Description
Previously, we were not dumping sysadmin membership for a database
user during database level dump due to which users other than sysadmin
were unable to drop the restored database.

This commit fixes the issue by correctly dumping role memberships for all
the database roles. Additionally, refactored the code a little bit in dump_babel_utils.c

Task: BABEL-4516
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
