### PR TITLE
OID Wraparound

### DIFF
--- a/src/backend/access/transam/varsup.c
+++ b/src/backend/access/transam/varsup.c
@@ -591,6 +591,14 @@ GetNewObjectId(void)
 }
 
 /*
+ * Simple function to get VAR_OID_PREFETCH when needed outside of this file.
+ */
+int GetVarOidPrefetch(void)
+{
+	return VAR_OID_PREFETCH;
+}
+
+/*
  * SetNextObjectId
  *
  * This may only be called during initdb; it advances the OID counter

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1307,7 +1307,7 @@ heap_create_with_catalog(const char *relname,
 
 		if (!OidIsValid(relid))
 			relid = GetNewRelFileNumber(reltablespace, pg_class_desc,
-										relpersistence);
+										relpersistence, false);
 	}
 
 	/*

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -962,8 +962,12 @@ index_create(Relation heapRelation,
 		}
 		else
 		{
-			indexRelationId =
-				GetNewRelFileNumber(tableSpaceId, pg_class, relpersistence);
+			/* 
+			 * Index OIDs must be kept in normal OID range due to deletion issues.
+			 * Since deletion is sorted by OID, adding indexes to temp OID range 
+			 * causes deletion order issues.
+			 */
+			indexRelationId = GetNewRelFileNumber(tableSpaceId, pg_class, relpersistence, is_enr);
 		}
 	}
 

--- a/src/backend/catalog/pg_depend.c
+++ b/src/backend/catalog/pg_depend.c
@@ -326,7 +326,8 @@ deleteDependencyRecordsFor(Oid classId, Oid objectId,
 			((Form_pg_depend) GETSTRUCT(tup))->deptype == DEPENDENCY_EXTENSION)
 			continue;
 
-		CatalogTupleDelete(depRel, &tup->t_self);
+		if (!ENRdropTuple(depRel, tup))
+			CatalogTupleDelete(depRel, &tup->t_self);
 		count++;
 	}
 

--- a/src/backend/catalog/toasting.c
+++ b/src/backend/catalog/toasting.c
@@ -200,6 +200,8 @@ create_toast_table(Relation rel, Oid toastOid, Oid toastIndexOid,
 	 */
 	if (sql_dialect == SQL_DIALECT_TSQL && RelationIsBBFTableVariable(rel))
 		pg_toast_prefix = "@pg_toast";
+	else if (sql_dialect == SQL_DIALECT_TSQL && rel->rd_rel->relpersistence == RELPERSISTENCE_TEMP && get_ENR_withoid(currentQueryEnv, rel->rd_id, ENR_TSQL_TEMP))
+		pg_toast_prefix = "#pg_toast";
 
 	snprintf(toast_relname, sizeof(toast_relname),
 			 "%s_%u", pg_toast_prefix, relOid);

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14609,7 +14609,7 @@ ATExecSetTableSpace(Oid tableOid, Oid newTableSpace, LOCKMODE lockmode)
 	 * need to allocate a new one in the new tablespace.
 	 */
 	newrelfilenumber = GetNewRelFileNumber(newTableSpace, NULL,
-										   rel->rd_rel->relpersistence);
+										   rel->rd_rel->relpersistence, false);
 
 	/* Open old and new relation */
 	newrlocator = rel->rd_locator;

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -3722,7 +3722,7 @@ RelationSetNewRelfilenumber(Relation relation, char persistence)
 	{
 		/* Allocate a new relfilenumber */
 		newrelfilenumber = GetNewRelFileNumber(relation->rd_rel->reltablespace,
-											   NULL, persistence);
+											   NULL, persistence, false);
 	}
 	else if (relation->rd_rel->relkind == RELKIND_INDEX)
 	{

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -87,6 +87,11 @@ char	   *GUC_check_errhint_string;
 /* Kluge: for speed, we examine this GUC variable's value directly */
 extern bool in_hot_standby_guc;
 
+/*
+ * OIDs are stored as uint32, so we will add INT_MIN to match the range.
+ */
+int			temp_oid_buffer_start;
+int			temp_oid_buffer_size;
 
 /*
  * Unit conversion tables.

--- a/src/include/access/transam.h
+++ b/src/include/access/transam.h
@@ -252,6 +252,12 @@ typedef struct VariableCacheData
 	 */
 	TransactionId oldestClogXid;	/* oldest it's safe to look up in clog */
 
+	/*
+	 * This field is also protected by OidGenLock. For tempOidStart, Shmem will
+	 * be the source of truth, as another process may have gotten there first and 
+	 * updated the start.
+	 */
+	Oid			tempOidStart;
 } VariableCacheData;
 
 typedef VariableCacheData *VariableCache;
@@ -294,6 +300,8 @@ extern void AdvanceOldestClogXid(TransactionId oldest_datfrozenxid);
 extern bool ForceTransactionIdLimitUpdate(void);
 extern Oid	GetNewObjectId(void);
 extern void StopGeneratingPinnedObjectIds(void);
+
+extern int GetVarOidPrefetch(void);
 
 typedef void (*GetNewObjectId_hook_type) (VariableCache variableCache);
 extern PGDLLEXPORT GetNewObjectId_hook_type GetNewObjectId_hook;

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -40,7 +40,14 @@ extern Oid	GetNewOidWithIndex(Relation relation, Oid indexId,
 							   AttrNumber oidcolumn);
 extern RelFileNumber GetNewRelFileNumber(Oid reltablespace,
 										 Relation pg_class,
-										 char relpersistence);
+										 char relpersistence,
+										 bool override_temp);
+
+typedef Oid (*GetNewTempObjectId_hook_type) (void);
+extern GetNewTempObjectId_hook_type GetNewTempObjectId_hook;
+
+typedef Oid (*GetNewTempOidWithIndex_hook_type) (Relation relation, Oid indexId, AttrNumber oidcolumn);
+extern GetNewTempOidWithIndex_hook_type GetNewTempOidWithIndex_hook;
 
 typedef bool (*IsExtendedCatalogHookType) (Oid relationId);
 extern PGDLLEXPORT IsExtendedCatalogHookType IsExtendedCatalogHook;

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -273,6 +273,9 @@ extern PGDLLIMPORT int temp_file_limit;
 
 extern PGDLLIMPORT int num_temp_buffers;
 
+extern PGDLLIMPORT int temp_oid_buffer_start;
+extern PGDLLIMPORT int temp_oid_buffer_size;
+
 extern PGDLLIMPORT char *cluster_name;
 extern PGDLLIMPORT char *ConfigFileName;
 extern PGDLLIMPORT char *HbaFileName;


### PR DESCRIPTION
### Description

This change adds a separate OID buffer for temp objects. Since temp objects are already session-local, we can allocate a separate buffer of OIDs set aside only for temp objects. This same buffer range can be used across all sessions.

 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
