### PR TITLE
Fix the remaining issues about default keyword in proc/func call

### DIFF
--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -4231,8 +4231,11 @@ fetch_function_defaults(HeapTuple func_tuple)
 	proargdefaults = SysCacheGetAttr(PROCOID, func_tuple,
 									 Anum_pg_proc_proargdefaults,
 									 &isnull);
-	if (isnull)
+	if (isnull && sql_dialect != SQL_DIALECT_TSQL)
+	// We don't want to see this error in TSQL
 		elog(ERROR, "not enough default arguments");
+	if (isnull && sql_dialect == SQL_DIALECT_TSQL)
+		return NIL;
 	str = TextDatumGetCString(proargdefaults);
 	defaults = castNode(List, stringToNode(str));
 	pfree(str);

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -4231,11 +4231,17 @@ fetch_function_defaults(HeapTuple func_tuple)
 	proargdefaults = SysCacheGetAttr(PROCOID, func_tuple,
 									 Anum_pg_proc_proargdefaults,
 									 &isnull);
-	if (isnull && sql_dialect != SQL_DIALECT_TSQL)
-	// We don't want to see this error in TSQL
+	if (isnull)
+	{
+		/* This error msg is not expected in Tsql for 2 reasons
+		   1. Procedure call will throw a specific error msg later
+		   2. Func call even without defining default value, it 
+		    won't error out, it'll use NULL instead */
+		if (sql_dialect == SQL_DIALECT_TSQL)
+			return NIL;
+
 		elog(ERROR, "not enough default arguments");
-	if (isnull && sql_dialect == SQL_DIALECT_TSQL)
-		return NIL;
+	}
 	str = TextDatumGetCString(proargdefaults);
 	defaults = castNode(List, stringToNode(str));
 	pfree(str);

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -3163,12 +3163,22 @@ transformCallStmt(ParseState *pstate, CallStmt *stmt)
 	targs = NIL;
 	foreach(lc, stmt->funccall->args)
 	{
-		if (sql_dialect == SQL_DIALECT_TSQL && nodeTag((Node*)lfirst(lc)) == T_SetToDefault)
+		if (sql_dialect == SQL_DIALECT_TSQL && 
+			(nodeTag((Node*)lfirst(lc)) == T_SetToDefault))
 		{
 			// For Tsql Default in function call, we set it to UNKNOWN in parser stage
 			// In analyzer it'll use other types to detect the right func candidate
 			((SetToDefault *)lfirst(lc))->typeId = UNKNOWNOID;
 			targs = lappend(targs, (Node *) lfirst(lc));
+		}
+		else if (sql_dialect == SQL_DIALECT_TSQL && 
+			 nodeTag((Node*)lfirst(lc)) == T_NamedArgExpr &&
+			 nodeTag(((NamedArgExpr*)lfirst(lc))->arg) == T_SetToDefault)
+		{
+			// For Tsql Default in function call, we set it to UNKNOWN in parser stage
+			// In analyzer it'll use other types to detect the right func candidate
+			((SetToDefault *)((NamedArgExpr*)lfirst(lc))->arg)->typeId = UNKNOWNOID;
+			targs = lappend(targs, (Node *) ((NamedArgExpr*)lfirst(lc))->arg);
 		}
 		else
 		{

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -3178,7 +3178,7 @@ transformCallStmt(ParseState *pstate, CallStmt *stmt)
 			// For Tsql Default in function call, we set it to UNKNOWN in parser stage
 			// In analyzer it'll use other types to detect the right func candidate
 			((SetToDefault *)((NamedArgExpr*)lfirst(lc))->arg)->typeId = UNKNOWNOID;
-			targs = lappend(targs, (Node *) ((NamedArgExpr*)lfirst(lc))->arg);
+			targs = lappend(targs, (Node *) lfirst(lc));
 		}
 		else
 		{


### PR DESCRIPTION
1. The error message should be the same as sql server when there's no default define for a param called by a procedure.
2. If default keyword is used in function call and that param doesn't have default define value, then use NULL as the value.
3. Support call proc with NamedAssignExpr with a default keyword like exec proc @p1 = default

Task: BABEL-335

### Example 

case 1 : 
```
1> create proc p @p1 int as select @p1
2> go
1> exec p default
2> go
```

case 1: 
```
1> create function f (@p1 int) returns int as begin return @p1 end
2> go
1> select dbo.f(default)
2> go
----------
      NULL 
```

case 3:
```
1> create proc p @p1 int=123 as select @p1 
2> go 
1> exec p @p1=default 
2> go
-----------         
123
```

### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
