### PR TITLE
Fix database does not exists error when is_member(), schema_id() function gets called in parallel query mode.

### DIFF
--- a/src/include/access/parallel.h
+++ b/src/include/access/parallel.h
@@ -82,4 +82,15 @@ extern void ParallelWorkerMain(Datum main_arg);
 /* Below helpers are added to support parallel workers in Babelfish context */
 extern bool IsBabelfishParallelWorker(void);
 
+/* Key for BabelfishFixedParallelState */
+#define BABELFISH_PARALLEL_KEY_FIXED        UINT64CONST(0xBBF0000000000001)
+
+/* Hooks for communicating babelfish related information to parallel worker */
+typedef void (*bbf_InitializeParallelDSM_hook_type)(ParallelContext *pcxt, bool estimate);
+extern PGDLLIMPORT bbf_InitializeParallelDSM_hook_type bbf_InitializeParallelDSM_hook;
+
+typedef void (*bbf_ParallelWorkerMain_hook_type)(shm_toc *toc);
+extern PGDLLIMPORT bbf_ParallelWorkerMain_hook_type bbf_ParallelWorkerMain_hook;
+
+
 #endif							/* PARALLEL_H */


### PR DESCRIPTION
### Description

This PR intends to solve the issue of parallel worker not being able to obtain correct logical database name. Whenever get_cur_db_name() is called, it returns static char current_db_name[] which is initialised as empty. Now, parallel workers are not aware of the database name. For them, it is empty whenever get_cur_db_name() gets called. Hence, we were getting the following error: 
```
database "" does not exist
```
So, to communicate the logical database name and more data related to babelfish we have introduced a struct BabelfishFixedParallelState. Currently BabelfishFixedParallelState has only 1 field, i.e., logical_db_name, we can add more fields to it whenever necessary. Then we will write the logical_db_name in DSM during initialisation (in InitializeParallelDSM) using a hook. Another hook is used while trying to fetch the logical database name in ParallelWorkerMain().

In this way we are introduction a mechanism through which we can communicate any babelfish related information to parallel workers.

Signed-off-by: Shameem Ahmed [shmeeh@amazon.com](mailto:rcv@amazon.com)
 
### Issues Resolved

BABEL-4538, BABEL-4481, BABEL-4421
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
