### PR TITLE
Fixed error code difference occurring due to parallel worker enforced

### DIFF
--- a/src/backend/access/transam/parallel.c
+++ b/src/backend/access/transam/parallel.c
@@ -96,14 +96,14 @@ typedef struct FixedParallelState
 	TimestampTz stmt_ts;
 	SerializableXactHandle serializable_xact_handle;
 
+	/* Track if parallel worker is spawned in the context of Babelfish */
+	bool babelfish_context;
+
 	/* Mutex protects remaining fields. */
 	slock_t		mutex;
 
 	/* Maximum XactLastRecEnd of any worker. */
 	XLogRecPtr	last_xlog_end;
-
-	/* Track if parallel worker is spawned in the context of Babelfish */
-	bool babelfish_context;
 } FixedParallelState;
 
 /*
@@ -335,9 +335,9 @@ InitializeParallelDSM(ParallelContext *pcxt)
 	fps->xact_ts = GetCurrentTransactionStartTimestamp();
 	fps->stmt_ts = GetCurrentStatementStartTimestamp();
 	fps->serializable_xact_handle = ShareSerializableXact();
+	fps->babelfish_context = MyProcPort->is_tds_conn;
 	SpinLockInit(&fps->mutex);
 	fps->last_xlog_end = 0;
-	fps->babelfish_context = MyProcPort->is_tds_conn;
 	shm_toc_insert(pcxt->toc, PARALLEL_KEY_FIXED, fps);
 
 	/* We can skip the rest of this if we're not budgeting for any workers. */

--- a/src/backend/access/transam/parallel.c
+++ b/src/backend/access/transam/parallel.c
@@ -31,7 +31,6 @@
 #include "libpq/pqmq.h"
 #include "miscadmin.h"
 #include "optimizer/optimizer.h"
-#include "parser/parser.h"
 #include "pgstat.h"
 #include "storage/ipc.h"
 #include "storage/predicate.h"

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -818,9 +818,9 @@ InitPlan(QueryDesc *queryDesc, int eflags)
 	int			i;
 
 	/*
-	 * Do permissions checks if not parallel worker
+	 * Do permissions checks if not Babelfish parallel worker
 	 */
