### PR TITLE
Explicit unnecessary cast should be eliminated

### DIFF
--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -56,6 +56,8 @@ tle_name_comparison_hook_type  tle_name_comparison_hook = NULL;
 
 sortby_nulls_hook_type  sortby_nulls_hook = NULL;
 
+optimize_explicit_cast_hook_type optimize_explicit_cast_hook = NULL;
+
 static int	extractRemainingColumns(ParseNamespaceColumn *src_nscolumns,
 									List *src_colnames,
 									List **src_colnos,
@@ -1741,11 +1743,13 @@ transformWhereClause(ParseState *pstate, Node *clause,
 
 	qual = transformExpr(pstate, clause, exprKind);
 
+	if (optimize_explicit_cast_hook)
+		qual = optimize_explicit_cast_hook(pstate, qual);
+	
 	qual = coerce_to_boolean(pstate, qual, constructName);
 
 	return qual;
 }
-
 
 /*
  * transformLimitClause -

--- a/src/include/parser/parse_clause.h
+++ b/src/include/parser/parse_clause.h
@@ -57,4 +57,7 @@ extern PGDLLIMPORT tle_name_comparison_hook_type tle_name_comparison_hook;
 typedef void (*sortby_nulls_hook_type)(SortGroupClause *sortcl, bool reverse);
 extern PGDLLIMPORT sortby_nulls_hook_type sortby_nulls_hook;
 
+typedef Node* (*optimize_explicit_cast_hook_type)(ParseState *pstate, Node *node);
+extern PGDLLIMPORT optimize_explicit_cast_hook_type optimize_explicit_cast_hook;
+
 #endif							/* PARSE_CLAUSE_H */


### PR DESCRIPTION
This commit can eliminate unnecessary explicit cast in where condition and tune the query to choose index in those conditions

Task: BABEL-4176

### Description

Previously, when using explicit casting, PG will not try to choose index scan. For example : 
```
select * from test where cast(id as bigint) = 1;
```
Even the id is defined as int, this query will not choose index scan on id index.

But for this explicit cast, it can be eliminate in certain circumstances like : 
```
        qual  in where condition

                                     \ 

                                '=' operator

                                     /        \
                cast(var( int )to bigint )       anything

```
should be optimized to 
```
        qual  in where condition

                              \ 

                                '=' operator

                               /        \

                              var       anything
```
The reason is an explicit cast from int4 to int8 for a var, won't change anything in the result, and eliminate that explicit cast would give a chance to choose the right index in optimization.

### Issues Resolved

When encountered a query structure like : 
```
        qual  in where condition

                                     \ 

                                '=' operator

                                     /        \

                cast(var( int )to bigint )       anything
```
This feature would eliminate the explicit cast : 
```
        qual  in where condition

                              \ 

                                '=' operator

                               /        \

                              var       anything
```
To make it possible to use the index scan instead of seq scan.

### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
