### PR TITLE
Remove redundant call to IsExtendedCatalogHook

### DIFF
--- a/src/backend/utils/cache/inval.c
+++ b/src/backend/utils/cache/inval.c
@@ -1217,11 +1217,11 @@ CacheInvalidateHeapTuple(Relation relation,
 		return;
 
 	/*
-	 * We only need to worry about invalidation for tuples that are either in
-       * system catalogs or in babelfish catalogs ; user-relation tuples are
-       * never in catcaches and can't affect the relcache either.
+	 * We only need to worry about invalidation for tuples that are in system
+	 * catalogs; user-relation tuples are never in catcaches and can't affect
+	 * the relcache either.
 	 */
-	if (!IsCatalogRelation(relation) && (!IsExtendedCatalogHook || !IsExtendedCatalogHook(relation->rd_id)))
+	if (!IsCatalogRelation(relation))
 		return;
 
 	/*


### PR DESCRIPTION
### Description
In CacheInvalidateHeapTuple(), we're checking
```
if (!IsCatalogRelation(relation) && (!IsExtendedCatalogHook || !IsExtendedCatalogHook(relation->rd_id)))
```
and again in IsCatalogRelation(), we're checking
```
if (IsExtendedCatalogHook && IsExtendedCatalogHook(relid))
```
Which means `IsExtendedCatalogHook` call in CacheInvalidateHeapTuple is redundant
since `IsCatalogRelation()` already takes care of checking for extended catalogs.

Task: BABEL-4721
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>

Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2398
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
