### PR TITLE
Add pg_attrdef to ENR for BBF table variables and temp tables

### DIFF
--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -758,6 +758,9 @@ ENRAddUncommittedTupleData(EphemeralNamedRelation enr, Oid catoid, ENRTupleOpera
 		case SequenceRelationId:
 			list_ptr = &enr->md.uncommitted_cattups[ENR_CATTUP_SEQUENCE];
 			break;
+		case AttrDefaultRelationId:
+			list_ptr = &enr->md.uncommitted_cattups[ENR_CATTUP_ATTR_DEF_REL];
+			break;
 		default:
 			/* Shouldn't reach here */
 			elog(ERROR, "Did not find matching ENR catalog entry for catoid %d", catoid);

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -38,6 +38,7 @@
 #include "catalog/pg_type.h"
 #include "catalog/pg_depend.h"
 #include "catalog/pg_sequence.h"
+#include "catalog/pg_attrdef.h"
 #include "catalog/pg_shdepend.h"
 #include "catalog/pg_index_d.h"
 #include "parser/parser.h"      /* only needed for GUC variables */
@@ -333,7 +334,8 @@ bool ENRgetSystableScan(Relation rel, Oid indexId, int nkeys, ScanKey key, List 
 		reloid != DependRelationId &&
 		reloid != SharedDependRelationId &&
 		reloid != IndexRelationId &&
-		reloid != SequenceRelationId)
+		reloid != SequenceRelationId &&
+		reloid != AttrDefaultRelationId)
 		return false;
 
 	switch (nkeys) {
@@ -614,6 +616,30 @@ bool ENRgetSystableScan(Relation rel, Oid indexId, int nkeys, ScanKey key, List 
 					}
 				}
 			}
+			else if (reloid == AttrDefaultRelationId) {
+				ListCell *lc;
+				foreach(lc, enr->md.cattups[ENR_CATTUP_ATTR_DEF_REL]) {
+					Form_pg_attrdef tup = (Form_pg_attrdef) GETSTRUCT((HeapTuple) lfirst(lc));
+					if(indexId == AttrDefaultIndexId) {
+						/* Callers could pass in nkeys=1 or nkeys=2 */
+						if ((nkeys == 1 && tup->adrelid == (Oid)v1) ||
+							(nkeys == 2 && tup->adrelid == (Oid)v1 && tup->adnum == (Oid)v2))
+						{
+							*tuplist = list_insert_nth(*tuplist, index++, lfirst(lc));
+							*tuplist_flags |= SYSSCAN_ENR_NEEDFREE;
+							found = true;
+						}
+					}
+					else if(indexId == AttrDefaultOidIndexId &&
+							tup->oid == (Oid)v1)
+					{
+						*tuplist = list_insert_nth(*tuplist, index++, lfirst(lc));
+						*tuplist_flags |= SYSSCAN_ENR_NEEDFREE;
+						found = true;
+					}
+				}
+				*tuplist_i = 0;
+			}
 		}
 		queryEnv = queryEnv->parentEnv;
 	}
@@ -664,6 +690,7 @@ find_enr(Form_pg_depend entry)
 				break;
 
 			case ConstraintRelationId:
+			case AttrDefaultRelationId:
 				return get_ENR_withoid(queryEnv, entry->refobjid, ENR_TSQL_TEMP);
 
 			default:
@@ -992,6 +1019,14 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 				if ((enr = get_ENR_withoid(queryEnv, rel_oid, ENR_TSQL_TEMP))) {
 					list_ptr = &enr->md.cattups[ENR_CATTUP_SEQUENCE];
 					lc = list_head(enr->md.cattups[ENR_CATTUP_SEQUENCE]);
+					ret = true;
+				}
+				break;
+			case AttrDefaultRelationId:
+				rel_oid = ((Form_pg_attrdef) GETSTRUCT(tup))->adrelid;
+				if ((enr = get_ENR_withoid(queryEnv, rel_oid, ENR_TSQL_TEMP))) {
+					list_ptr = &enr->md.cattups[ENR_CATTUP_ATTR_DEF_REL];
+					lc = list_head(enr->md.cattups[ENR_CATTUP_ATTR_DEF_REL]);
 					ret = true;
 				}
 				break;

--- a/src/include/utils/queryenvironment.h
+++ b/src/include/utils/queryenvironment.h
@@ -41,7 +41,8 @@ typedef enum ENRCatalogTupleType
 	ENR_CATTUP_SHDEPEND,
 	ENR_CATTUP_INDEX,
 	ENR_CATTUP_SEQUENCE,
-	ENR_CATTUP_END
+	ENR_CATTUP_ATTR_DEF_REL,
+	ENR_CATTUP_END,
 } ENRCatalogTupleType;
 
 typedef enum ENRTupleOperationType


### PR DESCRIPTION
### Description

Table Variables and Temp Tables can have identity columns which
adds entries to pg_attrdef. If the table is in ENR, then pg_attrdef
entry should also be in ENR otherwise we would have catalog
inconsistency.
 
### Issues Resolved

Task: BABEL-4752
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
