### PR TITLE
Fixed After and Instead of trigger issues on table Pg15

### DIFF
--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -4899,11 +4899,12 @@ ExecISInsertTriggers(EState *estate, ResultRelInfo *relinfo, TransitionCaptureSt
     IOTState prevState;
     trigdesc = relinfo->ri_TrigDesc;
     if (trigdesc == NULL)
-       	return IOT_NOT_REQUIRED;
-    if (!trigdesc->trig_insert_instead_statement) 
+		return IOT_NOT_REQUIRED;
+	
+	if (!trigdesc->trig_insert_instead_statement || !isTsqlInsteadofTriggerExecution(estate, relinfo, TRIGGER_EVENT_INSERT))
 	{
 		set_iot_state(RelationGetRelid(rel), CMD_INSERT, IOT_NOT_REQUIRED);
-    		return IOT_NOT_REQUIRED;
+		return IOT_NOT_REQUIRED;
 	}
 
     // if the trigger is already fired or not required
@@ -4928,7 +4929,8 @@ ExecISUpdateTriggers(EState *estate, ResultRelInfo *relinfo, TransitionCaptureSt
 	if (trigdesc == NULL)
 		return IOT_NOT_REQUIRED;
 
-	if (!trigdesc->trig_update_instead_statement) {
+	if (!trigdesc->trig_update_instead_statement || !isTsqlInsteadofTriggerExecution(estate, relinfo, TRIGGER_EVENT_UPDATE))
+	{
 		set_iot_state(RelationGetRelid(relinfo->ri_RelationDesc), CMD_UPDATE, IOT_NOT_REQUIRED);
 		return IOT_NOT_REQUIRED;
 	}
@@ -4955,7 +4957,9 @@ ExecISDeleteTriggers(EState *estate, ResultRelInfo *relinfo, TransitionCaptureSt
 
 	if (trigdesc == NULL)
 		return IOT_NOT_REQUIRED;
-	if (!trigdesc->trig_delete_instead_statement) {
+
+	if (!trigdesc->trig_delete_instead_statement || !isTsqlInsteadofTriggerExecution(estate, relinfo, TRIGGER_EVENT_DELETE))
+	{
 		set_iot_state(RelationGetRelid(relinfo->ri_RelationDesc), CMD_DELETE, IOT_NOT_REQUIRED);
 		return IOT_NOT_REQUIRED;
 	}
@@ -5463,7 +5467,11 @@ isTsqlInsteadofTriggerExecution(EState *estate, ResultRelInfo *relinfo, TriggerE
 	for (i = 0; i < trigdesc->numtriggers; i++)
 	{
 		Trigger *trigger = &trigdesc->triggers[i];
-		if (TriggerEnabled(estate, relinfo, trigger, event, NULL, NULL, NULL)){
+		if (TriggerEnabled(estate, relinfo, trigger, event, NULL, NULL, NULL) &&
+			(TRIGGER_TYPE_MATCHES(trigger->tgtype, TRIGGER_TYPE_STATEMENT, TRIGGER_TYPE_INSTEAD, TRIGGER_TYPE_INSERT) ||
+			 TRIGGER_TYPE_MATCHES(trigger->tgtype, TRIGGER_TYPE_STATEMENT, TRIGGER_TYPE_INSTEAD, TRIGGER_TYPE_UPDATE) ||
+			 TRIGGER_TYPE_MATCHES(trigger->tgtype, TRIGGER_TYPE_STATEMENT, TRIGGER_TYPE_INSTEAD, TRIGGER_TYPE_DELETE)))
+		{
 			return !TsqlRecuresiveCheck(relinfo);
 		}
 	}


### PR DESCRIPTION
1. If an After trigger exists on table, it is skipped  after instead of trigger is fired on same table in Babelfish.

2. Query execution and After trigger is skipped on table in babelfish when it has a disabled Instead of Trigger

Task: BABEL-4672 and BABEL-4801

### Description

Pg16 Pr: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/320

 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
