### PR TITLE
Upgrade failure fix changes for 14.11

### DIFF
--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -1269,7 +1269,8 @@ func_select_candidate(int nargs,
 	 * let's try to choose the best candidate by T-SQL precedence rule with setting resolved_unknowns.
 	 */
 	if (resolved_unknowns &&
-		sql_dialect == SQL_DIALECT_TSQL &&
+		(sql_dialect == SQL_DIALECT_TSQL ||
+		(dump_restore && strcmp(dump_restore, "on") == 0)) && /* execute hook if dialect is T-SQL or while restoring babelfish database */
 		func_select_candidate_hook != NULL)
 	{
 		last_candidate = func_select_candidate_hook(nargs, input_typeids, candidates, true);


### PR DESCRIPTION
### Description

During restore certain function calls get failed since `func_select_candidate_hook` is allowed only in `TSQL` dialect.
To fix this, added a check for dump_restore GUC along with `sql_dialect` check.
 
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>

### Issues Resolved

Task: BABEL-3826
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
