### PR TITLE
index created for UNIQUE table/column constraint in pltsql should be NULLS FIRST

### DIFF
--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -2593,7 +2593,7 @@ transformIndexConstraint(Constraint *constraint, CreateStmtContext *cxt)
 				iparam->ordering = i->ordering;
 			}
 
-			if (pltsql_unique_constraint_nulls_ordering_hook)
+			if (sql_dialect != SQL_DIALECT_TSQL && pltsql_unique_constraint_nulls_ordering_hook)
 			{
 				iparam->nulls_ordering = (* pltsql_unique_constraint_nulls_ordering_hook) (constraint->contype, iparam->ordering);
 			}

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -70,6 +70,7 @@
 
 /* Hook for pltsql plugin */
 pltsql_identity_datatype_hook_type pltsql_identity_datatype_hook = NULL;
+pltsql_unique_constraint_nulls_ordering_hook_type pltsql_unique_constraint_nulls_ordering_hook = NULL;
 post_transform_column_definition_hook_type post_transform_column_definition_hook = NULL;
 post_transform_table_definition_hook_type post_transform_table_definition_hook = NULL;
 
@@ -2591,6 +2592,12 @@ transformIndexConstraint(Constraint *constraint, CreateStmtContext *cxt)
 				IndexElem * i = (IndexElem *) lfirst(lc);
 				iparam->ordering = i->ordering;
 			}
+
+			if (pltsql_unique_constraint_nulls_ordering_hook)
+			{
+				iparam->nulls_ordering = (* pltsql_unique_constraint_nulls_ordering_hook) (constraint->contype, iparam->ordering);
+			}
+
 			/*
 			 * For a primary-key column, also create an item for ALTER TABLE
 			 * SET NOT NULL if we couldn't ensure it via is_not_null above.

--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -2593,7 +2593,7 @@ transformIndexConstraint(Constraint *constraint, CreateStmtContext *cxt)
 				iparam->ordering = i->ordering;
 			}
 
-			if (sql_dialect != SQL_DIALECT_TSQL && pltsql_unique_constraint_nulls_ordering_hook)
+			if (sql_dialect == SQL_DIALECT_TSQL && pltsql_unique_constraint_nulls_ordering_hook)
 			{
 				iparam->nulls_ordering = (* pltsql_unique_constraint_nulls_ordering_hook) (constraint->contype, iparam->ordering);
 			}

--- a/src/include/parser/parse_utilcmd.h
+++ b/src/include/parser/parse_utilcmd.h
@@ -22,7 +22,10 @@ struct AttrMap;					/* avoid including attmap.h here */
 /* IDENTITY datatype hook */
 typedef void (*pltsql_identity_datatype_hook_type) (ParseState *pstate,
 													ColumnDef *column);
+typedef SortByNulls (*pltsql_unique_constraint_nulls_ordering_hook_type) (ConstrType constraint_type,
+																		  SortByDir ordering);
 extern PGDLLIMPORT pltsql_identity_datatype_hook_type pltsql_identity_datatype_hook;
+extern PGDLLIMPORT pltsql_unique_constraint_nulls_ordering_hook_type pltsql_unique_constraint_nulls_ordering_hook;
 typedef void (*post_transform_column_definition_hook_type) (ParseState *pstate, RangeVar* relation, ColumnDef *column, List **alist);
 typedef void (*post_transform_table_definition_hook_type) (ParseState *pstate, RangeVar* relation, char *relname, List **alist);
 extern PGDLLIMPORT post_transform_column_definition_hook_type post_transform_column_definition_hook;


### PR DESCRIPTION
### Description

pltsql always defaults to NULLS FIRST ordering when ASC for index. One case which was not covered yet was UNIQUE constraint in CREATE TABLE command, which still creates an index with SORTBY_NULLS_DEFAULT. (PG default is NULLS LAST in ASC)
This UNIQUE constraint could be a column constraint or table constraint and PG does not support NULLS ORDERING for UNIQUE constraint in CREATE TABLE.
`CREATE TABLE name (col1 type UNIQUE)`    -- column constraint
or
`CREATE TABLE name (col1 type1, col2 type2, UNIQUE (col1))`     -- table constraint

To fix this we change the NULLS ORDERING for unique index created from table/column constraints.
The hook is placed in transformIndexConstraint which is responsible for converting the constraint node to create index node for create stmts.
We modify the NULLS ORDERING value here.

Also only index which have amcanorder set to true can accept ordering. Right now only b-tree are supported as unique index and b-tree does support ordering.
 
#### Engine PR: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/310
#### Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2392

### Issues Resolved

[BABEL-3571]
 
#### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
