### PR TITLE
Fixed crash when trying to drop ENR relations during subtransaction.

### DIFF
--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -27,6 +27,7 @@
 #include "access/tupdesc.h"
 #include "access/htup_details.h"
 #include "access/relscan.h"        /* SysScan related */
+#include "access/xact.h"           /* GetCurrentCommandId */
 #include "catalog/catalog.h"
 #include "catalog/dependency.h"
 #include "catalog/indexing.h"
@@ -867,8 +868,13 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 			default:
 				break;
 		}
+
 		/* add/drop/update is possible. Do it now. */
-		if (ret) {
+		if (ret)
+		{
+			/* Tell CommandCounterIncrement() we are about to create some inval messages */
+			GetCurrentCommandId(true);
+
 			Assert(queryEnv->memctx);
 			oldcxt = MemoryContextSwitchTo(queryEnv->memctx);
 			switch (op) {
@@ -878,21 +884,24 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 					CacheInvalidateHeapTuple(catalog_rel, newtup, NULL);
 					break;
 				case ENR_OP_UPDATE:
-					if (lc)
-					{
-						oldtup = lfirst(lc);
-						lfirst(lc) = heap_copytuple(tup);
-						CacheInvalidateHeapTuple(catalog_rel, oldtup, tup);
-					}
+					/*
+					* Invalidate the tuple before updating / removing it from the List.
+					* Consider the case when we remove the tuple and cache invalidation
+					* failed, then error handling would try to remove it again but would
+					* crash because entry is gone from the List but we could still find it in the syscache.
+					* If we failed to drop because we failed to invalidate, then subsequent
+					* creation of the same table would fail saying the tuple exists already
+					* which is much better than crashing.
+					*/
+					oldtup = lfirst(lc);
+					CacheInvalidateHeapTuple(catalog_rel, oldtup, tup);
+					lfirst(lc) = heap_copytuple(tup);
 					break;
 				case ENR_OP_DROP:
-					if (lc)
-					{
-						tmp = lfirst(lc);
-						*list_ptr = list_delete_ptr(*list_ptr, tmp);
-						CacheInvalidateHeapTuple(catalog_rel, tup, NULL);
-						heap_freetuple(tmp);
-					}
+					CacheInvalidateHeapTuple(catalog_rel, tup, NULL);
+					tmp = lfirst(lc);
+					*list_ptr = list_delete_ptr(*list_ptr, tmp);
+					heap_freetuple(tmp);
 					break;
 				default:
 					break;

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -878,15 +878,21 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 					CacheInvalidateHeapTuple(catalog_rel, newtup, NULL);
 					break;
 				case ENR_OP_UPDATE:
-					oldtup = lfirst(lc);
-					lfirst(lc) = heap_copytuple(tup);
-					CacheInvalidateHeapTuple(catalog_rel, oldtup, tup);
+					if (lc)
+					{
+						oldtup = lfirst(lc);
+						lfirst(lc) = heap_copytuple(tup);
+						CacheInvalidateHeapTuple(catalog_rel, oldtup, tup);
+					}
 					break;
 				case ENR_OP_DROP:
-					tmp = lfirst(lc);
-					*list_ptr = list_delete_ptr(*list_ptr, tmp);
-					CacheInvalidateHeapTuple(catalog_rel, tup, NULL);
-					heap_freetuple(tmp);
+					if (lc)
+					{
+						tmp = lfirst(lc);
+						*list_ptr = list_delete_ptr(*list_ptr, tmp);
+						CacheInvalidateHeapTuple(catalog_rel, tup, NULL);
+						heap_freetuple(tmp);
+					}
 					break;
 				default:
 					break;


### PR DESCRIPTION
### Description

Fixed crash when trying to drop ENR relations during subtransaction.

Unable to drop ENR tables in subtransaction because invalidation
messages was never accepted failing the check in PrepareInvalidationState().

This is because ENR relations skip GetCurrentCommandId(true) hence
making CommandCounterIncrement() practically a no-op.

Also fix a Day 1 issue when caller of pltsql_clean_table_variables()
skips some important error handling when
pltsql_clean_table_variables
fails.

Task: BABEL-4737
 
### Issues Resolved

[List any issues this PR will resolve]
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
