### PR TITLE
Added missing checks for parent queryEnv in certain ENR functions

### DIFF
--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1216,7 +1216,7 @@ heap_create_with_catalog(const char *relname,
 	 * But allow same-name ENR as long as the it's not in the current query env.
 	 */
 	existing_relid = get_relname_relid(relname, relnamespace);
-	if (existing_relid != InvalidOid && (!is_enr || get_ENR(currentQueryEnv, relname)))
+	if (existing_relid != InvalidOid && (!is_enr || get_ENR(currentQueryEnv, relname, false)))
 		ereport(ERROR,
 				(errcode(ERRCODE_DUPLICATE_TABLE),
 				 errmsg("relation \"%s\" already exists", relname)));
@@ -1230,7 +1230,7 @@ heap_create_with_catalog(const char *relname,
 	old_type_oid = GetSysCacheOid2(TYPENAMENSP, Anum_pg_type_oid,
 								   CStringGetDatum(relname),
 								   ObjectIdGetDatum(relnamespace));
-	if (OidIsValid(old_type_oid) && (!is_enr || get_ENR(currentQueryEnv, relname)))
+	if (OidIsValid(old_type_oid) && (!is_enr || get_ENR(currentQueryEnv, relname, false)))
 	{
 		if (!moveArrayTypeName(old_type_oid, relname, relnamespace))
 			ereport(ERROR,

--- a/src/backend/catalog/pg_type.c
+++ b/src/backend/catalog/pg_type.c
@@ -426,7 +426,7 @@ TypeCreate(Oid newTypeOid,
 	 * If the tuple is for an ENR that's not in the current query environment,
 	 * we are still allowed to create new type.
 	 */
-	if (HeapTupleIsValid(tup) && get_ENR(currentQueryEnv, typeName) == NULL)
+	if (HeapTupleIsValid(tup) && get_ENR(currentQueryEnv, typeName, false) == NULL)
 	{
 		Form_pg_type typform = (Form_pg_type) GETSTRUCT(tup);
 

--- a/src/backend/executor/nodeNamedtuplestorescan.c
+++ b/src/backend/executor/nodeNamedtuplestorescan.c
@@ -102,7 +102,7 @@ ExecInitNamedTuplestoreScan(NamedTuplestoreScan *node, EState *estate, int eflag
 	scanstate->ss.ps.state = estate;
 	scanstate->ss.ps.ExecProcNode = ExecNamedTuplestoreScan;
 
-	enr = get_ENR(estate->es_queryEnv, node->enrname);
+	enr = get_ENR(estate->es_queryEnv, node->enrname, false);
 	if (!enr)
 		elog(ERROR, "executor could not find named tuplestore \"%s\"",
 			 node->enrname);

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -3303,7 +3303,7 @@ _SPI_find_ENR_by_name(const char *name)
 	if (_SPI_current->queryEnv == NULL)
 		return NULL;
 
-	return get_ENR(_SPI_current->queryEnv, name);
+	return get_ENR(_SPI_current->queryEnv, name, false);
 }
 
 /*

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -1146,7 +1146,7 @@ retry:
 			break;
 		case RELPERSISTENCE_TEMP:
 			if (isTempOrTempToastNamespace(relation->rd_rel->relnamespace)
-				|| get_ENR(currentQueryEnv, relp->relname.data))
+				|| get_ENR(currentQueryEnv, relp->relname.data, false))
 			{
 				relation->rd_backend = BackendIdForTempRelations();
 				relation->rd_islocaltemp = true;

--- a/src/include/utils/queryenvironment.h
+++ b/src/include/utils/queryenvironment.h
@@ -96,7 +96,7 @@ extern EphemeralNamedRelationMetadata get_visible_ENR_metadata(QueryEnvironment 
 extern void register_ENR(QueryEnvironment *queryEnv, EphemeralNamedRelation enr);
 extern void unregister_ENR(QueryEnvironment *queryEnv, const char *name);
 extern List *get_namedRelList(void);
-extern EphemeralNamedRelation get_ENR(QueryEnvironment *queryEnv, const char *name);
+extern EphemeralNamedRelation get_ENR(QueryEnvironment *queryEnv, const char *name, bool search);
 extern EphemeralNamedRelation get_ENR_withoid(QueryEnvironment *queryEnv, Oid oid, EphemeralNameRelationType type);
 extern TupleDesc ENRMetadataGetTupDesc(EphemeralNamedRelationMetadata enrmd);
 extern bool ENRaddTuple(Relation rel, HeapTuple tup);


### PR DESCRIPTION
### Description

During the verification for the fix for BABEL-4498 (aka babelfish-for-postgresql/babelfish_extensions#2159), we found that an unexpected error would be thrown due to incorrectly value being saved to cache. This is due to conflicting visibility in certain cases with temp tables - some functions in queryenvironment.c are correctly searching through parentEnv during ENR lookup, and it was missing in others. This change corrects the functions which were not searching through parentEnv.
 

Test cases added in babelfish-for-postgresql/babelfish_extensions#2459

This is a cherry-pick of #321
### Issues Resolved

Missing temp table visibility in certain checks. 
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
