### PR TITLE
Handling babelfish specific GUC after commit a1a00b3bd00cf3f07d382ecb1219e1799b037676

### DIFF
--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -1744,7 +1744,7 @@ RemoveGUCFromLists(struct config_generic *gconf)
 {
 	if (gconf->source != PGC_S_DEFAULT)
 		dlist_delete(&gconf->nondef_link);
-	if (gconf->stack != NULL || gconf->session_stack != NULL)
+	if (gconf->stack != NULL)
 		slist_delete(&guc_stack_list, &gconf->stack_link);
 	if (gconf->status & GUC_NEEDS_REPORT)
 		slist_delete(&guc_report_list, &gconf->report_link);
@@ -4961,7 +4961,7 @@ reapply_stacked_values(struct config_generic *variable,
 			(void) set_config_option_ext(name, curvalue,
 										 curscontext, cursource, cursrole,
 										 GUC_ACTION_SET, true, WARNING, false);
-			if (variable->stack != NULL || variable->session_stack != NULL)
+			if (variable->stack != NULL)
 			{
 				slist_delete(&guc_stack_list, &variable->stack_link);
 				variable->stack = NULL;
@@ -6817,19 +6817,6 @@ void
 guc_set_stack_value(struct config_generic *gconf, config_var_value *val)
 {
 	set_stack_value(gconf,  val);
-}
-
-
-void
-update_guc_stack_list(slist_node *stack_link)
-{
-	slist_push_head(&guc_stack_list, stack_link);
-}
-
-void 
-delete_guc_stack_list(slist_node *stack_link)
-{
-	slist_delete(&guc_stack_list, stack_link);
 }
 
 void

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -1744,7 +1744,7 @@ RemoveGUCFromLists(struct config_generic *gconf)
 {
 	if (gconf->source != PGC_S_DEFAULT)
 		dlist_delete(&gconf->nondef_link);
-	if (gconf->stack != NULL)
+	if (gconf->stack != NULL || gconf->session_stack != NULL)
 		slist_delete(&guc_stack_list, &gconf->stack_link);
 	if (gconf->status & GUC_NEEDS_REPORT)
 		slist_delete(&guc_report_list, &gconf->report_link);
@@ -4961,7 +4961,7 @@ reapply_stacked_values(struct config_generic *variable,
 			(void) set_config_option_ext(name, curvalue,
 										 curscontext, cursource, cursrole,
 										 GUC_ACTION_SET, true, WARNING, false);
-			if (variable->stack != NULL)
+			if (variable->stack != NULL || variable->session_stack != NULL)
 			{
 				slist_delete(&guc_stack_list, &variable->stack_link);
 				variable->stack = NULL;
@@ -6817,4 +6817,23 @@ void
 guc_set_stack_value(struct config_generic *gconf, config_var_value *val)
 {
 	set_stack_value(gconf,  val);
+}
+
+
+void
+update_guc_stack_list(slist_node *stack_link)
+{
+	slist_push_head(&guc_stack_list, stack_link);
+}
+
+void 
+delete_guc_stack_list(slist_node *stack_link)
+{
+	slist_delete(&guc_stack_list, stack_link);
+}
+
+void
+babelfish_set_guc_source(struct config_generic *gconf, GucSource newsource)
+{
+	set_guc_source(gconf, newsource);
 }

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -12,6 +12,7 @@
 #ifndef GUC_H
 #define GUC_H
 
+#include "lib/ilist.h"
 #include "nodes/parsenodes.h"
 #include "tcop/dest.h"
 #include "utils/array.h"
@@ -442,5 +443,10 @@ extern void GUC_check_errcode(int sqlerrcode);
 #define GUC_check_errhint \
 	pre_format_elog_string(errno, TEXTDOMAIN), \
 	GUC_check_errhint_string = format_elog_string
+
+
+extern void update_guc_stack_list(slist_node *stack_link);
+
+extern void delete_guc_stack_list(slist_node *stack_link);
 
 #endif							/* GUC_H */

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -12,7 +12,6 @@
 #ifndef GUC_H
 #define GUC_H
 
-#include "lib/ilist.h"
 #include "nodes/parsenodes.h"
 #include "tcop/dest.h"
 #include "utils/array.h"
@@ -443,10 +442,5 @@ extern void GUC_check_errcode(int sqlerrcode);
 #define GUC_check_errhint \
 	pre_format_elog_string(errno, TEXTDOMAIN), \
 	GUC_check_errhint_string = format_elog_string
-
-
-extern void update_guc_stack_list(slist_node *stack_link);
-
-extern void delete_guc_stack_list(slist_node *stack_link);
 
 #endif							/* GUC_H */

--- a/src/include/utils/guc_tables.h
+++ b/src/include/utils/guc_tables.h
@@ -330,4 +330,6 @@ extern PGDLLEXPORT guc_push_old_value_hook_type guc_push_old_value_hook;
 typedef			void(*validate_set_config_function_hook_type) (char *name, char *value);
 extern PGDLLEXPORT validate_set_config_function_hook_type validate_set_config_function_hook;
 
+extern void babelfish_set_guc_source(struct config_generic *gconf, GucSource newsource);
+
 #endif							/* GUC_TABLES_H */


### PR DESCRIPTION
### Description

With commit a1a00b3bd00cf3f07d382ecb1219e1799b037676, community refactored the code related to GUC handling
and introduced certain optimisation around GUC handling. For example, they have introduced following three fields for various purpose --

```
static dlist_head guc_nondef_list;	/* list of variables that have source
									 * different from PGC_S_DEFAULT */
static slist_head guc_stack_list;	/* list of variables that have non-NULL
									 * stack */
static slist_head guc_report_list;	/* list of variables that have the
									 * GUC_NEEDS_REPORT bit set in status */
```

These all fields are getting updated based on various operations on the GUC. Field guc_nondef_list is to track non-default 
value of various GUCs and is updated through helper function set_guc_source(...). Now the logic of Babelfish GUC
handling is somewhat different and was not updated to accommodate these code changes. This resulted in hang while
communicating GUCs with non-default value to parallel worker. 

This commit aims to fix that issue by providing wrapper around set_guc_source(...) so that Babelfish side can utilise it to
update the guc_nondef_list stack appropriately. 

 Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2244
Task: BABEL-4668, BABEL-4669, BABEL-4670, BABEL-4671
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
