### PR TITLE
Add support for geospatial function syntax for STAsBinary, STAsText, …

### DIFF
--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -1479,6 +1479,7 @@ transformBoolExpr(ParseState *pstate, BoolExpr *a)
 static Node *
 transformFuncCall(ParseState *pstate, FuncCall *fn)
 {
+	Node		*ret;
 	Node	   *last_srf = pstate->p_last_srf;
 	List	   *targs;
 	ListCell   *args;
@@ -1537,6 +1538,11 @@ transformFuncCall(ParseState *pstate, FuncCall *fn)
             strncmp(functionname, "checksum", 8) == 0 &&
                 fn->agg_star == true)
             targs = ExpandChecksumStar(pstate, fn, fn->location);
+	}
+
+	if (pstate->p_post_funcref_hook != NULL)
+	{
+		targs = pstate->p_post_funcref_hook(pstate, fn, targs);
 	}
 
 	/* ... and hand off to ParseFuncOrColumn */

--- a/src/include/parser/parse_node.h
+++ b/src/include/parser/parse_node.h
@@ -89,6 +89,7 @@ typedef enum ParseExprKind
  */
 typedef Node *(*PreParseColumnRefHook) (ParseState *pstate, ColumnRef *cref);
 typedef Node *(*PostParseColumnRefHook) (ParseState *pstate, ColumnRef *cref, Node *var);
+typedef List *(*PostParseFunctionRefHook) (ParseState *pstate, FuncCall *fn, List *fargs);
 typedef void (*PostParseExpandStarHook) (ParseState *pstate, ColumnRef *cref, List *l);
 typedef Node *(*ColumnRefOverwriteHook) (ParseState *pstate, ColumnRef *cref, Node *var);
 typedef Node *(*ParseParamRefHook) (ParseState *pstate, ParamRef *pref);
@@ -222,6 +223,7 @@ struct ParseState
 	 */
 	PreParseColumnRefHook p_pre_columnref_hook;
 	PostParseColumnRefHook p_post_columnref_hook;
+	PostParseFunctionRefHook p_post_funcref_hook;
 	PostParseExpandStarHook p_post_expand_star_hook;
 	ColumnRefOverwriteHook p_column_ref_overwrite_hook;
 	ParseParamRefHook p_paramref_hook;

--- a/src/tools/pgindent/typedefs.list
+++ b/src/tools/pgindent/typedefs.list
@@ -2075,6 +2075,7 @@ PortalHashEnt
 PortalStatus
 PortalStrategy
 PostParseColumnRefHook
+PostParseFunctionRefHook
 PostgresPollingStatusType
 PostingItem
 PostponedQual


### PR DESCRIPTION
…STDistance

### Description

[Describe what this change achieves]
 
### Issues Resolved

[List any issues this PR will resolve]
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
