### PR TITLE
Fixed error code difference occurring due to parallel worker enforced

### DIFF
--- a/src/backend/access/transam/parallel.c
+++ b/src/backend/access/transam/parallel.c
@@ -96,6 +96,9 @@ typedef struct FixedParallelState
 	TimestampTz stmt_ts;
 	SerializableXactHandle serializable_xact_handle;
 
+	/* Track if parallel worker is spawned in the context of Babelfish */
+	bool babelfish_context;
+
 	/* Mutex protects remaining fields. */
 	slock_t		mutex;
 
@@ -332,6 +335,7 @@ InitializeParallelDSM(ParallelContext *pcxt)
 	fps->xact_ts = GetCurrentTransactionStartTimestamp();
 	fps->stmt_ts = GetCurrentStatementStartTimestamp();
 	fps->serializable_xact_handle = ShareSerializableXact();
+	fps->babelfish_context = MyProcPort->is_tds_conn;
 	SpinLockInit(&fps->mutex);
 	fps->last_xlog_end = 0;
 	shm_toc_insert(pcxt->toc, PARALLEL_KEY_FIXED, fps);
@@ -1582,4 +1586,14 @@ LookupParallelWorkerFunction(const char *libraryname, const char *funcname)
 	/* Otherwise load from external library. */
 	return (parallel_worker_main_type)
 		load_external_function(libraryname, funcname, true, NULL);
+}
+
+/*
+ * IsBabelfishParallelWorker - return bool based on whether given worker is
+ * spawned in Babelfish context.
+ */
+bool
+IsBabelfishParallelWorker(void)
+{
+	return (IsParallelWorker() && MyFixedParallelState->babelfish_context);
 }

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -815,9 +815,9 @@ InitPlan(QueryDesc *queryDesc, int eflags)
 	int			i;
 
 	/*
-	 * Do permissions checks if not parallel worker
+	 * Do permissions checks if not Babelfish parallel worker
 	 */
-	if (!(sql_dialect == SQL_DIALECT_TSQL && IsParallelWorker()))
+	if (!IsBabelfishParallelWorker())
 		ExecCheckRTPerms(rangeTable, true);
 
 	/*

--- a/src/backend/libpq/pqmq.c
+++ b/src/backend/libpq/pqmq.c
@@ -305,6 +305,16 @@ pq_parse_errornotice(StringInfo msg, ErrorData *edata)
 			case PG_DIAG_SOURCE_FUNCTION:
 				edata->funcname = pstrdup(value);
 				break;
+			case PG_DIAG_MESSAGE_ID:
+				if (MyProcPort->is_tds_conn)
+				{
+					edata->message_id = (const char *) pstrdup(value);
+				}
+				else
+				{
+					elog(ERROR, "Unexpected error field message_id is found");
+				}
+				break;
 			default:
 				elog(ERROR, "unrecognized error field code: %d", (int) code);
 				break;

--- a/src/include/access/parallel.h
+++ b/src/include/access/parallel.h
@@ -79,4 +79,7 @@ extern void ParallelWorkerReportLastRecEnd(XLogRecPtr last_xlog_end);
 
 extern void ParallelWorkerMain(Datum main_arg);
 
+/* Below helpers are added to support parallel workers in Babelfish context */
+extern bool IsBabelfishParallelWorker(void);
+
 #endif							/* PARALLEL_H */

--- a/src/include/libpq/libpq-be.h
+++ b/src/include/libpq/libpq-be.h
@@ -252,6 +252,7 @@ typedef struct Port
 	SSL		   *ssl;
 	X509	   *peer;
 #endif
+	bool		is_tds_conn;
 } Port;
 
 #ifdef USE_SSL

--- a/src/include/postgres_ext.h
+++ b/src/include/postgres_ext.h
@@ -70,5 +70,6 @@ typedef PG_INT64_TYPE pg_int64;
 #define PG_DIAG_SOURCE_FILE		'F'
 #define PG_DIAG_SOURCE_LINE		'L'
 #define PG_DIAG_SOURCE_FUNCTION 'R'
+#define PG_DIAG_MESSAGE_ID      'I'
 
 #endif							/* POSTGRES_EXT_H */


### PR DESCRIPTION
When any error raised from parallel worker then Postgres by default does not share message_id (part of edata) to leader worker. Babelfish's error mapping framework relies on message_id to map to correct T-SQL error code. But since it is no more available to leader worker, T-SQL error code would not be found and default error code will be used. This will also affect the transactional behaviour of given error.

In order to fix this issue, we need to store if given worker is spawned in the context of Babelfish or not to share error message_id. Hence, this changes made changes in two data structure namely Port and FixedParallelState to store context about Babelfish

Extension changes: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2155
Task: BABEL-4539
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
