### PR TITLE
Optimize the select_best_admin search for babelfish

### DIFF
--- a/src/backend/utils/adt/acl.c
+++ b/src/backend/utils/adt/acl.c
@@ -5124,7 +5124,8 @@ select_best_admin(Oid member, Oid role)
 	if (member == role)
 		return InvalidOid;
 
-	if (get_bbf_admin_oid_hook  && member == (*get_bbf_admin_oid_hook)())
+	if (sql_dialect == SQL_DIALECT_TSQL &&
+		get_bbf_admin_oid_hook  && member == (*get_bbf_admin_oid_hook)())
 	{
 		return member;
 	}

--- a/src/backend/utils/adt/acl.c
+++ b/src/backend/utils/adt/acl.c
@@ -5126,7 +5126,8 @@ select_best_admin(Oid member, Oid role)
 		return InvalidOid;
 
 	if (sql_dialect == SQL_DIALECT_TSQL &&
-		get_bbf_admin_oid_hook  && member == (*get_bbf_admin_oid_hook)())
+		get_bbf_admin_oid_hook  && member == (*get_bbf_admin_oid_hook)() &&
+		GetUserId() == (*get_bbf_admin_oid_hook)())
 	{
 		return member;
 	}

--- a/src/backend/utils/adt/acl.c
+++ b/src/backend/utils/adt/acl.c
@@ -39,6 +39,7 @@
 #include "funcapi.h"
 #include "lib/qunique.h"
 #include "miscadmin.h"
+#include "parser/parser.h"
 #include "utils/acl.h"
 #include "utils/array.h"
 #include "utils/builtins.h"

--- a/src/backend/utils/adt/acl.c
+++ b/src/backend/utils/adt/acl.c
@@ -124,6 +124,7 @@ static AclResult pg_role_aclcheck(Oid role_oid, Oid roleid, AclMode mode);
 static void RoleMembershipCacheCallback(Datum arg, int cacheid, uint32 hashvalue);
 
 bbf_get_sysadmin_oid_hook_type bbf_get_sysadmin_oid_hook = NULL;
+get_bbf_admin_oid_hook_type get_bbf_admin_oid_hook = NULL;
 
 
 /*
@@ -5122,6 +5123,11 @@ select_best_admin(Oid member, Oid role)
 	/* By policy, a role cannot have WITH ADMIN OPTION on itself. */
 	if (member == role)
 		return InvalidOid;
+
+	if (get_bbf_admin_oid_hook  && member == (*get_bbf_admin_oid_hook)())
+	{
+		return member;
+	}
 
 	(void) roles_is_member_of(member, ROLERECURSE_PRIVS, role, &admin_role);
 	return admin_role;

--- a/src/include/utils/acl.h
+++ b/src/include/utils/acl.h
@@ -281,4 +281,7 @@ extern PGDLLEXPORT tsql_has_linked_srv_permissions_hook_type tsql_has_linked_srv
 typedef Oid (*bbf_get_sysadmin_oid_hook_type) (void);
 extern PGDLLEXPORT bbf_get_sysadmin_oid_hook_type bbf_get_sysadmin_oid_hook;
 
+typedef Oid (*get_bbf_admin_oid_hook_type) (void);
+extern PGDLLEXPORT get_bbf_admin_oid_hook_type get_bbf_admin_oid_hook;
+
 #endif							/* ACL_H */


### PR DESCRIPTION
### Description
In Major version 16 Babelfish introduced a new role bbf_admin_role which is a member of all the roles which created implicitly from TSQL. This increases the Load on any Grant/Revoke operations that happen since in Vanilla PG 16 the path to select the best admin is inefficient and loops over members of members to find the best admin and it is uniquely exacerbated by babelfish due to this role.
This commit optimizes the selection of best admin for babelfish by escaping the search for any TSQL roles conditionally.
Without the  changes on github the time taken to create database increases drastically and linearly:
```
2nd 'create db' stmt 4 ms

2000th 'create db' stmt 1024 ms

The average time consumed by eached create db stmt: 1651.895 ms
```
On Github with these changes we see the time taken to create database increasing linearly but not as drastically as it was before the changes:
```
2nd 'create db' stmt 5 ms

2000th 'create db' stmt 5089 ms

The average time consumed by eached create db stmt: 361.684 ms
```
So the speedup to create 2000 dbs achieved with this change is: (1651.895 - 361.684) * 2000
Which is significant.


### Issues Resolved

BABEL-4849

Authored-by: Kushaal Shroff [kushaal@amazon.com](mailto:kushaal@amazon.com)
Signed-off-by: Kushaal Shroff [kushaal@amazon.com](mailto:kushaal@amazon.com)

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).