### PR TITLE
Fix database  does not exists error when is_member(), schema_id() function gets called in parallel query mode.

### DIFF
--- a/src/backend/access/transam/parallel.c
+++ b/src/backend/access/transam/parallel.c
@@ -1490,14 +1490,14 @@ ParallelWorkerMain(Datum main_arg)
 	relmapperspace = shm_toc_lookup(toc, PARALLEL_KEY_RELMAPPER_STATE, false);
 	RestoreRelationMap(relmapperspace);
 
-	/* Hook for babelfish to restore babelfish fixed parallel state */
-	if (MyFixedParallelState->babelfish_context && bbf_ParallelWorkerMain_hook)
-		(*bbf_ParallelWorkerMain_hook) (toc);
-
 	/* Restore uncommitted enums. */
 	uncommittedenumsspace = shm_toc_lookup(toc, PARALLEL_KEY_UNCOMMITTEDENUMS,
 										   false);
 	RestoreUncommittedEnums(uncommittedenumsspace);
+
+	/* Hook for babelfish to restore babelfish fixed parallel state */
+	if (MyFixedParallelState->babelfish_context && bbf_ParallelWorkerMain_hook)
+		(*bbf_ParallelWorkerMain_hook) (toc);
 
 	/* Attach to the leader's serializable transaction, if SERIALIZABLE. */
 	AttachSerializableXact(fps->serializable_xact_handle);

--- a/src/backend/access/transam/parallel.c
+++ b/src/backend/access/transam/parallel.c
@@ -77,6 +77,10 @@
 #define PARALLEL_KEY_RELMAPPER_STATE		UINT64CONST(0xFFFFFFFFFFFF000D)
 #define PARALLEL_KEY_UNCOMMITTEDENUMS		UINT64CONST(0xFFFFFFFFFFFF000E)
 
+/* Hooks for communicating babelfish related information to parallel worker */
+bbf_parallel_serialise_babelfixedparallelstate_and_insert_into_dsm_hook_type bbf_parallel_serialise_babelfixedparallelstate_and_insert_into_dsm_hook;
+bbf_parallel_restore_babelfishfixedparallelstate_hook_type bbf_parallel_restore_babelfishfixedparallelstate_hook;
+
 /* Fixed-size parallel state. */
 typedef struct FixedParallelState
 {
@@ -291,7 +295,13 @@ InitializeParallelDSM(ParallelContext *pcxt)
 		shm_toc_estimate_chunk(&pcxt->estimator, strlen(pcxt->library_name) +
 							   strlen(pcxt->function_name) + 2);
 		shm_toc_estimate_keys(&pcxt->estimator, 1);
+
+		/* Estimate how much we'll need for the babelfish fixed parallel state */
+		if (MyProcPort->is_tds_conn && bbf_parallel_serialise_babelfixedparallelstate_and_insert_into_dsm_hook)
+			(*bbf_parallel_serialise_babelfixedparallelstate_and_insert_into_dsm_hook) (pcxt, true);
 	}
+
+	
 
 	/*
 	 * Create DSM and initialize with new table of contents.  But if the user
@@ -465,7 +475,12 @@ InitializeParallelDSM(ParallelContext *pcxt)
 		strcpy(entrypointstate, pcxt->library_name);
 		strcpy(entrypointstate + lnamelen + 1, pcxt->function_name);
 		shm_toc_insert(pcxt->toc, PARALLEL_KEY_ENTRYPOINT, entrypointstate);
+
+		/* Initialize babelfish fixed-size state in shared memory. */
+		if (MyProcPort->is_tds_conn && bbf_parallel_serialise_babelfixedparallelstate_and_insert_into_dsm_hook)
+			(*bbf_parallel_serialise_babelfixedparallelstate_and_insert_into_dsm_hook) (pcxt, false);
 	}
+	
 
 	/* Restore previous memory context. */
 	MemoryContextSwitchTo(oldcontext);
@@ -1485,6 +1500,12 @@ ParallelWorkerMain(Datum main_arg)
 
 	/* Attach to the leader's serializable transaction, if SERIALIZABLE. */
 	AttachSerializableXact(fps->serializable_xact_handle);
+
+
+	/* Hook for babelfish to restore babelfish fixed parallel state */
+	if (MyFixedParallelState->babelfish_context && bbf_parallel_restore_babelfishfixedparallelstate_hook)
+		(*bbf_parallel_restore_babelfishfixedparallelstate_hook) (toc);
+
 
 	/*
 	 * We've initialized all of our state now; nothing should change

--- a/src/backend/access/transam/parallel.c
+++ b/src/backend/access/transam/parallel.c
@@ -78,8 +78,8 @@
 #define PARALLEL_KEY_UNCOMMITTEDENUMS		UINT64CONST(0xFFFFFFFFFFFF000E)
 
 /* Hooks for communicating babelfish related information to parallel worker */
