### PR TITLE
Fix backward scan flag for parallel queries

### DIFF
--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -1706,6 +1706,7 @@ SPI_cursor_open_internal(const char *name, SPIPlanPtr plan,
 		if (list_length(stmt_list) == 1 &&
 			linitial_node(PlannedStmt, stmt_list)->commandType != CMD_UTILITY &&
 			linitial_node(PlannedStmt, stmt_list)->rowMarks == NIL &&
+			!(sql_dialect == SQL_DIALECT_TSQL && linitial_node(PlannedStmt, stmt_list)->parallelModeNeeded) &&
 			ExecSupportsBackwardScan(linitial_node(PlannedStmt, stmt_list)->planTree))
 			portal->cursorOptions |= CURSOR_OPT_SCROLL;
 		else


### PR DESCRIPTION
### Description
Currently there is a bug in Babelfish that allows the backward scan flag to be set for parallel queries. However, backward scans cannot be parallelized. This bug results in assertion failures in the Postgres engine and leads Babelfish queries to crash. In this commit, we fix the issue by disallowing backward scan flag to be set when a query is in parallel mode. This issue occurs during the implementation of full text search in Babelfish. Fixing the issue unblocks full text search implementation.

Extension PR: [PR-2001]( https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2001)

Cherry-Picked from [PR-158](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/158)

Signed-off-by: Rohit Bhagat [rohitbgt@amazon.com](mailto:rohitbgt@amazon.com)
 
### Issues Resolved
BABEL-4281
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