-	if (!(sql_dialect == SQL_DIALECT_TSQL && IsParallelWorker()))
+	if (!IsBabelfishParallelWorker())
 		ExecCheckRTPerms(rangeTable, true);
 
 	/*

--- a/src/backend/libpq/pqmq.c
+++ b/src/backend/libpq/pqmq.c
@@ -17,7 +17,6 @@
 #include "libpq/pqformat.h"
 #include "libpq/pqmq.h"
 #include "miscadmin.h"
-#include "parser/parser.h"
 #include "pgstat.h"
 #include "tcop/tcopprot.h"
 #include "utils/builtins.h"
@@ -312,7 +311,14 @@ pq_parse_errornotice(StringInfo msg, ErrorData *edata)
 				edata->funcname = pstrdup(value);
 				break;
 			case PG_DIAG_MESSAGE_ID:
-				edata->message_id = (const char *) pstrdup(value);
+				if (MyProcPort->is_tds_conn)
+				{
+					edata->message_id = (const char *) pstrdup(value);
+				}
+				else
+				{
+					elog(ERROR, "Unexpected error message_is field is found");
+				}
 				break;
 			default:
 				elog(ERROR, "unrecognized error field code: %d", (int) code);

--- a/src/backend/libpq/pqmq.c
+++ b/src/backend/libpq/pqmq.c
@@ -17,6 +17,7 @@
 #include "libpq/pqformat.h"
 #include "libpq/pqmq.h"
 #include "miscadmin.h"
+#include "parser/parser.h"
 #include "pgstat.h"
 #include "tcop/tcopprot.h"
 #include "utils/builtins.h"
@@ -309,6 +310,16 @@ pq_parse_errornotice(StringInfo msg, ErrorData *edata)
 				break;
 			case PG_DIAG_SOURCE_FUNCTION:
 				edata->funcname = pstrdup(value);
+				break;
+			case PG_DIAG_MESSAGE_ID:
+				if (sql_dialect == SQL_DIALECT_TSQL)
+				{
+					edata->message_id = pstrdup(value);
+				}
+				else
+				{
+					elog(ERROR, "Unexpected message_id found");
+				}
 				break;
 			default:
 				elog(ERROR, "unrecognized error field code: %d", (int) code);

--- a/src/backend/libpq/pqmq.c
+++ b/src/backend/libpq/pqmq.c
@@ -312,14 +312,7 @@ pq_parse_errornotice(StringInfo msg, ErrorData *edata)
 				edata->funcname = pstrdup(value);
 				break;
 			case PG_DIAG_MESSAGE_ID:
-				if (sql_dialect == SQL_DIALECT_TSQL)
-				{
-					edata->message_id = pstrdup(value);
-				}
-				else
-				{
-					elog(ERROR, "Unexpected message_id found");
-				}
+				edata->message_id = (const char *) pstrdup(value);
 				break;
 			default:
 				elog(ERROR, "unrecognized error field code: %d", (int) code);

--- a/src/backend/libpq/pqmq.c
+++ b/src/backend/libpq/pqmq.c
@@ -317,7 +317,7 @@ pq_parse_errornotice(StringInfo msg, ErrorData *edata)
 				}
 				else
 				{
-					elog(ERROR, "Unexpected error message_is field is found");
+					elog(ERROR, "Unexpected error field message_id is found");
 				}
 				break;
 			default:

--- a/src/backend/postmaster/bgworker.c
+++ b/src/backend/postmaster/bgworker.c
@@ -128,6 +128,9 @@ static const struct
 	},
 	{
 		"ApplyWorkerMain", ApplyWorkerMain
+	},
+	{
+		"BabelfishParallelWorkerMain", BabelfishParallelWorkerMain
 	}
 };
 

--- a/src/backend/postmaster/bgworker.c
+++ b/src/backend/postmaster/bgworker.c
@@ -128,9 +128,6 @@ static const struct
 	},
 	{
 		"ApplyWorkerMain", ApplyWorkerMain
-	},
-	{
-		"BabelfishParallelWorkerMain", BabelfishParallelWorkerMain
 	}
 };
 

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -73,7 +73,6 @@
 #include "libpq/pqformat.h"
 #include "mb/pg_wchar.h"
 #include "miscadmin.h"
-#include "parser/parser.h"
 #include "pgstat.h"
 #include "postmaster/bgworker.h"
 #include "postmaster/postmaster.h"
@@ -3260,10 +3259,11 @@ send_message_to_frontend(ErrorData *edata)
 			err_sendstring(&msgbuf, edata->funcname);
 		}
 
-		if (IsParallelWorker() && sql_dialect == SQL_DIALECT_TSQL)
+		if (IsBabelfishParallelWorker())
 		{
 			if (edata->message_id)
 			{
+				elog(LOG, "Sending message_id");
 				pq_sendbyte(&msgbuf, PG_DIAG_MESSAGE_ID);
 				err_sendstring(&msgbuf, edata->message_id);
 			}

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -67,6 +67,7 @@
 #endif
 
 #include "access/transam.h"
+#include "access/parallel.h"
 #include "access/xact.h"
 #include "libpq/libpq.h"
 #include "libpq/pqformat.h"
@@ -3253,7 +3254,7 @@ send_message_to_frontend(ErrorData *edata)
 			err_sendstring(&msgbuf, edata->funcname);
 		}
 
-		if (sql_dialect == SQL_DIALECT_TSQL)
+		if (IsParallelWorker() && sql_dialect == SQL_DIALECT_TSQL)
 		{
 			if (edata->message_id)
 			{

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -3263,7 +3263,6 @@ send_message_to_frontend(ErrorData *edata)
 		{
 			if (edata->message_id)
 			{
-				elog(LOG, "Sending message_id");
 				pq_sendbyte(&msgbuf, PG_DIAG_MESSAGE_ID);
 				err_sendstring(&msgbuf, edata->message_id);
 			}

--- a/src/backend/utils/error/elog.c
+++ b/src/backend/utils/error/elog.c
@@ -1705,8 +1705,6 @@ ThrowErrorData(ErrorData *edata)
 	if (edata->backtrace)
 		newedata->backtrace = pstrdup(edata->backtrace);
 	/* assume message_id is not available */