-bbf_parallel_serialise_babelfixedparallelstate_and_insert_into_dsm_hook_type bbf_parallel_serialise_babelfixedparallelstate_and_insert_into_dsm_hook;
-bbf_parallel_restore_babelfishfixedparallelstate_hook_type bbf_parallel_restore_babelfishfixedparallelstate_hook;
+babelfixedparallelstate_insert_hook_type babelfixedparallelstate_insert_hook;
+babelfixedparallelstate_restore_hook_type babelfixedparallelstate_restore_hook;
 
 /* Fixed-size parallel state. */
 typedef struct FixedParallelState
@@ -297,8 +297,8 @@ InitializeParallelDSM(ParallelContext *pcxt)
 		shm_toc_estimate_keys(&pcxt->estimator, 1);
 
 		/* Estimate how much we'll need for the babelfish fixed parallel state */
-		if (MyProcPort->is_tds_conn && bbf_parallel_serialise_babelfixedparallelstate_and_insert_into_dsm_hook)
-			(*bbf_parallel_serialise_babelfixedparallelstate_and_insert_into_dsm_hook) (pcxt, true);
+		if (MyProcPort->is_tds_conn && babelfixedparallelstate_insert_hook)
+			(*babelfixedparallelstate_insert_hook) (pcxt, true);
 	}
 
 	
@@ -477,8 +477,8 @@ InitializeParallelDSM(ParallelContext *pcxt)
 		shm_toc_insert(pcxt->toc, PARALLEL_KEY_ENTRYPOINT, entrypointstate);
 
 		/* Initialize babelfish fixed-size state in shared memory. */
-		if (MyProcPort->is_tds_conn && bbf_parallel_serialise_babelfixedparallelstate_and_insert_into_dsm_hook)
-			(*bbf_parallel_serialise_babelfixedparallelstate_and_insert_into_dsm_hook) (pcxt, false);
+		if (MyProcPort->is_tds_conn && babelfixedparallelstate_insert_hook)
+			(*babelfixedparallelstate_insert_hook) (pcxt, false);
 	}
 	
 
@@ -1503,8 +1503,8 @@ ParallelWorkerMain(Datum main_arg)
 
 
 	/* Hook for babelfish to restore babelfish fixed parallel state */
-	if (MyFixedParallelState->babelfish_context && bbf_parallel_restore_babelfishfixedparallelstate_hook)
-		(*bbf_parallel_restore_babelfishfixedparallelstate_hook) (toc);
+	if (MyFixedParallelState->babelfish_context && babelfixedparallelstate_restore_hook)
+		(*babelfixedparallelstate_restore_hook) (toc);
 
 
 	/*

--- a/src/include/access/parallel.h
+++ b/src/include/access/parallel.h
@@ -83,11 +83,11 @@ extern void ParallelWorkerMain(Datum main_arg);
 extern bool IsBabelfishParallelWorker(void);
 
 /* Hooks for communicating babelfish related information to parallel worker */
-typedef void (*InitializeParallelDSM_hook_type)(ParallelContext *pcxt, bool estimate);
-extern PGDLLIMPORT InitializeParallelDSM_hook_type InitializeParallelDSM_hook;
+typedef void (*bbf_InitializeParallelDSM_hook_type)(ParallelContext *pcxt, bool estimate);
+extern PGDLLIMPORT bbf_InitializeParallelDSM_hook_type bbf_InitializeParallelDSM_hook;
 
-typedef void (*ParallelWorkerMain_hook_type)(shm_toc *toc);
-extern PGDLLIMPORT ParallelWorkerMain_hook_type ParallelWorkerMain_hook;
+typedef void (*bbf_ParallelWorkerMain_hook_type)(shm_toc *toc);
+extern PGDLLIMPORT bbf_ParallelWorkerMain_hook_type bbf_ParallelWorkerMain_hook;
 
 
 #endif							/* PARALLEL_H */

--- a/src/include/access/parallel.h
+++ b/src/include/access/parallel.h
@@ -82,4 +82,12 @@ extern void ParallelWorkerMain(Datum main_arg);
 /* Below helpers are added to support parallel workers in Babelfish context */
 extern bool IsBabelfishParallelWorker(void);
 
+/* Hooks for communicating babelfish related information to parallel worker */
+typedef void (*bbf_parallel_serialise_babelfixedparallelstate_and_insert_into_dsm_hook_type)(ParallelContext *pcxt, bool estimate);
+extern PGDLLIMPORT bbf_parallel_serialise_babelfixedparallelstate_and_insert_into_dsm_hook_type bbf_parallel_serialise_babelfixedparallelstate_and_insert_into_dsm_hook;
+
+typedef void (*bbf_parallel_restore_babelfishfixedparallelstate_hook_type)(shm_toc *toc);
+extern PGDLLIMPORT bbf_parallel_restore_babelfishfixedparallelstate_hook_type bbf_parallel_restore_babelfishfixedparallelstate_hook;
+
+
 #endif							/* PARALLEL_H */

