### PR TITLE
Correctly dump the data of babelfish_extended_properties (#314)

### DIFF
--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -25,6 +25,7 @@ extern char *bbf_db_name;
 extern void bbf_selectDumpableObject(DumpableObject *dobj, Archive *fout);
 extern void fixTsqlDefaultExpr(Archive *fout, AttrDefInfo *attrDefInfo);
 extern bool isBabelfishDatabase(Archive *fout);
+extern bool isBabelfishConfigTable(Archive *fout, TableInfo *tbinfo);
 extern void fixOprRegProc(Archive *fout, const OprInfo *oprinfo, const char *oprleft, const char *oprright, char **oprregproc);
 extern void fixTsqlTableTypeDependency(Archive *fout, DumpableObject *func, DumpableObject *tabletype, char deptype);
 extern bool isTsqlTableType(Archive *fout, const TableInfo *tbinfo);
@@ -33,19 +34,19 @@ extern void fixAttoptionsBbfOriginalName(Archive *fout, Oid relOid, const TableI
 extern void setOrResetPltsqlFuncRestoreGUCs(Archive *fout, PQExpBuffer q, const FuncInfo *finfo, char prokind, bool proretset, bool is_set);
 extern void dumpBabelfishSpecificConfig(Archive *AH, const char *dbname, PQExpBuffer outbuf);
 extern void updateExtConfigArray(Archive *fout, char ***extconfigarray, int nconfigitems);
-extern char *babelfish_handle_view_def(Archive *fout, char *view_def);
 extern void prepareForBabelfishDatabaseDump(Archive *fout, SimpleStringList *schema_include_patterns);
 extern void setBabelfishDependenciesForLogicalDatabaseDump(Archive *fout);
 extern void dumpBabelGUCs(Archive *fout);
-extern void fixCursorForBbfCatalogTableData(Archive *fout, TableInfo *tbinfo, PQExpBuffer buf, int *nfields, char *attgenerated);
 extern void fixCopyCommand(Archive *fout, PQExpBuffer copyBuf, TableInfo *tbinfo, bool isFrom);
-extern bool hasSqlvariantColumn(TableInfo *tbinfo);
 extern bool bbfIsDumpWithInsert(Archive *fout, TableInfo *tbinfo);
-extern int fixCursorForBbfSqlvariantTableData(Archive *fout,
-                                            TableInfo *tbinfo,
-                                            PQExpBuffer query,
-                                            int nfields,
-                                            int **sqlvar_metdata_pos);
+extern void addFromClauseForBabelfishCatalogTable(PQExpBuffer buf, TableInfo *tbinfo);
+extern void fixCursorForBbfTableData(Archive *fout,
+                                     TableInfo *tbinfo,
+                                     PQExpBuffer buf,
+                                     int *nfields,
+                                     int *nfields_new,
+                                     char *attgenerated,
+                                     int **sqlvar_metdata_pos);
 extern void castSqlvariantToBasetype(PGresult *res,
                                     Archive *fout,
                                     int row,


### PR DESCRIPTION
### Description
Previously, there were two issues with the dump of `babelfish_extended_properties` catalog table:  
1. Current restore logic requires that `babelfish_sysdatabases` table's data gets restored first before any other table containing `dbid` column so that we generate the `dbid` once in the beginning and use it for all the remaining tables. But it was not the case yet.
2. `sql_variant` column handling was not there for catalog table's data but  `babelfish_extended_properties` contains it.

This commit fixes both the above two issues so that we correctly dump the data of `babelfish_extended_properties` catalog.

Task: BABEL-4720
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
