### PR TITLE
Add check hook for pgstat_end_function_usage in fmgr

### DIFF
--- a/src/backend/commands/event_trigger.c
+++ b/src/backend/commands/event_trigger.c
@@ -917,14 +917,13 @@ EventTriggerInvoke(List *fn_oid_list, EventTriggerData *trigdata)
 								 InvalidOid, (Node *) trigdata, NULL);
 		pgstat_init_function_usage(fcinfo, &fcusage);
 		FunctionCallInvoke(fcinfo);
-		if (pltsql_pgstat_end_function_usage_hook && (&fcusage)->fs != NULL)
+		if (pltsql_pgstat_end_function_usage_hook)
 		{
 			(*pltsql_pgstat_end_function_usage_hook)(fcinfo, &fcusage, PROKIND_FUNCTION, true);
 		}
 		else
 		{
 			pgstat_end_function_usage(&fcusage, true);
-
 		}
 
 		/* Reclaim memory. */

--- a/src/backend/commands/event_trigger.c
+++ b/src/backend/commands/event_trigger.c
@@ -917,7 +917,9 @@ EventTriggerInvoke(List *fn_oid_list, EventTriggerData *trigdata)
 								 InvalidOid, (Node *) trigdata, NULL);
 		pgstat_init_function_usage(fcinfo, &fcusage);
 		FunctionCallInvoke(fcinfo);
-		pgstat_end_function_usage(&fcusage, true);
+		if (!pltsql_pgstat_function_check_hook || ((&fcusage)->fs != NULL
+		    && (*pltsql_pgstat_function_check_hook)(fcinfo)))
+			pgstat_end_function_usage(&fcusage, true);
 
 		/* Reclaim memory. */
 		MemoryContextReset(context);

--- a/src/backend/commands/event_trigger.c
+++ b/src/backend/commands/event_trigger.c
@@ -917,9 +917,15 @@ EventTriggerInvoke(List *fn_oid_list, EventTriggerData *trigdata)
 								 InvalidOid, (Node *) trigdata, NULL);
 		pgstat_init_function_usage(fcinfo, &fcusage);
 		FunctionCallInvoke(fcinfo);
-		if (!pltsql_pgstat_function_check_hook || ((&fcusage)->fs != NULL
-		    && (*pltsql_pgstat_function_check_hook)(fcinfo)))
+		if (pltsql_pgstat_end_function_usage_hook && (&fcusage)->fs != NULL)
+		{
+			(*pltsql_pgstat_end_function_usage_hook)(fcinfo, &fcusage, PROKIND_FUNCTION, true);
+		}
+		else
+		{
 			pgstat_end_function_usage(&fcusage, true);
+
+		}
 
 		/* Reclaim memory. */
 		MemoryContextReset(context);