--- a/src/include/access/parallel.h
+++ b/src/include/access/parallel.h
@@ -83,11 +83,11 @@ extern void ParallelWorkerMain(Datum main_arg);
 extern bool IsBabelfishParallelWorker(void);
 
 /* Hooks for communicating babelfish related information to parallel worker */
-typedef void (*babelfixedparallelstate_insert_hook_type)(ParallelContext *pcxt, bool estimate);
-extern PGDLLIMPORT babelfixedparallelstate_insert_hook_type babelfixedparallelstate_insert_hook;
+typedef void (*InitializeParallelDSM_hook_type)(ParallelContext *pcxt, bool estimate);
+extern PGDLLIMPORT InitializeParallelDSM_hook_type InitializeParallelDSM_hook;
 
-typedef void (*babelfixedparallelstate_restore_hook_type)(shm_toc *toc);
-extern PGDLLIMPORT babelfixedparallelstate_restore_hook_type babelfixedparallelstate_restore_hook;
+typedef void (*ParallelWorkerMain_hook_type)(shm_toc *toc);
+extern PGDLLIMPORT ParallelWorkerMain_hook_type ParallelWorkerMain_hook;
 
 
 #endif							/* PARALLEL_H */

--- a/src/include/access/parallel.h
+++ b/src/include/access/parallel.h
@@ -83,11 +83,11 @@ extern void ParallelWorkerMain(Datum main_arg);
 extern bool IsBabelfishParallelWorker(void);
 
 /* Hooks for communicating babelfish related information to parallel worker */
-typedef void (*bbf_parallel_serialise_babelfixedparallelstate_and_insert_into_dsm_hook_type)(ParallelContext *pcxt, bool estimate);
-extern PGDLLIMPORT bbf_parallel_serialise_babelfixedparallelstate_and_insert_into_dsm_hook_type bbf_parallel_serialise_babelfixedparallelstate_and_insert_into_dsm_hook;
+typedef void (*babelfixedparallelstate_insert_hook_type)(ParallelContext *pcxt, bool estimate);
+extern PGDLLIMPORT babelfixedparallelstate_insert_hook_type babelfixedparallelstate_insert_hook;
 
-typedef void (*bbf_parallel_restore_babelfishfixedparallelstate_hook_type)(shm_toc *toc);
-extern PGDLLIMPORT bbf_parallel_restore_babelfishfixedparallelstate_hook_type bbf_parallel_restore_babelfishfixedparallelstate_hook;
+typedef void (*babelfixedparallelstate_restore_hook_type)(shm_toc *toc);
+extern PGDLLIMPORT babelfixedparallelstate_restore_hook_type babelfixedparallelstate_restore_hook;
 
 
 #endif							/* PARALLEL_H */

--- a/src/include/access/parallel.h
+++ b/src/include/access/parallel.h
@@ -82,6 +82,9 @@ extern void ParallelWorkerMain(Datum main_arg);
 /* Below helpers are added to support parallel workers in Babelfish context */
 extern bool IsBabelfishParallelWorker(void);
 
+/* Key for BabelfishFixedParallelState */
+#define BABELFISH_PARALLEL_KEY_FIXED        UINT64CONST(0xBBF0000000000001)
+
 /* Hooks for communicating babelfish related information to parallel worker */
 typedef void (*bbf_InitializeParallelDSM_hook_type)(ParallelContext *pcxt, bool estimate);
 extern PGDLLIMPORT bbf_InitializeParallelDSM_hook_type bbf_InitializeParallelDSM_hook;


### PR DESCRIPTION
### Description

This PR intends to solve the issue of parallel worker not being able to obtain correct logical database name. Whenever get_cur_db_name() is called, it returns static char current_db_name[] which is initialised as empty. Now, parallel workers are not aware of the database name. For them, it is empty whenever get_cur_db_name() gets called. Hence, we were getting the following error: 
```
database "" does not exist
```
So, to communicate the logical database name and more data related to babelfish we have introduced a struct BabelfishFixedParallelState. Currently BabelfishFixedParallelState has only 1 field, i.e., logical_db_name, we can add more fields to it whenever necessary. Then we will write the logical_db_name in DSM during initialisation (in InitializeParallelDSM) using a hook. Another hook is used while trying to fetch the logical database name in ParallelWorkerMain().

In this way we are introduction a mechanism through which we can communicate any babelfish related information to parallel workers.

Signed-off-by: Shameem Ahmed [shmeeh@amazon.com](mailto:rcv@amazon.com)
 
### Issues Resolved

BABEL-4538, BABEL-4481, BABEL-4421
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
