### PR TITLE
Check that trigger address hook is only called on T-SQL connection PG15

### DIFF
--- a/src/backend/catalog/objectaddress.c
+++ b/src/backend/catalog/objectaddress.c
@@ -73,6 +73,7 @@
 #include "commands/trigger.h"
 #include "foreign/foreign.h"
 #include "funcapi.h"
+#include "libpq/libpq-be.h"
 #include "miscadmin.h"
 #include "nodes/makefuncs.h"
 #include "parser/parse_func.h"
@@ -991,7 +992,7 @@ get_object_address(ObjectType objtype, Node *object,
 													   &relation, missing_ok);
 				break;
 			case OBJECT_TRIGGER:
-				if(get_trigger_object_address_hook){
+				if(get_trigger_object_address_hook && MyProcPort->is_tds_conn && sql_dialect == SQL_DIALECT_TSQL){
 						address = (*get_trigger_object_address_hook)(castNode(List, object),
 															&relation, missing_ok,false);
 				}


### PR DESCRIPTION
### Description

`get_trigger_object_address_hook` does not expect to be called on a Postgres connection and returns empty address despite having `missing_ok` parameter as `false`.

This was eventually leading to crash of the server. This commit aims to fix that by adding a check that `get_trigger_object_address_hook` is only called on T-SQL connection.
 
### Issues Resolved

PG16 PR: #324
Issue: [#2413](https://github.com/babelfish-for-postgresql/babelfish_extensions/issues/2413)
Taks: BABEL-4844
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Alex Kasko <alex@staticlibs.net>