### PR TITLE
Add toasts to ENR for temp tables

### DIFF
--- a/src/backend/catalog/pg_depend.c
+++ b/src/backend/catalog/pg_depend.c
@@ -326,7 +326,8 @@ deleteDependencyRecordsFor(Oid classId, Oid objectId,
 			((Form_pg_depend) GETSTRUCT(tup))->deptype == DEPENDENCY_EXTENSION)
 			continue;
 
-		CatalogTupleDelete(depRel, &tup->t_self);
+		if (!ENRdropTuple(depRel, tup))
+				CatalogTupleDelete(depRel, &tup->t_self);
 		count++;
 	}
 

--- a/src/backend/catalog/toasting.c
+++ b/src/backend/catalog/toasting.c
@@ -200,6 +200,8 @@ create_toast_table(Relation rel, Oid toastOid, Oid toastIndexOid,
 	 */
 	if (sql_dialect == SQL_DIALECT_TSQL && RelationIsBBFTableVariable(rel))
 		pg_toast_prefix = "@pg_toast";
+	else if (sql_dialect == SQL_DIALECT_TSQL && rel->rd_rel->relpersistence == RELPERSISTENCE_TEMP && get_ENR_withoid(currentQueryEnv, rel->rd_id, ENR_TSQL_TEMP))
+  		pg_toast_prefix = "#pg_toast";
 
 	snprintf(toast_relname, sizeof(toast_relname),
 			 "%s_%u", pg_toast_prefix, relOid);


### PR DESCRIPTION
### Description

Adding toasts to ENR for temp tables. This was originally introduced as part of #295, we are cherry-picking just this change into REL15 to fix an issue with orphaned temp toast table entries. 
 
### Issues Resolved
Fixes an issue with orphaned temp toast table entries.

Tests added in babelfish-for-postgresql/babelfish_extensions#2291

### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
