### PR TITLE
Block Babelfish restore on versions prior to 15.5 (#263)

### DIFF
--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -221,7 +221,7 @@ void
 dumpBabelRestoreChecks(Archive *fout)
 {
 	PGresult	*res;
-	char		*source_server_version;
+	int     	source_server_version_num;
 	char		*source_migration_mode;
 	PQExpBuffer	qry;
 	ArchiveFormat format = ((ArchiveHandle *) fout)->format;
@@ -237,8 +237,8 @@ dumpBabelRestoreChecks(Archive *fout)
 	 * differs from source server version.
 	 */
 	qry = createPQExpBuffer();
-	res = ExecuteSqlQueryForSingleRow(fout, "SHOW server_version");
-	source_server_version = pstrdup(PQgetvalue(res, 0, 0));
+	res = ExecuteSqlQueryForSingleRow(fout, "SELECT setting::INT from pg_settings WHERE name = 'server_version_num';");
+	source_server_version_num = atoi(PQgetvalue(res, 0, 0));
 
 	/*
 	 * Temporarily enable ON_ERROR_STOP so that whole restore script
@@ -250,15 +250,17 @@ dumpBabelRestoreChecks(Archive *fout)
 	appendPQExpBuffer(qry,
 					  "DO $$"
 					  "\nDECLARE"
-					  "\n    target_server_version VARCHAR;"
+					  "\n    target_server_version_num INT;"
 					  "\nBEGIN"
-					  "\n    SELECT INTO target_server_version setting from pg_settings"
-					  "\n        WHERE name = 'server_version';"
-					  "\n    IF target_server_version::VARCHAR != '%s' THEN"
+					  "\n    SELECT INTO target_server_version_num setting::INT from pg_settings"
+					  "\n        WHERE name = 'server_version_num';"
+					  "\n    IF target_server_version_num != %d THEN"
 					  "\n        RAISE 'Dump and restore across different Postgres versions is not yet supported.';"
+					  "\n    ELSIF target_server_version_num < 150005 THEN"
+					  "\n        RAISE 'Target Postgres version must be 15.5 or higher for Babelfish restore.';"
 					  "\n    END IF;"
 					  "\nEND$$;\n\n"
-					  , source_server_version);
+					  , source_server_version_num);
 	PQclear(res);
 
 	/*
@@ -290,7 +292,6 @@ dumpBabelRestoreChecks(Archive *fout)
 							  .section = SECTION_PRE_DATA,
 							  .createStmt = qry->data));
 	destroyPQExpBuffer(qry);
-	pfree(source_server_version);
 	pfree(source_migration_mode);
 }
 


### PR DESCRIPTION
### Description
Restore can only be performed on PG15.5 or higher versions, this commits blocks it on older versions.

Signed-off-by: Rishabh Tanwar ritanwar@amazon.com
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
