### PR TITLE
Previously insert exec impl didn't consider the type cast during exec…

### DIFF
--- a/src/backend/access/common/attmap.c
+++ b/src/backend/access/common/attmap.c
@@ -307,7 +307,7 @@ check_attrmap_match(TupleDesc indesc,
 			return false;
 
 		/**
-		 * in tsql insert exec, we nned a cast
+		 * in tsql insert exec, we need a cast
 		 */
 		if (called_from_tsql_insert_exec_hook && called_from_tsql_insert_exec_hook()
 		 	&& (inatt->atttypid != outatt->atttypid ||

--- a/src/backend/access/common/attmap.c
+++ b/src/backend/access/common/attmap.c
@@ -26,6 +26,7 @@
 #include "access/htup_details.h"
 #include "utils/builtins.h"
 
+called_from_tsql_insert_exec_hook_type called_from_tsql_insert_exec_hook = NULL;
 
 static bool check_attrmap_match(TupleDesc indesc,
 								TupleDesc outdesc,
@@ -114,8 +115,10 @@ build_attrmap_by_position(TupleDesc indesc,
 			nincols++;
 
 			/* Found matching column, now check type */
-			if (atttypid != att->atttypid ||
-				(atttypmod != att->atttypmod && atttypmod >= 0))
+			/* skip check type if it's tsql insert exec */
+			if ((atttypid != att->atttypid ||
+				(atttypmod != att->atttypmod && atttypmod >= 0)) &&
+				!(called_from_tsql_insert_exec_hook && called_from_tsql_insert_exec_hook()))
 				ereport(ERROR,
 						(errcode(ERRCODE_DATATYPE_MISMATCH),
 						 errmsg_internal("%s", _(msg)),
@@ -301,6 +304,14 @@ check_attrmap_match(TupleDesc indesc,
 		 * If the input column has a missing attribute, we need a conversion.
 		 */
 		if (inatt->atthasmissing)
+			return false;
+
+		/**
+		 * in tsql insert exec, we nned a cast
+		 */
+		if (called_from_tsql_insert_exec_hook && called_from_tsql_insert_exec_hook()
+		 	&& (inatt->atttypid != outatt->atttypid ||
+			inatt->atttypmod != outatt->atttypmod))
 			return false;
 
 		if (attrMap->attnums[i] == (i + 1))

--- a/src/backend/access/common/tupconvert.c
+++ b/src/backend/access/common/tupconvert.c
@@ -21,6 +21,7 @@
 #include "access/tupconvert.h"
 #include "executor/tuptable.h"
 
+
 /*
  * The conversion setup routines have the following common API:
  *

--- a/src/backend/access/common/tupconvert.c
+++ b/src/backend/access/common/tupconvert.c
@@ -21,7 +21,6 @@
 #include "access/tupconvert.h"
 #include "executor/tuptable.h"
 
-
 /*
  * The conversion setup routines have the following common API:
  *

--- a/src/include/access/attmap.h
+++ b/src/include/access/attmap.h
@@ -48,5 +48,7 @@ extern AttrMap *build_attrmap_by_name_if_req(TupleDesc indesc,
 extern AttrMap *build_attrmap_by_position(TupleDesc indesc,
 										  TupleDesc outdesc,
 										  const char *msg);
+typedef bool (*called_from_tsql_insert_exec_hook_type)();
+extern PGDLLIMPORT called_from_tsql_insert_exec_hook_type called_from_tsql_insert_exec_hook;
 
 #endif							/* ATTMAP_H */

--- a/src/include/access/tupconvert.h
+++ b/src/include/access/tupconvert.h
@@ -48,4 +48,10 @@ extern Bitmapset *execute_attr_map_cols(AttrMap *attrMap, Bitmapset *inbitmap);
 
 extern void free_conversion_map(TupleConversionMap *map);
 
+typedef Datum (*exec_tsql_cast_value_hook_type)(Datum value, bool *isnull,
+							 Oid valtype, int32 valtypmod,
+							 Oid reqtype, int32 reqtypmod);
+extern PGDLLIMPORT exec_tsql_cast_value_hook_type exec_tsql_cast_value_hook;
+
+
 #endif							/* TUPCONVERT_H */


### PR DESCRIPTION
Previously insert exec impl didn't consider the type cast during execution, this fix has add a implicit type cast between insert execution and exec execution if the type is mismatched.

Task: BABEL-2999, BABEL-4426

 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
