### PR TITLE
Support Babelfish schema-only and data-only dump/restore (#326)

### DIFF
--- a/src/bin/pg_dump/pg_backup.h
+++ b/src/bin/pg_dump/pg_backup.h
@@ -152,6 +152,7 @@ typedef struct _restoreOptions
 	int			enable_row_security;
 	int			sequence_data;	/* dump sequence data even in schema-only mode */
 	int			binary_upgrade;
+	bool		babelfish_db; /* is this a Babelfish database? */
 } RestoreOptions;
 
 typedef struct _dumpOptions

--- a/src/bin/pg_dump/pg_backup_archiver.c
+++ b/src/bin/pg_dump/pg_backup_archiver.c
@@ -2826,6 +2826,11 @@ _tocEntryRequired(TocEntry *te, teSection curSection, ArchiveHandle *AH)
 		strcmp(te->desc, "SEARCHPATH") == 0)
 		return REQ_SPECIAL;
 
+	/* These items are always dumped */
+	if (strcmp(te->desc, "BABELFISHGUCS") == 0 ||
+		strcmp(te->desc, "BABELFISHCHECKS") == 0)
+		return res;
+
 	/*
 	 * DATABASE and DATABASE PROPERTIES also have a special rule: they are
 	 * restored in createDB mode, and not restored otherwise, independently of
@@ -3058,8 +3063,14 @@ _tocEntryRequired(TocEntry *te, teSection curSection, ArchiveHandle *AH)
 	if ((strcmp(te->desc, "<Init>") == 0) && (strcmp(te->tag, "Max OID") == 0))
 		return 0;
 
-	/* Mask it if we only want schema */
-	if (ropt->schemaOnly)
+	/*
+	 * Mask it if we only want schema.
+	 * Babelfish db dump overrides schemaOnly option unless it is binary-upgrade
+	 * mode. This is needed to make sure that we dump Babelfish configuration
+	 * tables' data even in schema only mode as user data in a configuration table
+	 * is treated like schema metadata.
+	 */
+	if (ropt->schemaOnly && (!ropt->babelfish_db || ropt->binary_upgrade))
 	{
 		/*
 		 * The sequence_data option overrides schemaOnly for SEQUENCE SET.

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -273,7 +273,6 @@ static void addBoundaryDependencies(DumpableObject **dobjs, int numObjs,
 static void addConstrChildIdxDeps(DumpableObject *dobj, const IndxInfo *refidx);
 static void getDomainConstraints(Archive *fout, TypeInfo *tyinfo);
 static void getTableData(DumpOptions *dopt, TableInfo *tblinfo, int numTables, char relkind);
-static void makeTableDataInfo(DumpOptions *dopt, TableInfo *tbinfo);
 static void buildMatViewRefreshDependencies(Archive *fout);
 static void getTableDataFKConstraints(void);
 static char *format_function_arguments(const FuncInfo *finfo, const char *funcargs,
@@ -961,6 +960,7 @@ main(int argc, char **argv)
 	ropt->enable_row_security = dopt.enable_row_security;
 	ropt->sequence_data = dopt.sequence_data;
 	ropt->binary_upgrade = dopt.binary_upgrade;
+	ropt->babelfish_db = isBabelfishDatabase(fout);
 
 	if (compressLevel == -1)
 		ropt->compression = 0;
@@ -1067,6 +1067,8 @@ help(const char *progname)
 	printf(_("  --use-set-session-authorization\n"
 			 "                               use SET SESSION AUTHORIZATION commands instead of\n"
 			 "                               ALTER OWNER commands to set ownership\n"));
+	printf(_("  --bbf-database-name=BBF_DBNAME\n"
+			 "                               The name of the Babelfish T-SQL database to dump\n"));
 
 	printf(_("\nConnection options:\n"));
 	printf(_("  -d, --dbname=DBNAME      database to dump\n"));
@@ -2687,7 +2689,7 @@ getTableData(DumpOptions *dopt, TableInfo *tblinfo, int numTables, char relkind)
  * Note: we make a TableDataInfo if and only if we are going to dump the
  * table data; the "dump" field in such objects isn't very interesting.
  */
-static void
+void
 makeTableDataInfo(DumpOptions *dopt, TableInfo *tbinfo)
 {
 	TableDataInfo *tdinfo;

--- a/src/bin/pg_dump/pg_dump.h
+++ b/src/bin/pg_dump/pg_dump.h
@@ -749,5 +749,6 @@ extern void getPublicationNamespaces(Archive *fout);
 extern void getPublicationTables(Archive *fout, TableInfo tblinfo[],
 								 int numTables);
 extern void getSubscriptions(Archive *fout);
+extern void makeTableDataInfo(DumpOptions *dopt, TableInfo *tbinfo);
 
 #endif							/* PG_DUMP_H */

--- a/src/bin/pg_dump/pg_dumpall.c
+++ b/src/bin/pg_dump/pg_dumpall.c
@@ -655,6 +655,9 @@ help(void)
 	printf(_("  --use-set-session-authorization\n"
 			 "                               use SET SESSION AUTHORIZATION commands instead of\n"
 			 "                               ALTER OWNER commands to set ownership\n"));
+	printf(_("  --bbf-database-name=BBF_DBNAME\n"
+			 "                               The name of the Babelfish T-SQL database to selectively\n"
+			 "                               dump T-SQL logins associated with that specific T-SQL database\n"));
 
 	printf(_("\nConnection options:\n"));
 	printf(_("  -d, --dbname=CONNSTR     connect using connection string\n"));


### PR DESCRIPTION
### Description
This commit contains following changes:
* Fixes the issues with Babelfish schema-only and data-only dump/restore.
* Adds help for --bbf-database-name option.

Tasks: BABEL-4764, BABEL-4765
Signed-off-by: Rishabh Tanwar ritanwar@amazon.com
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
