### PR TITLE
Check that trigger address hook is only called on T-SQL connection

### DIFF
--- a/src/backend/catalog/objectaddress.c
+++ b/src/backend/catalog/objectaddress.c
@@ -1011,11 +1011,11 @@ get_object_address(ObjectType objtype, Node *object,
 													   &relation, missing_ok);
 				break;
 			case OBJECT_TRIGGER:
-				if(get_trigger_object_address_hook){
+				if(get_trigger_object_address_hook && sql_dialect == SQL_DIALECT_TSQL){
 						address = (*get_trigger_object_address_hook)(castNode(List, object),
 															&relation, missing_ok,false);
 				}
-				if (!OidIsValid(address.objectId))
+				else
 					address = get_object_address_relobject(objtype, castNode(List, object),
 													   &relation, missing_ok);
 				break;

--- a/src/backend/catalog/objectaddress.c
+++ b/src/backend/catalog/objectaddress.c
@@ -1011,11 +1011,11 @@ get_object_address(ObjectType objtype, Node *object,
 													   &relation, missing_ok);
 				break;
 			case OBJECT_TRIGGER:
-				if(get_trigger_object_address_hook && sql_dialect == SQL_DIALECT_TSQL){
+				if(get_trigger_object_address_hook){
 						address = (*get_trigger_object_address_hook)(castNode(List, object),
 															&relation, missing_ok,false);
 				}
-				else
+				if (!OidIsValid(address.objectId))
 					address = get_object_address_relobject(objtype, castNode(List, object),
 													   &relation, missing_ok);
 				break;

--- a/src/backend/catalog/objectaddress.c
+++ b/src/backend/catalog/objectaddress.c
@@ -1011,7 +1011,7 @@ get_object_address(ObjectType objtype, Node *object,
 													   &relation, missing_ok);
 				break;
 			case OBJECT_TRIGGER:
-				if(get_trigger_object_address_hook){
+				if(get_trigger_object_address_hook && sql_dialect == SQL_DIALECT_TSQL){
 						address = (*get_trigger_object_address_hook)(castNode(List, object),
 															&relation, missing_ok,false);
 				}

--- a/src/backend/catalog/objectaddress.c
+++ b/src/backend/catalog/objectaddress.c
@@ -74,6 +74,7 @@
 #include "commands/trigger.h"
 #include "foreign/foreign.h"
 #include "funcapi.h"
+#include "libpq/libpq-be.h"
 #include "miscadmin.h"
 #include "nodes/makefuncs.h"
 #include "parser/parse_func.h"
@@ -1011,7 +1012,7 @@ get_object_address(ObjectType objtype, Node *object,
 													   &relation, missing_ok);
 				break;
 			case OBJECT_TRIGGER:
-				if(get_trigger_object_address_hook && sql_dialect == SQL_DIALECT_TSQL){
+				if(get_trigger_object_address_hook && MyProcPort->is_tds_conn){
 						address = (*get_trigger_object_address_hook)(castNode(List, object),
 															&relation, missing_ok,false);
 				}

--- a/src/backend/catalog/objectaddress.c
+++ b/src/backend/catalog/objectaddress.c
@@ -1012,7 +1012,7 @@ get_object_address(ObjectType objtype, Node *object,
 													   &relation, missing_ok);
 				break;
 			case OBJECT_TRIGGER:
-				if(get_trigger_object_address_hook && MyProcPort->is_tds_conn){
+				if(get_trigger_object_address_hook && MyProcPort->is_tds_conn && sql_dialect == SQL_DIALECT_TSQL){
 						address = (*get_trigger_object_address_hook)(castNode(List, object),
 															&relation, missing_ok,false);
 				}


### PR DESCRIPTION
### Description

[get_trigger_object_address_hook](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/195044dcde070f6267cd80c6ce50f7b99bde29b0/contrib/babelfishpg_tsql/src/hooks.c#L2381) does not expect to be called on a Postgres connection and returns empty address despite having `missing_ok` parameter as `false`.

It is suggested to add a check that `get_trigger_object_address_hook` is only called on T-SQL connection.
 


Issue: [#2413](https://github.com/babelfish-for-postgresql/babelfish_extensions/issues/2413)
Taks: BABEL-4844 
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Alex Kasko <alex@staticlibs.net>
