### PR TITLE
Support Instead of Trigger On Views

### DIFF
--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -70,6 +70,7 @@ int			SessionReplicationRole = SESSION_REPLICATION_ROLE_ORIGIN;
 
 /* How many levels deep into trigger execution are we? */
 static int	MyTriggerDepth = 0;
+List *triggerOids = NIL; /* To store all trigger calls information */
 
 /* Local function prototypes */
 static void renametrig_internal(Relation tgrel, Relation targetrel,
@@ -489,7 +490,7 @@ CreateTriggerFiringOn(CreateTrigStmt *stmt, const char *queryString,
 								RelationGetRelationName(rel)),
 						 errdetail("Triggers on foreign tables cannot have transition tables.")));
 
-			if (rel->rd_rel->relkind == RELKIND_VIEW)
+			if (rel->rd_rel->relkind == RELKIND_VIEW && sql_dialect != SQL_DIALECT_TSQL)
 				ereport(ERROR,
 						(errcode(ERRCODE_WRONG_OBJECT_TYPE),
 						 errmsg("\"%s\" is a view",
@@ -2571,11 +2572,13 @@ ExecCallTriggerFunc(TriggerData *trigdata,
 	MyTriggerDepth++;
 	PG_TRY();
 	{
+		triggerOids = lappend_oid(triggerOids, trigdata->tg_trigger->tgoid);
 		result = FunctionCallInvoke(fcinfo);
 	}
 	PG_FINALLY();
 	{
 		MyTriggerDepth--;
+		triggerOids = list_delete_oid(triggerOids, trigdata->tg_trigger->tgoid);
 	}
 	PG_END_TRY();
 

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -70,7 +70,7 @@ int			SessionReplicationRole = SESSION_REPLICATION_ROLE_ORIGIN;
 
 /* How many levels deep into trigger execution are we? */
 static int	MyTriggerDepth = 0;
-List *triggerOids = NIL; /* To store all trigger calls information */
+List *triggerInvocationSequence = NIL; /* List to store all oids for triggers called*/
 
 /* Local function prototypes */
 static void renametrig_internal(Relation tgrel, Relation targetrel,
@@ -2572,13 +2572,13 @@ ExecCallTriggerFunc(TriggerData *trigdata,
 	MyTriggerDepth++;
 	PG_TRY();
 	{
-		triggerOids = lappend_oid(triggerOids, trigdata->tg_trigger->tgoid);
+		triggerInvocationSequence = lappend_oid(triggerInvocationSequence, trigdata->tg_trigger->tgoid);
 		result = FunctionCallInvoke(fcinfo);
 	}
 	PG_FINALLY();
 	{
 		MyTriggerDepth--;
-		triggerOids = list_delete_oid(triggerOids, trigdata->tg_trigger->tgoid);
+		triggerInvocationSequence = list_delete_last(triggerInvocationSequence);
 	}
 	PG_END_TRY();
 

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -1031,7 +1031,7 @@ CheckValidResultRel(ResultRelInfo *resultRelInfo, CmdType operation)
 			switch (operation)
 			{
 				case CMD_INSERT:
-					if (!trigDesc || (!trigDesc->trig_insert_instead_row))
+					if (!trigDesc || (!trigDesc->trig_insert_instead_row && (sql_dialect == SQL_DIALECT_TSQL && !trigDesc->trig_insert_instead_statement)))
 						ereport(ERROR,
 								(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 								 errmsg("cannot insert into view \"%s\"",
@@ -1039,7 +1039,7 @@ CheckValidResultRel(ResultRelInfo *resultRelInfo, CmdType operation)
 								 errhint("To enable inserting into the view, provide an INSTEAD OF INSERT trigger or an unconditional ON INSERT DO INSTEAD rule.")));
 					break;
 				case CMD_UPDATE:
-					if (!trigDesc || (!trigDesc->trig_update_instead_row))
+					if (!trigDesc || (!trigDesc->trig_update_instead_row && (sql_dialect == SQL_DIALECT_TSQL && !trigDesc->trig_update_instead_statement)))
 						ereport(ERROR,
 								(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 								 errmsg("cannot update view \"%s\"",
@@ -1047,7 +1047,7 @@ CheckValidResultRel(ResultRelInfo *resultRelInfo, CmdType operation)
 								 errhint("To enable updating the view, provide an INSTEAD OF UPDATE trigger or an unconditional ON UPDATE DO INSTEAD rule.")));
 					break;
 				case CMD_DELETE:
-					if (!trigDesc || (!trigDesc->trig_delete_instead_row))
+					if (!trigDesc || (!trigDesc->trig_delete_instead_row && (sql_dialect == SQL_DIALECT_TSQL && !trigDesc->trig_delete_instead_statement)))
 						ereport(ERROR,
 								(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
 								 errmsg("cannot delete from view \"%s\"",

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -66,6 +66,7 @@
 #include "utils/memutils.h"
 #include "utils/rel.h"
 
+bbfCheckRecursionInTrigger_hook_type bbfCheckRecursionInTrigger_hook = NULL;
 
 typedef struct MTTargetRelLookup
 {
@@ -810,7 +811,7 @@ ExecInsert(ModifyTableContext *context,
 			return NULL;		/* "do nothing" */
 	}
 	else if (sql_dialect == SQL_DIALECT_TSQL && resultRelInfo->ri_TrigDesc &&
-		resultRelInfo->ri_TrigDesc->trig_insert_instead_statement &&
+		resultRelInfo->ri_TrigDesc->trig_insert_instead_statement && bbfCheckRecursionInTrigger_hook && (bbfCheckRecursionInTrigger_hook)(resultRelInfo) &&
 		isTsqlInsteadofTriggerExecution(estate, resultRelInfo, TRIGGER_EVENT_INSERT))
 	{
 		ExecIRInsertTriggersTSQL(estate, resultRelInfo, slot, mtstate->mt_transition_capture);
@@ -1480,7 +1481,7 @@ ExecDelete(ModifyTableContext *context,
 
 	if (resultRelInfo->ri_TrigDesc &&
 		resultRelInfo->ri_TrigDesc->trig_delete_instead_statement &&
-		sql_dialect == SQL_DIALECT_TSQL &&
+		sql_dialect == SQL_DIALECT_TSQL && bbfCheckRecursionInTrigger_hook && (bbfCheckRecursionInTrigger_hook)(resultRelInfo) &&
 		isTsqlInsteadofTriggerExecution(estate, resultRelInfo, TRIGGER_EVENT_DELETE))
 	{
 		ExecIRDeleteTriggersTSQL(estate, resultRelInfo, tupleid, oldtuple, context->mtstate->mt_transition_capture);
@@ -2335,7 +2336,7 @@ ExecUpdate(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
 
 	if (resultRelInfo->ri_TrigDesc &&
 		resultRelInfo->ri_TrigDesc->trig_update_instead_statement &&
-		sql_dialect == SQL_DIALECT_TSQL &&
+		sql_dialect == SQL_DIALECT_TSQL && bbfCheckRecursionInTrigger_hook && (bbfCheckRecursionInTrigger_hook)(resultRelInfo) &&
 		isTsqlInsteadofTriggerExecution(estate, resultRelInfo, TRIGGER_EVENT_INSTEAD))
 	{
 		ExecIRUpdateTriggersTSQL(estate, resultRelInfo, tupleid, oldtuple, slot, context->mtstate->mt_transition_capture);

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -66,7 +66,6 @@
 #include "utils/memutils.h"
 #include "utils/rel.h"
 
-bbfCheckRecursionInTrigger_hook_type bbfCheckRecursionInTrigger_hook = NULL;
 
 typedef struct MTTargetRelLookup
 {
@@ -811,7 +810,8 @@ ExecInsert(ModifyTableContext *context,
 			return NULL;		/* "do nothing" */
 	}
 	else if (sql_dialect == SQL_DIALECT_TSQL && resultRelInfo->ri_TrigDesc &&
-		resultRelInfo->ri_TrigDesc->trig_insert_instead_statement && bbfCheckRecursionInTrigger_hook && (bbfCheckRecursionInTrigger_hook)(resultRelInfo) &&
+		resultRelInfo->ri_TrigDesc->trig_insert_instead_statement && 
+		bbfViewHasInsteadofTrigger_hook && (bbfViewHasInsteadofTrigger_hook)(resultRelationDesc, CMD_INSERT) &&
 		isTsqlInsteadofTriggerExecution(estate, resultRelInfo, TRIGGER_EVENT_INSERT))
 	{
 		ExecIRInsertTriggersTSQL(estate, resultRelInfo, slot, mtstate->mt_transition_capture);
@@ -1481,7 +1481,8 @@ ExecDelete(ModifyTableContext *context,
 
 	if (resultRelInfo->ri_TrigDesc &&
 		resultRelInfo->ri_TrigDesc->trig_delete_instead_statement &&
-		sql_dialect == SQL_DIALECT_TSQL && bbfCheckRecursionInTrigger_hook && (bbfCheckRecursionInTrigger_hook)(resultRelInfo) &&
+		sql_dialect == SQL_DIALECT_TSQL &&
+		bbfViewHasInsteadofTrigger_hook && (bbfViewHasInsteadofTrigger_hook)(resultRelationDesc, CMD_DELETE) &&
 		isTsqlInsteadofTriggerExecution(estate, resultRelInfo, TRIGGER_EVENT_DELETE))
 	{
 		ExecIRDeleteTriggersTSQL(estate, resultRelInfo, tupleid, oldtuple, context->mtstate->mt_transition_capture);
@@ -2336,7 +2337,7 @@ ExecUpdate(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
 
 	if (resultRelInfo->ri_TrigDesc &&
 		resultRelInfo->ri_TrigDesc->trig_update_instead_statement &&
-		sql_dialect == SQL_DIALECT_TSQL && bbfCheckRecursionInTrigger_hook && (bbfCheckRecursionInTrigger_hook)(resultRelInfo) &&
+		sql_dialect == SQL_DIALECT_TSQL && bbfViewHasInsteadofTrigger_hook && (bbfViewHasInsteadofTrigger_hook)(resultRelationDesc, CMD_UPDATE) &&
 		isTsqlInsteadofTriggerExecution(estate, resultRelInfo, TRIGGER_EVENT_INSTEAD))
 	{
 		ExecIRUpdateTriggersTSQL(estate, resultRelInfo, tupleid, oldtuple, slot, context->mtstate->mt_transition_capture);

--- a/src/backend/rewrite/rewriteHandler.c
+++ b/src/backend/rewrite/rewriteHandler.c
@@ -33,7 +33,7 @@
 #include "nodes/nodeFuncs.h"
 #include "optimizer/optimizer.h"
 #include "parser/analyze.h"
-#include "parser/parser.h" 
+#include "parser/parser.h"
 #include "parser/parse_coerce.h"
 #include "parser/parse_relation.h"
 #include "parser/parsetree.h"
@@ -45,6 +45,8 @@
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
+
+bbfViewHasInsteadofTrigger_hook_type bbfViewHasInsteadofTrigger_hook = NULL; /** BBF Hook to check Instead Of trigger on View */
 
 /* We use a list of these to detect recursion in RewriteQuery */
 typedef struct rewrite_event
@@ -1472,7 +1474,8 @@ rewriteValuesRTE(Query *parsetree, RangeTblEntry *rte, int rti,
 	 */
 	isAutoUpdatableView = false;
 	if (target_relation->rd_rel->relkind == RELKIND_VIEW &&
-		!view_has_instead_trigger(target_relation, CMD_INSERT))
+		(!view_has_instead_trigger(target_relation, CMD_INSERT) &&
+			!(sql_dialect == SQL_DIALECT_TSQL && bbfViewHasInsteadofTrigger_hook && (bbfViewHasInsteadofTrigger_hook)(target_relation, CMD_INSERT))))
 	{
 		List	   *locks;
 		bool		hasUpdate;
@@ -3953,7 +3956,8 @@ RewriteQuery(Query *parsetree, List *rewrite_events, int orig_rt_length)
 		 */
 		if (!instead &&
 			rt_entry_relation->rd_rel->relkind == RELKIND_VIEW &&
-			!view_has_instead_trigger(rt_entry_relation, event))
+			(!view_has_instead_trigger(rt_entry_relation, event) 
+			&& !(sql_dialect == SQL_DIALECT_TSQL && bbfViewHasInsteadofTrigger_hook && (bbfViewHasInsteadofTrigger_hook)(rt_entry_relation, event))))
 		{
 			/*
 			 * If there were any qualified INSTEAD rules, don't allow the view

--- a/src/include/commands/trigger.h
+++ b/src/include/commands/trigger.h
@@ -309,6 +309,7 @@ extern void AfterTriggerEndSubXact(bool isCommit);
 extern void AfterTriggerSetState(ConstraintsSetStmt *stmt);
 extern bool AfterTriggerPendingOnRel(Oid relid);
 
+extern List *triggerOids; /* To store all trigger calls information */
 
 /*
  * in utils/adt/ri_triggers.c

--- a/src/include/commands/trigger.h
+++ b/src/include/commands/trigger.h
@@ -309,7 +309,7 @@ extern void AfterTriggerEndSubXact(bool isCommit);
 extern void AfterTriggerSetState(ConstraintsSetStmt *stmt);
 extern bool AfterTriggerPendingOnRel(Oid relid);
 
-extern List *triggerOids; /* To store all trigger calls information */
+extern List *triggerInvocationSequence; /* List to store all oids for triggers called */
 
 /*
  * in utils/adt/ri_triggers.c

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -87,6 +87,12 @@ extern PGDLLIMPORT ExecutorCheckPerms_hook_type ExecutorCheckPerms_hook;
 typedef bool (*TriggerRecuresiveCheck_hook_type) (ResultRelInfo *resultRelInfo);
 extern PGDLLIMPORT TriggerRecuresiveCheck_hook_type TriggerRecuresiveCheck_hook;
 
+typedef bool (*bbfViewHasInsteadofTrigger_hook_type) (Relation view, CmdType event);
+extern PGDLLIMPORT bbfViewHasInsteadofTrigger_hook_type bbfViewHasInsteadofTrigger_hook;
+
+typedef bool (*bbfCheckRecursionInTrigger_hook_type) (ResultRelInfo *resultRelInfo);
+extern PGDLLIMPORT bbfCheckRecursionInTrigger_hook_type bbfCheckRecursionInTrigger_hook;
+
 typedef bool (*check_rowcount_hook_type) (int es_processed);
 extern PGDLLIMPORT check_rowcount_hook_type check_rowcount_hook;
 

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -90,9 +90,6 @@ extern PGDLLIMPORT TriggerRecuresiveCheck_hook_type TriggerRecuresiveCheck_hook;
 typedef bool (*bbfViewHasInsteadofTrigger_hook_type) (Relation view, CmdType event);
 extern PGDLLIMPORT bbfViewHasInsteadofTrigger_hook_type bbfViewHasInsteadofTrigger_hook;
 
-typedef bool (*bbfCheckRecursionInTrigger_hook_type) (ResultRelInfo *resultRelInfo);
-extern PGDLLIMPORT bbfCheckRecursionInTrigger_hook_type bbfCheckRecursionInTrigger_hook;
-
 typedef bool (*check_rowcount_hook_type) (int es_processed);
 extern PGDLLIMPORT check_rowcount_hook_type check_rowcount_hook;
 


### PR DESCRIPTION
### Description

Currently Postgres does not support Instead of Trigger On Views for DML queries.

On running such a query on VIEW, query rewriting substitutes view with underlying base table.
Added a hook for skipping the substitution for DML query on the VIEW.

This change will add support for Instead of Triggers for DML queries when using Babelfish.

Task: BABEL-2170/BABEL-4532/BABEL-4514

Extensions PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2158

### Issues Resolved

BABEL-2170/BABEL-4532/BABEL-4514
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
