### PR TITLE
Fix SPI clean up incase of errors for insert into execute with @tablevarible

### DIFF
--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -3438,3 +3438,9 @@ SPI_get_depth(int *depth)
 {
 	*depth = _SPI_connected;
 }
+
+void 
+SPI_getCurrentInternalTxnMode(bool *mode)
+{
+	*mode = _SPI_current->internal_xact;
+}

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -3438,9 +3438,3 @@ SPI_get_depth(int *depth)
 {
 	*depth = _SPI_connected;
 }
-
-void 
-SPI_getCurrentInternalTxnMode(bool *mode)
-{
-	*mode = _SPI_current->internal_xact;
-}

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -3433,8 +3433,8 @@ SPI_setCurrentInternalTxnMode(bool mode)
 	_SPI_current->internal_xact = mode;
 }
 
-void 
-SPI_get_depth(int *depth)
+int
+SPI_get_depth(void)
 {
-	*depth = _SPI_connected;
+	return _SPI_connected;
 }

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -3432,3 +3432,9 @@ SPI_setCurrentInternalTxnMode(bool mode)
 {
 	_SPI_current->internal_xact = mode;
 }
+
+void 
+SPI_get_depth(int *depth)
+{
+	*depth = _SPI_connected;
+}

--- a/src/include/executor/spi.h
+++ b/src/include/executor/spi.h
@@ -213,4 +213,5 @@ extern void AtEOSubXact_SPI(bool isCommit, SubTransactionId mySubid);
 extern bool SPI_inside_nonatomic_context(void);
 
 extern void SPI_setCurrentInternalTxnMode(bool mode);
+extern void SPI_get_depth(int *depth);
 #endif							/* SPI_H */

--- a/src/include/executor/spi.h
+++ b/src/include/executor/spi.h
@@ -214,4 +214,5 @@ extern bool SPI_inside_nonatomic_context(void);
 
 extern void SPI_setCurrentInternalTxnMode(bool mode);
 extern void SPI_get_depth(int *depth);
+extern void SPI_getCurrentInternalTxnMode(bool *mode);
 #endif							/* SPI_H */

--- a/src/include/executor/spi.h
+++ b/src/include/executor/spi.h
@@ -214,5 +214,4 @@ extern bool SPI_inside_nonatomic_context(void);
 
 extern void SPI_setCurrentInternalTxnMode(bool mode);
 extern void SPI_get_depth(int *depth);
-extern void SPI_getCurrentInternalTxnMode(bool *mode);
 #endif							/* SPI_H */

--- a/src/include/executor/spi.h
+++ b/src/include/executor/spi.h
@@ -213,5 +213,5 @@ extern void AtEOSubXact_SPI(bool isCommit, SubTransactionId mySubid);
 extern bool SPI_inside_nonatomic_context(void);
 
 extern void SPI_setCurrentInternalTxnMode(bool mode);
-extern void SPI_get_depth(int *depth);
+extern int  SPI_get_depth(void);
 #endif							/* SPI_H */


### PR DESCRIPTION
### Description
 
Introduce functions to fetch SPI connected value (spi stack depth). 

#### Engine PR: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/274
#### Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2183

### Issues Resolved

[BABEL-4360]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
