### PR TITLE
PIVOT Bugs Fix 

### DIFF
--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1758,9 +1758,9 @@ typedef struct SelectStmt
 	bool	isPivot;
 	struct SelectStmt *srcSql;
 	struct SelectStmt *catSql;
-	List	*value_col_strlist;
-	char	*pivotCol;
-	Node	*aggFunc;
+	List		*value_col_strlist;
+	ColumnRef	*pivotCol;
+	Node		*aggFunc;
 } SelectStmt;
 
 


### PR DESCRIPTION
### Description

Previously, Babelfish PIVOT operator has many bug and limitation. In this PR, we fixed the bugs and block some unsupported edge cases.
 
### Issues Resolved
BABEL-284-bug-fix (bugs tracker issue)
BABEL-4567, BABEL-4568, BABEL-4569, BABEL-4576, BABEL-4558, BABEL-4559
* fixed pivot used in function/procedure will cause server restart
* fixed table/schema name used in 'FOR (colname)' will cause server restart
* fixed view usage in pivot stmt produce empty result
* NULL should be the aggregate result when no row is selected(except COUNT)
* Error message for creating view on pivot, 
* Error message when use pivot in WITH CTE 
* Error message when use join with PIVOT stmt

### Test Scenarios Covered ###
- call function/procedure multiple times
- table schema name used in 'FOR (colname)'
- view usage in pivot stmt
- NULL value output when no row is selected by aggregate function in PIVOT
- creating view on pivot
- use pivot in WITH CTE
- join with PIVOT stmt
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
