### PR TITLE
Add temp OID support for type, index, and constraint creation

### DIFF
--- a/src/backend/catalog/catalog.c
+++ b/src/backend/catalog/catalog.c
@@ -540,7 +540,7 @@ GetNewOidWithIndex(Relation relation, Oid indexId, AttrNumber oidcolumn)
  * created by bootstrap have preassigned OIDs, so there's no need.
  */
 RelFileNumber
-GetNewRelFileNumber(Oid reltablespace, Relation pg_class, char relpersistence, bool override_temp)
+GetNewRelFileNumber(Oid reltablespace, Relation pg_class, char relpersistence)
 {
 	RelFileLocatorBackend rlocator;
 	char	   *rpath;
@@ -584,7 +584,7 @@ GetNewRelFileNumber(Oid reltablespace, Relation pg_class, char relpersistence, b
 	rlocator.backend = backend;
 
 	use_bbf_oid_buffer = (relpersistence == RELPERSISTENCE_TEMP && sql_dialect == SQL_DIALECT_TSQL 
-						&& GetNewTempOidWithIndex_hook && temp_oid_buffer_size > 0 && !override_temp);
+						&& GetNewTempOidWithIndex_hook && temp_oid_buffer_size > 0);
 
 	do
 	{

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1429,6 +1429,11 @@ heap_create_with_catalog(const char *relname,
 			
 			Assert(!OidIsValid(reltypeid));
 
+			/* 
+			 * We also assign reltypeid here. It would usually be assigned during AddNewRelationType
+			 * if the value provided is InvalidOid. Since we are providing a value, it won't
+			 * try to call GetNewOidWithIndex.
+			 */
 			reltypeid = GetNewTempOidWithIndex_hook(pg_type, TypeOidIndexId, Anum_pg_type_oid);
 			table_close(pg_type, AccessShareLock);
 		}

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -80,7 +80,6 @@
 InvokePreAddConstraintsHook_type InvokePreAddConstraintsHook = NULL;
 transform_check_constraint_expr_hook_type transform_check_constraint_expr_hook = NULL;
 drop_relation_refcnt_hook_type drop_relation_refcnt_hook = NULL;
-AssignTempTypeOid_hook_type AssignTempTypeOid_hook = NULL;
 
 /* Potentially set by pg_upgrade_support functions */
 Oid			binary_upgrade_next_heap_pg_class_oid = InvalidOid;
@@ -1446,12 +1445,12 @@ heap_create_with_catalog(const char *relname,
 		 * committed yet when we checked for a duplicate name above.
 		 */
 		new_type_addr = AddNewRelationType(relname,
-										relnamespace,
-										relid,
-										relkind,
-										ownerid,
-										reltypeid,
-										new_array_oid);
+										   relnamespace,
+										   relid,
+										   relkind,
+										   ownerid,
+										   reltypeid,
+										   new_array_oid);
 
 		new_type_oid = new_type_addr.objectId;
 		if (typaddress)

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -72,6 +72,7 @@
 #include "storage/predicate.h"
 #include "utils/builtins.h"
 #include "utils/fmgroids.h"
+#include "utils/guc.h"
 #include "utils/inval.h"
 #include "utils/lsyscache.h"
 #include "utils/syscache.h"
@@ -79,6 +80,8 @@
 InvokePreAddConstraintsHook_type InvokePreAddConstraintsHook = NULL;
 transform_check_constraint_expr_hook_type transform_check_constraint_expr_hook = NULL;
 drop_relation_refcnt_hook_type drop_relation_refcnt_hook = NULL;
+AssignTempTypeArrayOid_hook_type AssignTempTypeArrayOid_hook = NULL;
+AddNewTempRelationType_hook_type AddNewTempRelationType_hook = NULL;
 
 /* Potentially set by pg_upgrade_support functions */
 Oid			binary_upgrade_next_heap_pg_class_oid = InvalidOid;
@@ -1183,6 +1186,7 @@ heap_create_with_catalog(const char *relname,
 	TransactionId relfrozenxid;
 	MultiXactId relminmxid;
 	bool		is_enr = false;
+	bool		use_bbf_oid_buffer = false;
 
 	if (relpersistence == RELPERSISTENCE_TEMP && sql_dialect == SQL_DIALECT_TSQL)
 	{
@@ -1196,6 +1200,9 @@ heap_create_with_catalog(const char *relname,
 		 */
 		if (relname && strlen(relname) > 0)
 			is_enr = (relname[0] == '@') || (relname[0] == '#' && !CheckTempTableHasDependencies(tupdesc));
+
+		if (is_enr)
+			use_bbf_oid_buffer = (AssignTempTypeArrayOid_hook && AddNewTempRelationType_hook && temp_oid_buffer_size > 0);
 	}
 
 	pg_class_desc = table_open(RelationRelationId, RowExclusiveLock);
@@ -1410,7 +1417,10 @@ heap_create_with_catalog(const char *relname,
 		 * We'll make an array over the composite type, too.  For largely
 		 * historical reasons, the array type's OID is assigned first.
 		 */
-		new_array_oid = AssignTypeArrayOid();
+		if (is_enr && use_bbf_oid_buffer && AssignTempTypeArrayOid_hook)
+			new_array_oid = AssignTempTypeArrayOid_hook();
+		else
+			new_array_oid = AssignTypeArrayOid();
 
 		/*
 		 * Make the pg_type entry for the composite type.  The OID of the
@@ -1421,13 +1431,23 @@ heap_create_with_catalog(const char *relname,
 		 * else is creating the same type name in parallel but hadn't
 		 * committed yet when we checked for a duplicate name above.
 		 */
-		new_type_addr = AddNewRelationType(relname,
+		if (is_enr && use_bbf_oid_buffer && AddNewTempRelationType_hook)
+			new_type_addr = AddNewTempRelationType_hook(relname,
 										   relnamespace,
 										   relid,
 										   relkind,
 										   ownerid,
 										   reltypeid,
 										   new_array_oid);
+		else
+			new_type_addr = AddNewRelationType(relname,
+										   relnamespace,
+										   relid,
+										   relkind,
+										   ownerid,
+										   reltypeid,
+										   new_array_oid);
+
 		new_type_oid = new_type_addr.objectId;
 		if (typaddress)
 			*typaddress = new_type_addr;

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1199,7 +1199,7 @@ heap_create_with_catalog(const char *relname,
 		if (relname && strlen(relname) > 0)
 			is_enr = (relname[0] == '@') || (relname[0] == '#' && !CheckTempTableHasDependencies(tupdesc));
 
-		if (is_enr && GetNewTempOidWithIndex_hook)
+		if (is_enr && GetNewTempOidWithIndex_hook && temp_oid_buffer_size > 0)
 			use_temp_oid_buffer = true;
 	}
 

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1184,7 +1184,6 @@ heap_create_with_catalog(const char *relname,
 	TransactionId relfrozenxid;
 	MultiXactId relminmxid;
 	bool		is_enr = false;
-	bool 		use_temp_oid_buffer = false;
 
 	if (relpersistence == RELPERSISTENCE_TEMP && sql_dialect == SQL_DIALECT_TSQL)
 	{
@@ -1198,9 +1197,6 @@ heap_create_with_catalog(const char *relname,
 		 */
 		if (relname && strlen(relname) > 0)
 			is_enr = (relname[0] == '@') || (relname[0] == '#' && !CheckTempTableHasDependencies(tupdesc));
-
-		if (is_enr && GetNewTempOidWithIndex_hook && temp_oid_buffer_size > 0)
-			use_temp_oid_buffer = true;
 	}
 
 	pg_class_desc = table_open(RelationRelationId, RowExclusiveLock);
@@ -1417,7 +1413,7 @@ heap_create_with_catalog(const char *relname,
 		 * 
 		 * For temp tables, we use temp OID assignment code here as well.
 		 */
-		if (use_temp_oid_buffer)
+		if (is_enr && useTempOidBuffer())
 		{
 			Relation	pg_type;
 
@@ -1456,7 +1452,6 @@ heap_create_with_catalog(const char *relname,
 										   ownerid,
 										   reltypeid,
 										   new_array_oid);
-
 		new_type_oid = new_type_addr.objectId;
 		if (typaddress)
 			*typaddress = new_type_addr;

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -962,12 +962,7 @@ index_create(Relation heapRelation,
 		}
 		else
 		{
-			/* 
-			 * Index OIDs must be kept in normal OID range due to deletion issues.
-			 * Since deletion is sorted by OID, adding indexes to temp OID range 
-			 * causes deletion order issues.
-			 */
-			indexRelationId = GetNewRelFileNumber(tableSpaceId, pg_class, relpersistence, is_enr);
+			indexRelationId = GetNewRelFileNumber(tableSpaceId, pg_class, relpersistence);
 		}
 	}
 

--- a/src/backend/catalog/pg_constraint.c
+++ b/src/backend/catalog/pg_constraint.c
@@ -178,10 +178,10 @@ CreateConstraintEntry(const char *constraintName,
 
 	if (sql_dialect == SQL_DIALECT_TSQL && isTempNamespace(constraintNamespace))
 	{
-		is_enr = get_ENR_withoid(currentQueryEnv, relId, ENR_TSQL_TEMP) && GetNewTempOidWithIndex_hook;
+		is_enr = get_ENR_withoid(currentQueryEnv, relId, ENR_TSQL_TEMP);
 	}
 
-	if (is_enr)
+	if (is_enr && GetNewTempOidWithIndex_hook)
 		conOid = GetNewTempOidWithIndex_hook(conDesc, ConstraintOidIndexId,
 									Anum_pg_constraint_oid);
 	else

--- a/src/backend/catalog/pg_constraint.c
+++ b/src/backend/catalog/pg_constraint.c
@@ -100,7 +100,6 @@ CreateConstraintEntry(const char *constraintName,
 	ObjectAddress conobject;
 	ObjectAddresses *addrs_auto;
 	ObjectAddresses *addrs_normal;
-	bool		is_enr = false;
 
 	conDesc = table_open(ConstraintRelationId, RowExclusiveLock);
 
@@ -177,12 +176,7 @@ CreateConstraintEntry(const char *constraintName,
 		values[i] = (Datum) NULL;
 	}
 
-	if (sql_dialect == SQL_DIALECT_TSQL && isTempNamespace(constraintNamespace))
-	{
-		is_enr = get_ENR_withoid(currentQueryEnv, relId, ENR_TSQL_TEMP);
-	}
-
-	if (is_enr && GetNewTempOidWithIndex_hook && temp_oid_buffer_size > 0)
+	if (useTempOidBufferForOid(relId) && isTempNamespace(constraintNamespace))
 		conOid = GetNewTempOidWithIndex_hook(conDesc, ConstraintOidIndexId,
 									Anum_pg_constraint_oid);
 	else

--- a/src/backend/catalog/pg_constraint.c
+++ b/src/backend/catalog/pg_constraint.c
@@ -22,16 +22,19 @@
 #include "catalog/catalog.h"
 #include "catalog/dependency.h"
 #include "catalog/indexing.h"
+#include "catalog/namespace.h"
 #include "catalog/objectaccess.h"
 #include "catalog/pg_constraint.h"
 #include "catalog/pg_operator.h"
 #include "catalog/pg_type.h"
 #include "commands/defrem.h"
 #include "commands/tablecmds.h"
+#include "parser/parser.h"
 #include "utils/array.h"
 #include "utils/builtins.h"
 #include "utils/fmgroids.h"
 #include "utils/lsyscache.h"
+#include "utils/queryenvironment.h"
 #include "utils/rel.h"
 #include "utils/syscache.h"
 
@@ -96,6 +99,7 @@ CreateConstraintEntry(const char *constraintName,
 	ObjectAddress conobject;
 	ObjectAddresses *addrs_auto;
 	ObjectAddresses *addrs_normal;
+	bool		is_enr = false;
 
 	conDesc = table_open(ConstraintRelationId, RowExclusiveLock);
 
@@ -172,8 +176,17 @@ CreateConstraintEntry(const char *constraintName,
 		values[i] = (Datum) NULL;
 	}
 
-	conOid = GetNewOidWithIndex(conDesc, ConstraintOidIndexId,
-								Anum_pg_constraint_oid);
+	if (sql_dialect == SQL_DIALECT_TSQL && isTempNamespace(constraintNamespace))
+	{
+		is_enr = get_ENR_withoid(currentQueryEnv, relId, ENR_TSQL_TEMP) && GetNewTempOidWithIndex_hook;
+	}
+
+	if (is_enr)
+		conOid = GetNewTempOidWithIndex_hook(conDesc, ConstraintOidIndexId,
+									Anum_pg_constraint_oid);
+	else
+		conOid = GetNewOidWithIndex(conDesc, ConstraintOidIndexId,
+									Anum_pg_constraint_oid);
 	values[Anum_pg_constraint_oid - 1] = ObjectIdGetDatum(conOid);
 	values[Anum_pg_constraint_conname - 1] = NameGetDatum(&cname);
 	values[Anum_pg_constraint_connamespace - 1] = ObjectIdGetDatum(constraintNamespace);

--- a/src/backend/catalog/pg_constraint.c
+++ b/src/backend/catalog/pg_constraint.c
@@ -33,6 +33,7 @@
 #include "utils/array.h"
 #include "utils/builtins.h"
 #include "utils/fmgroids.h"
+#include "utils/guc.h"
 #include "utils/lsyscache.h"
 #include "utils/queryenvironment.h"
 #include "utils/rel.h"
@@ -181,7 +182,7 @@ CreateConstraintEntry(const char *constraintName,
 		is_enr = get_ENR_withoid(currentQueryEnv, relId, ENR_TSQL_TEMP);
 	}
 
-	if (is_enr && GetNewTempOidWithIndex_hook)
+	if (is_enr && GetNewTempOidWithIndex_hook && temp_oid_buffer_size > 0)
 		conOid = GetNewTempOidWithIndex_hook(conDesc, ConstraintOidIndexId,
 									Anum_pg_constraint_oid);
 	else

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -14707,7 +14707,7 @@ ATExecSetTableSpace(Oid tableOid, Oid newTableSpace, LOCKMODE lockmode)
 	 * need to allocate a new one in the new tablespace.
 	 */
 	newrelfilenumber = GetNewRelFileNumber(newTableSpace, NULL,
-										   rel->rd_rel->relpersistence, false);
+										   rel->rd_rel->relpersistence);
 
 	/* Open old and new relation */
 	newrlocator = rel->rd_locator;

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -3722,7 +3722,7 @@ RelationSetNewRelfilenumber(Relation relation, char persistence)
 	{
 		/* Allocate a new relfilenumber */
 		newrelfilenumber = GetNewRelFileNumber(relation->rd_rel->reltablespace,
-											   NULL, persistence, false);
+											   NULL, persistence);
 	}
 	else if (relation->rd_rel->relkind == RELKIND_INDEX)
 	{

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -1442,6 +1442,25 @@ void ENRRollbackSubtransaction(SubTransactionId subid, QueryEnvironment *queryEn
 	MemoryContextSwitchTo(oldcxt);
 }
 
+/* 
+ * Simple check for whether to use temp OID buffer.
+ */
+bool useTempOidBuffer()
+{
+	return sql_dialect == SQL_DIALECT_TSQL 
+		&& GetNewTempOidWithIndex_hook 
+		&& temp_oid_buffer_size > 0;
+}
+
+/* Simple check for whether to use temp OID buffer given an existing OID. */
+bool useTempOidBufferForOid(Oid relId)
+{
+	return sql_dialect == SQL_DIALECT_TSQL 
+		&& GetNewTempOidWithIndex_hook 
+		&& temp_oid_buffer_size > 0
+		&& get_ENR_withoid(currentQueryEnv, relId, ENR_TSQL_TEMP);
+}
+
 /*
  * Drop all the temp tables registered as ENR in the given query environment.
  */

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -42,8 +42,7 @@ extern Oid	GetNewOidWithIndex(Relation relation, Oid indexId,
 							   AttrNumber oidcolumn);
 extern RelFileNumber GetNewRelFileNumber(Oid reltablespace,
 										 Relation pg_class,
-										 char relpersistence,
-										 bool override_temp);
+										 char relpersistence);
 
 typedef Oid (*GetNewTempObjectId_hook_type) (void);
 extern GetNewTempObjectId_hook_type GetNewTempObjectId_hook;

--- a/src/include/catalog/heap.h
+++ b/src/include/catalog/heap.h
@@ -166,4 +166,16 @@ extern PGDLLEXPORT transform_check_constraint_expr_hook_type transform_check_con
 typedef void (*drop_relation_refcnt_hook_type) (Relation rel);
 extern PGDLLEXPORT drop_relation_refcnt_hook_type drop_relation_refcnt_hook;
 
+typedef Oid (*AssignTempTypeArrayOid_hook_type) (void);
+extern PGDLLEXPORT AssignTempTypeArrayOid_hook_type AssignTempTypeArrayOid_hook;
+
+typedef ObjectAddress (*AddNewTempRelationType_hook_type) (const char *typeName,
+				   Oid typeNamespace,
+				   Oid new_rel_oid,
+				   char new_rel_kind,
+				   Oid ownerid,
+				   Oid new_row_type,
+				   Oid new_array_type);
+extern PGDLLEXPORT AddNewTempRelationType_hook_type AddNewTempRelationType_hook;
+
 #endif							/* HEAP_H */

--- a/src/include/catalog/heap.h
+++ b/src/include/catalog/heap.h
@@ -166,16 +166,7 @@ extern PGDLLEXPORT transform_check_constraint_expr_hook_type transform_check_con
 typedef void (*drop_relation_refcnt_hook_type) (Relation rel);
 extern PGDLLEXPORT drop_relation_refcnt_hook_type drop_relation_refcnt_hook;
 
-typedef Oid (*AssignTempTypeArrayOid_hook_type) (void);
-extern PGDLLEXPORT AssignTempTypeArrayOid_hook_type AssignTempTypeArrayOid_hook;
-
-typedef ObjectAddress (*AddNewTempRelationType_hook_type) (const char *typeName,
-				   Oid typeNamespace,
-				   Oid new_rel_oid,
-				   char new_rel_kind,
-				   Oid ownerid,
-				   Oid new_row_type,
-				   Oid new_array_type);
-extern PGDLLEXPORT AddNewTempRelationType_hook_type AddNewTempRelationType_hook;
+typedef Oid (*AssignTempTypeOid_hook_type) (void);
+extern PGDLLEXPORT AssignTempTypeOid_hook_type AssignTempTypeOid_hook;
 
 #endif							/* HEAP_H */

--- a/src/include/catalog/heap.h
+++ b/src/include/catalog/heap.h
@@ -166,7 +166,4 @@ extern PGDLLEXPORT transform_check_constraint_expr_hook_type transform_check_con
 typedef void (*drop_relation_refcnt_hook_type) (Relation rel);
 extern PGDLLEXPORT drop_relation_refcnt_hook_type drop_relation_refcnt_hook;
 
-typedef Oid (*AssignTempTypeOid_hook_type) (void);
-extern PGDLLEXPORT AssignTempTypeOid_hook_type AssignTempTypeOid_hook;
-
 #endif							/* HEAP_H */

--- a/src/include/utils/queryenvironment.h
+++ b/src/include/utils/queryenvironment.h
@@ -150,6 +150,9 @@ extern void ENRCommitChanges(QueryEnvironment *queryEnv);
 extern void ENRRollbackChanges(QueryEnvironment *queryEnv);
 extern void ENRRollbackSubtransaction(SubTransactionId subid, QueryEnvironment *queryEnv);
 
+extern bool useTempOidBuffer(void);
+extern bool useTempOidBufferForOid(Oid relId);
+
 typedef EphemeralNamedRelation (*pltsql_get_tsql_enr_from_oid_hook_type) (Oid oid);
 extern PGDLLIMPORT pltsql_get_tsql_enr_from_oid_hook_type pltsql_get_tsql_enr_from_oid_hook;
 


### PR DESCRIPTION
### Description

Normal OIDs were still being consumed in some cases during temp table creation even with temp oid buffer on. To fix this, ensure that the appropriate temp table dependent objects also use temp OID.

1. Redirect type creation functions to use temp OID when it's a TSQL temp table.
2. Redirect constraint creation to use temp OID in those cases as well. 
3. Remove workaround for indexes on temp tables. Previously, we needed to force indexes on temp tables to consume normal OIDs. With changes described in lines 1+2 above, we can now remove the workaround added in #232 and properly allow indexes to use temp oid buffer. 

Extension PR: babelfish-for-postgresql/babelfish_extensions#2443
 
### Issues Resolved

BABEL-4750
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
