### PR TITLE
Add perl as BuildRequires in BabelfisDump.spec (#267)

### DIFF
--- a/BabelfishDump.spec
+++ b/BabelfishDump.spec
@@ -23,14 +23,14 @@
 
 Name: BabelfishDump
 Summary: Postgresql dump utilities modified for Babelfish
-Version: 15.latest
+Version: 15.5
 Release: 1%{?dist}
 License: PostgreSQL Global Development Group
 Url: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish
 
 BuildRequires: make
 BuildRequires: lz4-devel
-BuildRequires: gcc
+BuildRequires: gcc perl
 BuildRequires: glibc-devel bison flex
 BuildRequires: readline-devel zlib-devel
 %if %external_libpq


### PR DESCRIPTION
### Description
BabelfishDump RPM requires perl during build so this commit adds it in BuildRequires. Additionally, update RPM package version to 15.5.

 Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
