### PR TITLE
[valgrind] Invalid read in postquel_sub_params

### DIFF
--- a/src/backend/executor/functions.c
+++ b/src/backend/executor/functions.c
@@ -974,15 +974,15 @@ postquel_sub_params(SQLFunctionCachePtr fcache,
 			if (i >= fcache->pinfo->nargs)
 			{
 				prm->value =  MakeExpandedObjectReadOnly(fcinfo->args[i].value,
-						prm->isnull
-						get_typlen(NULL));
-				prm->ptype = NULL;
+									 prm->isnull,
+									 get_typlen(NULL));
+				prm->ptype = 0;
 			}
 			else
 			{
 				prm->value = MakeExpandedObjectReadOnly(fcinfo->args[i].value,
-						prm->isnull,
-						get_typlen(argtypes[i]));
+									prm->isnull,
+									get_typlen(argtypes[i]));
 				prm->ptype = argtypes[i];
 			}
 			prm->pflags = 0;

--- a/src/backend/executor/functions.c
+++ b/src/backend/executor/functions.c
@@ -971,11 +971,21 @@ postquel_sub_params(SQLFunctionCachePtr fcache,
 			 * because of possible function inlining during planning.)
 			 */
 			prm->isnull = fcinfo->args[i].isnull;
-			prm->value = MakeExpandedObjectReadOnly(fcinfo->args[i].value,
-													prm->isnull,
-													get_typlen(argtypes[i]));
+			if (i >= fcache->pinfo->nargs)
+			{
+				prm->value =  MakeExpandedObjectReadOnly(fcinfo->args[i].value,
+						prm->isnull
+						get_typlen(NULL));
+				prm->ptype = NULL;
+			}
+			else
+			{
+				prm->value = MakeExpandedObjectReadOnly(fcinfo->args[i].value,
+						prm->isnull,
+						get_typlen(argtypes[i]));
+				prm->ptype = argtypes[i];
+			}
 			prm->pflags = 0;
-			prm->ptype = argtypes[i];
 		}
 	}
 	else

--- a/src/backend/executor/functions.c
+++ b/src/backend/executor/functions.c
@@ -973,16 +973,16 @@ postquel_sub_params(SQLFunctionCachePtr fcache,
 			prm->isnull = fcinfo->args[i].isnull;
 			if (i >= fcache->pinfo->nargs)
 			{
-				prm->value =  MakeExpandedObjectReadOnly(fcinfo->args[i].value,
-									 prm->isnull,
-									 get_typlen(NULL));
+				prm->value = MakeExpandedObjectReadOnly(fcinfo->args[i].value,
+													prm->isnull,
+													get_typlen(0));
 				prm->ptype = 0;
 			}
 			else
 			{
 				prm->value = MakeExpandedObjectReadOnly(fcinfo->args[i].value,
-									prm->isnull,
-									get_typlen(argtypes[i]));
+													prm->isnull,
+													get_typlen(argtypes[i]));
 				prm->ptype = argtypes[i];
 			}
 			prm->pflags = 0;


### PR DESCRIPTION
### Description

Previously in postquel_sub_params there is an invalid read when ran valgrind aganist it. Fixed the invalid read in postquel_sub_params when valgrind ran aganist the fuction by passing the correct values.
 
### Issues Resolved

BABEL-4476
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
