### PR TITLE
Fix SPI clean up incase of errors for insert into execute with @table

### DIFF
--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -3424,3 +3424,9 @@ SPI_setCurrentInternalTxnMode(bool mode)
 {
 	_SPI_current->internal_xact = mode;
 }
+
+int
+SPI_get_depth(void)
+{
+	return _SPI_connected;
+}

--- a/src/include/executor/spi.h
+++ b/src/include/executor/spi.h
@@ -213,4 +213,5 @@ extern void AtEOSubXact_SPI(bool isCommit, SubTransactionId mySubid);
 extern bool SPI_inside_nonatomic_context(void);
 
 extern void SPI_setCurrentInternalTxnMode(bool mode);
+extern int  SPI_get_depth(void);
 #endif							/* SPI_H */


### PR DESCRIPTION
### Description

Introduce functions to fetch SPI connected value (spi stack depth).
 
### Issues Resolved

[BABEL-4360]

### Cherry Picked From 3_X

https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/274
 
#### Merge Conflict

None

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
