### PR TITLE
release sys cache reference after string literal hook

### DIFF
--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -329,9 +329,11 @@ coerce_type(ParseState *pstate, Node *node,
 												  targetTypeMod, baseTypeMod,
 												  newcon, DatumGetCString(con->constvalue),
 												  ccontext, cformat, location);
-			if (result) /* runtimer error function returned */
+			if (result)
+			{
+				ReleaseSysCache(baseType);
 				return result;
-
+			}
 			/*
 			 * If the result is NULL, the newcon should be already updated properly.
 			 * Keep advancing the code.


### PR DESCRIPTION
### Description

Release syscache reference when returning not null nodes from string literal hook to avoid cache reference leak

#### Engine PR: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/254
#### Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2009

### Issues Resolved
[BABEL-1940]

### Sign-off
Signed-off-by: Tanzeel Khan [tzlkhan@amazon.com](mailto:tzlkhan@amazon.com)
Co-authored-by: Rohit Bhagat [rohitbgt@amazon.com](mailto:rohitbgt@amazon.com)
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