--- a/src/backend/commands/functioncmds.c
+++ b/src/backend/commands/functioncmds.c
@@ -2490,7 +2490,9 @@ ExecuteCallStmt(CallStmt *stmt, ParamListInfo params, bool atomic, DestReceiver 
 	/* Here we actually call the procedure */
 	pgstat_init_function_usage(fcinfo, &fcusage);
 	retval = FunctionCallInvoke(fcinfo);
-	pgstat_end_function_usage(&fcusage, true);
+	if (!pltsql_pgstat_function_check_hook || ((&fcusage)->fs != NULL
+	    && (*pltsql_pgstat_function_check_hook)(fcinfo)))
+		pgstat_end_function_usage(&fcusage, true);
 
 	/* Handle the procedure's outputs */
 	if (((stmt->relation && stmt->attrnos) || (stmt->retdesc && stmt->dest)) &&

--- a/src/backend/commands/functioncmds.c
+++ b/src/backend/commands/functioncmds.c
@@ -2490,14 +2490,13 @@ ExecuteCallStmt(CallStmt *stmt, ParamListInfo params, bool atomic, DestReceiver 
 	/* Here we actually call the procedure */
 	pgstat_init_function_usage(fcinfo, &fcusage);
 	retval = FunctionCallInvoke(fcinfo);
-	if (pltsql_pgstat_end_function_usage_hook && (&fcusage)->fs != NULL)
+	if (pltsql_pgstat_end_function_usage_hook)
 	{
 		(*pltsql_pgstat_end_function_usage_hook)(fcinfo,  &fcusage, PROKIND_FUNCTION, true);
 	}
 	else
 	{
 		pgstat_end_function_usage(&fcusage, true);
-
 	}
 
 	/* Handle the procedure's outputs */

--- a/src/backend/commands/functioncmds.c
+++ b/src/backend/commands/functioncmds.c
@@ -2490,9 +2490,15 @@ ExecuteCallStmt(CallStmt *stmt, ParamListInfo params, bool atomic, DestReceiver 
 	/* Here we actually call the procedure */
 	pgstat_init_function_usage(fcinfo, &fcusage);
 	retval = FunctionCallInvoke(fcinfo);
-	if (!pltsql_pgstat_function_check_hook || ((&fcusage)->fs != NULL
-	    && (*pltsql_pgstat_function_check_hook)(fcinfo)))
+	if (pltsql_pgstat_end_function_usage_hook && (&fcusage)->fs != NULL)
+	{
+		(*pltsql_pgstat_end_function_usage_hook)(fcinfo,  &fcusage, PROKIND_FUNCTION, true);
+	}
+	else
+	{
 		pgstat_end_function_usage(&fcusage, true);
+
+	}
 
 	/* Handle the procedure's outputs */
 	if (((stmt->relation && stmt->attrnos) || (stmt->retdesc && stmt->dest)) &&

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -2519,14 +2519,13 @@ ExecCallTriggerFunc(TriggerData *trigdata,
 	}
 	PG_END_TRY();
 
-	if (pltsql_pgstat_end_function_usage_hook && (&fcusage)->fs != NULL)
+	if (pltsql_pgstat_end_function_usage_hook)
 	{
 		(*pltsql_pgstat_end_function_usage_hook)(fcinfo,  &fcusage, PROKIND_FUNCTION, true);
 	}
 	else
 	{
 		pgstat_end_function_usage(&fcusage, true);
-
 	}
 
 	MemoryContextSwitchTo(oldContext);

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -2519,7 +2519,9 @@ ExecCallTriggerFunc(TriggerData *trigdata,
 	}
 	PG_END_TRY();
 
-	pgstat_end_function_usage(&fcusage, true);
+	if (!pltsql_pgstat_function_check_hook || ((&fcusage)->fs != NULL
+	    && (*pltsql_pgstat_function_check_hook)(fcinfo)))
+		pgstat_end_function_usage(&fcusage, true);
 
 	MemoryContextSwitchTo(oldContext);
 

--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -2519,9 +2519,15 @@ ExecCallTriggerFunc(TriggerData *trigdata,
 	}
 	PG_END_TRY();
 
-	if (!pltsql_pgstat_function_check_hook || ((&fcusage)->fs != NULL
-	    && (*pltsql_pgstat_function_check_hook)(fcinfo)))
+	if (pltsql_pgstat_end_function_usage_hook && (&fcusage)->fs != NULL)
+	{
+		(*pltsql_pgstat_end_function_usage_hook)(fcinfo,  &fcusage, PROKIND_FUNCTION, true);
+	}
+	else
+	{
 		pgstat_end_function_usage(&fcusage, true);
+
+	}
 
 	MemoryContextSwitchTo(oldContext);
 

--- a/src/backend/utils/activity/pgstat_function.c
+++ b/src/backend/utils/activity/pgstat_function.c
@@ -41,6 +41,7 @@ int			pgstat_track_functions = TRACK_FUNC_OFF;
 static instr_time total_func_time;
 
 pre_function_call_hook_type pre_function_call_hook = NULL;
+pltsql_pgstat_end_function_usage_hook_type pltsql_pgstat_end_function_usage_hook = NULL;
 
 /*
  * Ensure that stats are dropped if transaction aborts.

--- a/src/backend/utils/activity/pgstat_shmem.c
+++ b/src/backend/utils/activity/pgstat_shmem.c
@@ -1005,3 +1005,11 @@ pgstat_setup_memcxt(void)
 								  "PgStat Shared Ref Hash",
 								  ALLOCSET_SMALL_SIZES);
 }
+
+bool
+lookup_pgstat_entry_in_cache(PgStat_Kind kind, Oid dboid, Oid objoid)
+{
+	PgStat_HashKey key = {.kind = kind,.dboid = dboid,.objoid = objoid};
+	
+	return pgstat_entry_ref_hash_lookup(pgStatEntryRefHash, key);
+}

--- a/src/backend/utils/activity/pgstat_shmem.c
+++ b/src/backend/utils/activity/pgstat_shmem.c
@@ -1009,7 +1009,10 @@ pgstat_setup_memcxt(void)
 bool
 lookup_pgstat_entry_in_cache(PgStat_Kind kind, Oid dboid, Oid objoid)
 {
-	PgStat_HashKey key = {.kind = kind,.dboid = dboid,.objoid = objoid};
-	
-	return pgstat_entry_ref_hash_lookup(pgStatEntryRefHash, key);
+	if (pgStatEntryRefHash)
+	{
+		PgStat_HashKey key = {.kind = kind,.dboid = dboid,.objoid = objoid};
+		return pgstat_entry_ref_hash_lookup(pgStatEntryRefHash, key);
+	}
+	return false;
 }

--- a/src/backend/utils/fmgr/fmgr.c
+++ b/src/backend/utils/fmgr/fmgr.c
@@ -23,6 +23,7 @@
 #include "catalog/pg_proc.h"
 #include "catalog/pg_type.h"
 #include "commands/proclang.h"
+#include "commands/trigger.h"
 #include "executor/functions.h"
 #include "lib/stringinfo.h"
 #include "miscadmin.h"
@@ -871,8 +872,9 @@ fmgr_security_definer(PG_FUNCTION_ARGS)
 		 * so we have to test to see what finalize flag to use.
 		 */
 		
-		if (!pltsql_pgstat_function_check_hook || ((&fcusage)->fs != NULL
-		     && ((*pltsql_pgstat_function_check_hook)(fcinfo->flinfo->fn_oid))))
+		if (!pltsql_pgstat_function_check_hook ||
+		    (fcache->prokind != PROKIND_PROCEDURE && !CALLED_AS_TRIGGER(fcinfo)) ||
+		    ((&fcusage)->fs != NULL && (*pltsql_pgstat_function_check_hook)(fcinfo)))
 			pgstat_end_function_usage(&fcusage,
 									  (fcinfo->resultinfo == NULL ||
 									   !IsA(fcinfo->resultinfo, ReturnSetInfo) ||

--- a/src/backend/utils/fmgr/fmgr.c
+++ b/src/backend/utils/fmgr/fmgr.c
@@ -870,7 +870,7 @@ fmgr_security_definer(PG_FUNCTION_ARGS)
 		 * so we have to test to see what finalize flag to use.
 		 */
 		
-		if (pltsql_pgstat_end_function_usage_hook && (&fcusage)->fs != NULL)
+		if (pltsql_pgstat_end_function_usage_hook)
 		{
 			(*pltsql_pgstat_end_function_usage_hook)(fcinfo, &fcusage, fcache->prokind, 
 													 (fcinfo->resultinfo == NULL ||

--- a/src/include/fmgr.h
+++ b/src/include/fmgr.h
@@ -797,7 +797,7 @@ typedef void (*non_tsql_proc_entry_hook_type) (int, int);
 
 typedef void (*get_func_language_oids_hook_type)(Oid *, Oid *);
 
-typedef bool (*pltsql_pgstat_function_check_hook_type) (Oid oid);
+typedef bool (*pltsql_pgstat_function_check_hook_type) (FunctionCallInfo fcinfo);
 
 typedef char *(*set_local_schema_for_func_hook_type) (Oid proc_nsp_oid);
 

--- a/src/include/fmgr.h
+++ b/src/include/fmgr.h
@@ -797,13 +797,16 @@ typedef void (*non_tsql_proc_entry_hook_type) (int, int);
 
 typedef void (*get_func_language_oids_hook_type)(Oid *, Oid *);
 
+typedef bool (*pltsql_pgstat_function_check_hook_type) (Oid oid);
+
 typedef char *(*set_local_schema_for_func_hook_type) (Oid proc_nsp_oid);
-extern set_local_schema_for_func_hook_type set_local_schema_for_func_hook;
 
 extern PGDLLIMPORT needs_fmgr_hook_type needs_fmgr_hook;
 extern PGDLLIMPORT fmgr_hook_type fmgr_hook;
 extern PGDLLEXPORT non_tsql_proc_entry_hook_type non_tsql_proc_entry_hook;
 extern PGDLLEXPORT get_func_language_oids_hook_type get_func_language_oids_hook;
+extern PGDLLEXPORT pltsql_pgstat_function_check_hook_type pltsql_pgstat_function_check_hook;
+extern PGDLLEXPORT set_local_schema_for_func_hook_type set_local_schema_for_func_hook;
 
 #define FmgrHookIsNeeded(fn_oid)							\
 	(!needs_fmgr_hook ? false : (*needs_fmgr_hook)(fn_oid))

--- a/src/include/fmgr.h
+++ b/src/include/fmgr.h
@@ -797,15 +797,12 @@ typedef void (*non_tsql_proc_entry_hook_type) (int, int);
 
 typedef void (*get_func_language_oids_hook_type)(Oid *, Oid *);
 
-typedef bool (*pltsql_pgstat_function_check_hook_type) (FunctionCallInfo fcinfo);
-
 typedef char *(*set_local_schema_for_func_hook_type) (Oid proc_nsp_oid);
 
 extern PGDLLIMPORT needs_fmgr_hook_type needs_fmgr_hook;
 extern PGDLLIMPORT fmgr_hook_type fmgr_hook;
 extern PGDLLEXPORT non_tsql_proc_entry_hook_type non_tsql_proc_entry_hook;
 extern PGDLLEXPORT get_func_language_oids_hook_type get_func_language_oids_hook;
-extern PGDLLEXPORT pltsql_pgstat_function_check_hook_type pltsql_pgstat_function_check_hook;
 extern PGDLLEXPORT set_local_schema_for_func_hook_type set_local_schema_for_func_hook;
 
 #define FmgrHookIsNeeded(fn_oid)							\

--- a/src/include/pgstat.h
+++ b/src/include/pgstat.h
@@ -799,4 +799,6 @@ extern PGDLLEXPORT tsql_has_pgstat_permissions_hook_type tsql_has_pgstat_permiss
 typedef void (*pgstat_function_wrapper_hook_type)(FunctionCallInfo, PgStat_FunctionCallUsage *, char *);
 extern PGDLLEXPORT pgstat_function_wrapper_hook_type pgstat_function_wrapper_hook;
 
+extern bool lookup_pgstat_entry_in_cache(PgStat_Kind kind, Oid dboid, Oid objoid);
+
 #endif							/* PGSTAT_H */

--- a/src/include/pgstat.h
+++ b/src/include/pgstat.h
@@ -799,6 +799,11 @@ extern PGDLLEXPORT tsql_has_pgstat_permissions_hook_type tsql_has_pgstat_permiss
 typedef void (*pgstat_function_wrapper_hook_type)(FunctionCallInfo, PgStat_FunctionCallUsage *, char *);
 extern PGDLLEXPORT pgstat_function_wrapper_hook_type pgstat_function_wrapper_hook;
 
+typedef void (*pltsql_pgstat_end_function_usage_hook_type) (FunctionCallInfo fcinfo, 
+															PgStat_FunctionCallUsage *fcu,
+															char prokind, bool finalize);
+extern PGDLLEXPORT pltsql_pgstat_end_function_usage_hook_type pltsql_pgstat_end_function_usage_hook;
+
 extern bool lookup_pgstat_entry_in_cache(PgStat_Kind kind, Oid dboid, Oid objoid);
 
 #endif							/* PGSTAT_H */


### PR DESCRIPTION
### Description

Introduce function to check if pg_stat entry exists in local cache for given key.
Add a hook to validate if pg_stat entry still exists before calling pgstat_end_function_usage.

#### Engine PR: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/305
#### Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2352

### Issues Resolved

[BABEL-4740]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
