### PR TITLE
Fix Crash when Instead of View Trigger calls itself

### DIFF
--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -70,6 +70,7 @@ int			SessionReplicationRole = SESSION_REPLICATION_ROLE_ORIGIN;
 
 /* How many levels deep into trigger execution are we? */
 static int	MyTriggerDepth = 0;
+List *triggerOids = NIL; /* To store all trigger calls information */
 
 /* Local function prototypes */
 static void renametrig_internal(Relation tgrel, Relation targetrel,

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -2579,7 +2579,6 @@ ExecCallTriggerFunc(TriggerData *trigdata,
 	{
 		MyTriggerDepth--;
 		triggerOids = list_delete_oid(triggerOids, trigdata->tg_trigger->tgoid);
-		// triggerOids = list_delete_last(triggerOids);
 	}
 	PG_END_TRY();
 

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -2572,11 +2572,13 @@ ExecCallTriggerFunc(TriggerData *trigdata,
 	MyTriggerDepth++;
 	PG_TRY();
 	{
+		triggerOids = lappend_oid(triggerOids, trigdata->tg_trigger->tgoid);
 		result = FunctionCallInvoke(fcinfo);
 	}
 	PG_FINALLY();
 	{
 		MyTriggerDepth--;
+		triggerOids = NIL;
 	}
 	PG_END_TRY();
 

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -2578,7 +2578,8 @@ ExecCallTriggerFunc(TriggerData *trigdata,
 	PG_FINALLY();
 	{
 		MyTriggerDepth--;
-		triggerOids = NIL;
+		triggerOids = list_delete_oid(triggerOids, trigdata->tg_trigger->tgoid);
+		// triggerOids = list_delete_last(triggerOids);
 	}
 	PG_END_TRY();
 

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -5446,29 +5446,6 @@ isTsqlInsteadofTriggerExecution(EState *estate, ResultRelInfo *relinfo, TriggerE
 	return false;
 }
 
-void checkRecursiveTriggerDepth(ResultRelInfo *relinfo)
-{
-	if (triggerOids && relinfo->ri_TrigDesc)
-	{
-		TriggerDesc *trigdesc;
-		int i;
-		trigdesc = relinfo->ri_TrigDesc;
-		for (i = 0; i < trigdesc->numtriggers; i++)
-		{
-			Trigger *trigger = &trigdesc->triggers[i];
-			Oid current_tgoid = trigger->tgoid;
-			Oid prev_tgoid = lfirst_oid(list_tail(triggerOids));
-			if (prev_tgoid != current_tgoid && list_member_oid(triggerOids, current_tgoid))
-			{
-				/** Indirect recursive trigger case*/
-				ereport(ERROR,
-						(errcode(ERRCODE_SYNTAX_ERROR),
-						 errmsg("Maximum stored procedure, function, trigger, or view nesting level exceeded (limit 32)")));
-			}
-		}
-	}
-}
-
 /* ----------
  * AfterTriggerBeginXact()
  *

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -802,9 +802,6 @@ ExecInsert(ModifyTableContext *context,
 	if (resultRelInfo->ri_projectReturning)
 		result = ExecProcessReturning(resultRelInfo, slot, planSlot);
 
-	if (sql_dialect == SQL_DIALECT_TSQL)
-		checkRecursiveTriggerDepth(resultRelInfo);
-		
 	/* INSTEAD OF ROW INSERT Triggers */
 	if (resultRelInfo->ri_TrigDesc &&
 		resultRelInfo->ri_TrigDesc->trig_insert_instead_row)
@@ -1480,8 +1477,6 @@ ExecDelete(ModifyTableContext *context,
 
 		ExecClearTuple(slot);
 	}
-	if (sql_dialect == SQL_DIALECT_TSQL)
-		checkRecursiveTriggerDepth(resultRelInfo);
 
 	if (resultRelInfo->ri_TrigDesc &&
 		resultRelInfo->ri_TrigDesc->trig_delete_instead_statement &&
@@ -2337,9 +2332,6 @@ ExecUpdate(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
 	/* Process RETURNING if present */
 	if (resultRelInfo->ri_projectReturning && sql_dialect == SQL_DIALECT_TSQL)
 		rslot = ExecProcessReturning(resultRelInfo, slot, context->planSlot);
-
-	if (sql_dialect == SQL_DIALECT_TSQL)
-		checkRecursiveTriggerDepth(resultRelInfo);
 
 	if (resultRelInfo->ri_TrigDesc &&
 		resultRelInfo->ri_TrigDesc->trig_update_instead_statement &&

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -802,6 +802,9 @@ ExecInsert(ModifyTableContext *context,
 	if (resultRelInfo->ri_projectReturning)
 		result = ExecProcessReturning(resultRelInfo, slot, planSlot);
 
+	if (sql_dialect == SQL_DIALECT_TSQL)
+		checkRecursiveTriggerDepth(resultRelInfo);
+		
 	/* INSTEAD OF ROW INSERT Triggers */
 	if (resultRelInfo->ri_TrigDesc &&
 		resultRelInfo->ri_TrigDesc->trig_insert_instead_row)
@@ -1477,6 +1480,8 @@ ExecDelete(ModifyTableContext *context,
 
 		ExecClearTuple(slot);
 	}
+	if (sql_dialect == SQL_DIALECT_TSQL)
+		checkRecursiveTriggerDepth(resultRelInfo);
 
 	if (resultRelInfo->ri_TrigDesc &&
 		resultRelInfo->ri_TrigDesc->trig_delete_instead_statement &&
@@ -2332,6 +2337,9 @@ ExecUpdate(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
 	/* Process RETURNING if present */
 	if (resultRelInfo->ri_projectReturning && sql_dialect == SQL_DIALECT_TSQL)
 		rslot = ExecProcessReturning(resultRelInfo, slot, context->planSlot);
+
+	if (sql_dialect == SQL_DIALECT_TSQL)
+		checkRecursiveTriggerDepth(resultRelInfo);
 
 	if (resultRelInfo->ri_TrigDesc &&
 		resultRelInfo->ri_TrigDesc->trig_update_instead_statement &&

--- a/src/backend/rewrite/rewriteHandler.c
+++ b/src/backend/rewrite/rewriteHandler.c
@@ -3736,7 +3736,8 @@ RewriteQuery(Query *parsetree, List *rewrite_events, int orig_rt_length)
 		result_relation = parsetree->resultRelation;
 		Assert(result_relation != 0);
 		rt_entry = rt_fetch(result_relation, parsetree->rtable);
-		Assert(rt_entry->rtekind == RTE_RELATION);
+		/** allow transition table in TSQL inside trigger body, rtekind can be RTE_NAMEDTUPLESTORE, eg inserted and deleted*/
+		Assert(rt_entry->rtekind == RTE_RELATION || (sql_dialect == SQL_DIALECT_TSQL && rt_entry->rtekind == RTE_NAMEDTUPLESTORE));
 
 		/*
 		 * We can use NoLock here since either the parser or

--- a/src/include/commands/trigger.h
+++ b/src/include/commands/trigger.h
@@ -309,6 +309,7 @@ extern void AfterTriggerEndSubXact(bool isCommit);
 extern void AfterTriggerSetState(ConstraintsSetStmt *stmt);
 extern bool AfterTriggerPendingOnRel(Oid relid);
 
+extern List *triggerOids; /* To store all trigger calls information */
 
 /*
  * in utils/adt/ri_triggers.c

--- a/src/include/commands/trigger.h
+++ b/src/include/commands/trigger.h
@@ -298,6 +298,7 @@ extern void ExecASTruncateTriggers(EState *estate,
 								   ResultRelInfo *relinfo);
 
 extern bool isTsqlInsteadofTriggerExecution(EState *estate, ResultRelInfo *relinfo, TriggerEvent event);
+extern void checkRecursiveTriggerDepth(ResultRelInfo *relinfo);
 
 extern void AfterTriggerBeginXact(void);
 extern void AfterTriggerBeginQuery(void);

--- a/src/include/commands/trigger.h
+++ b/src/include/commands/trigger.h
@@ -298,7 +298,6 @@ extern void ExecASTruncateTriggers(EState *estate,
 								   ResultRelInfo *relinfo);
 
 extern bool isTsqlInsteadofTriggerExecution(EState *estate, ResultRelInfo *relinfo, TriggerEvent event);
-extern void checkRecursiveTriggerDepth(ResultRelInfo *relinfo);
 
 extern void AfterTriggerBeginXact(void);
 extern void AfterTriggerBeginQuery(void);


### PR DESCRIPTION
### Description
This change will fix crashes when an
Instead of Trigger on View calls itself directly

Also fix  crash IO view trigger inserted is used with join (BABEL-4514)

Task: BABEL-2170

### Issues Resolved

 BABEL-2170

### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