-	if (edata->message_id)
-		newedata->message_id = pstrdup(edata->message_id);
 	if (edata->schema_name)
 		newedata->schema_name = pstrdup(edata->schema_name);
 	if (edata->table_name)
@@ -1721,6 +1719,14 @@ ThrowErrorData(ErrorData *edata)
 	newedata->internalpos = edata->internalpos;
 	if (edata->internalquery)
 		newedata->internalquery = pstrdup(edata->internalquery);
+
+	/*
+	 * Generally, vanilla postgres does not share messaged_id with leader node from
+	 * parallel worker. But case of Babelfish where message_id is needed to find
+	 * T-SQL error code; below hook is defined to handle message_id for Babelfish. 
+	 */
+	if (edata->message_id)
+		newedata->message_id = (const char *) pstrdup(edata->message_id);
 
 	MemoryContextSwitchTo(oldcontext);
 	recursion_depth--;

--- a/src/include/access/parallel.h
+++ b/src/include/access/parallel.h
@@ -80,8 +80,6 @@ extern void ParallelWorkerReportLastRecEnd(XLogRecPtr last_xlog_end);
 extern void ParallelWorkerMain(Datum main_arg);
 
 /* Below helpers are added to support parallel workers in Babelfish context */
-extern bool isBabelfishParallelWorker; 
-extern void BabelfishParallelWorkerMain(Datum main_arg);
-#define IsBabelfishParallelWorker() (ParallelWorkerNumber >= 0 && isBabelfishParallelWorker)
+extern bool IsBabelfishParallelWorker(void);
 
 #endif							/* PARALLEL_H */

--- a/src/include/access/parallel.h
+++ b/src/include/access/parallel.h
@@ -79,4 +79,9 @@ extern void ParallelWorkerReportLastRecEnd(XLogRecPtr last_xlog_end);
 
 extern void ParallelWorkerMain(Datum main_arg);
 
+/* Below helpers are added to support parallel workers in Babelfish context */
+extern bool isBabelfishParallelWorker; 
+extern void BabelfishParallelWorkerMain(Datum main_arg);
+#define IsBabelfishParallelWorker() (ParallelWorkerNumber >= 0 && isBabelfishParallelWorker)
+
 #endif							/* PARALLEL_H */

--- a/src/include/libpq/libpq-be.h
+++ b/src/include/libpq/libpq-be.h
@@ -250,6 +250,7 @@ typedef struct Port
 	SSL		   *ssl;
 	X509	   *peer;
 #endif
+	bool		is_tds_conn;
 } Port;
 
 #ifdef USE_SSL

--- a/src/include/postgres_ext.h
+++ b/src/include/postgres_ext.h
@@ -70,5 +70,6 @@ typedef PG_INT64_TYPE pg_int64;
 #define PG_DIAG_SOURCE_FILE		'F'
 #define PG_DIAG_SOURCE_LINE		'L'
 #define PG_DIAG_SOURCE_FUNCTION 'R'
+#define PG_DIAG_MESSAGE_ID      'I'
 
 #endif							/* POSTGRES_EXT_H */


### PR DESCRIPTION
### Description

When any error raised from parallel worker then Postgres by default does not share message_id (part of edata) to leader worker. Babelfish's error mapping framework relies on message_id to map to correct T-SQL error code. But since it is no more available to leader worker, T-SQL error code would not be found and default error code will be used. This will also affect the transactional behaviour of given error. 

In order to fix this issue, we need to store if given worker is spawned in the context of Babelfish or not to share error
message_id. Hence, this changes made changes in two data structure namely Port and FixedParallelState to store context
about Babelfish
 
### Issues Resolved
BABEL-4539

### Check List
Existing JDBC test cases should be sufficient to test these changes. 
Also, regression test suite provided by vanilla Postgres runs fine with these changes.

Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
