### PR TITLE
[OSS ONLY] Update spec file to use SPDX short name for license and include same (#285)

### DIFF
--- a/BabelfishDump.spec
+++ b/BabelfishDump.spec
@@ -19,13 +19,16 @@
 # https://fedoraproject.org/wiki/Packaging:Guidelines#Packaging_of_Additional_RPM_Macros
 %global macrosdir %(d=%{_rpmconfigdir}/macros.d; [ -d $d ] || d=%{_sysconfdir}/rpm; echo $d)
 
+%define _trivial .0
+%define _buildid .1
+
 %undefine _missing_build_ids_terminate_build
 
 Name: BabelfishDump
 Summary: Postgresql dump utilities modified for Babelfish
 Version: 16.1
-Release: 1%{?dist}
-License: PostgreSQL Global Development Group
+Release: 1%{?dist}%{?_trivial}%{?_buildid}
+License: PostgreSQL
 Url: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish
 
 BuildRequires: make
@@ -134,6 +137,8 @@ LD_LIBRARY_PATH=%{_builddir}/%{name}/src/interfaces/libpq $RPM_BUILD_ROOT/usr/bi
 
 # FILES sections.
 %files
+%doc COPYRIGHT
+%doc LICENSE.PostgreSQL
 %{_bindir}/bbf_dump
 %{_bindir}/bbf_dumpall
 

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ tarball: rpm-clean
 	cp -p GNUmakefile* $(PACKAGE_NAME)
 	cp -p Makefile $(PACKAGE_NAME)
 	cp -rp config src $(PACKAGE_NAME)
+	cp COPYRIGHT LICENSE.PostgreSQL $(PACKAGE_NAME)
 
 	tar -czf $(SOURCE_TARBALL) $(PACKAGE_NAME)/*
 


### PR DESCRIPTION
### Description
Compared the included license file with SPDX and confirmed match. See https://spdx.org/licenses/PostgreSQL.html.

Update spec file to include proper license string and add _trivial and _buildid macros to allow for RPM iteration.

The current license in the spec file is PostgreSQL Global Development Group which is not a valid SPDX license and was flagged by our automation as invalid for inclusion in Amazon Linux.

The proper upstream SPDX license is changed to per https://spdx.org/licenses/PostgreSQL.html.

Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com> 

### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
