### PR TITLE
Do not reset SysCacheRelationOidSize and SysCacheSupportingRelOidSize

### DIFF
--- a/src/backend/utils/cache/syscache.c
+++ b/src/backend/utils/cache/syscache.c
@@ -766,7 +766,7 @@ InitExtensionCatalogCache(struct cachedesc *ext_cacheinfo, int startid, int ext_
 	int			cacheId;
 	int			i;
 
-	SysCacheRelationOidSize = SysCacheSupportingRelOidSize = 0;
+	Assert(CacheInitialized);
 
 	for (i = 0; i < ext_cachelength; i++)
 	{


### PR DESCRIPTION
Do not reset SysCacheRelationOidSize and SysCacheSupportingRelOidSize in InitExtensionCatalogCache. Otherwise any invalidation on catalog tables that happened on the babelfish database will not be reported causing inconsistency issues.

Task: BABEL-4119
Signed-off-by: Kristian Lejao <klejao@amazon.com>
(cherry picked from commit 062dadc3e998500154f0c8b155b960509af2567a)
