### PR TITLE
Do not dump babelfish_domain_mapping catalog table for database-level dump

### DIFF
--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -163,15 +163,16 @@ isBabelfishConfigTable(Archive *fout, TableInfo *tbinfo)
 	if (!isBabelfishDatabase(fout))
 		return false;
 	/* 
-	 * We don't want to dump babelfish_authid_login_ext and 
-	 * babelfish_server_options in case of logical database dump.
+	 * We don't want to dump babelfish_authid_login_ext, babelfish_domain_mapping
+	 * and babelfish_server_options in case of logical database dump.
 	 */
 	if (tbinfo == NULL || tbinfo->relkind != RELKIND_RELATION ||
 		(tbinfo->dobj.namespace &&
 		strcmp(tbinfo->dobj.namespace->dobj.name, "sys") == 0 &&
 		(bbf_db_name != NULL && 
 			(strcmp(tbinfo->dobj.name, "babelfish_authid_login_ext") == 0 ||
-				strcmp(tbinfo->dobj.name, "babelfish_server_options") == 0))))
+				strcmp(tbinfo->dobj.name, "babelfish_server_options") == 0 ||
+				strcmp(tbinfo->dobj.name, "babelfish_domain_mapping") == 0))))
 			return false;
 
 	if (catalog_table_include_oids.head != NULL &&
@@ -1090,9 +1091,6 @@ addFromClauseForLogicalDatabaseDump(PQExpBuffer buf, TableInfo *tbinfo)
 						  "'tempdb_dbo', 'tempdb_db_owner', 'tempdb_guest') ",
 						  fmtQualifiedDumpable(tbinfo), bbf_db_id);
 	}
-	else if(strcmp(tbinfo->dobj.name, "babelfish_domain_mapping") == 0)
-		appendPQExpBuffer(buf, " FROM ONLY %s a",
-						  fmtQualifiedDumpable(tbinfo));
 	else
 	{
 		pg_log_error("Unrecognized Babelfish catalog table %s.", fmtQualifiedDumpable(tbinfo));


### PR DESCRIPTION
### Description
The babelfish_domain_mapping catalog table does not contain data specific to a single T-SQL database and the data is rather global to whole Babelfish server so it does not makes sense to dump it's content for a database-level dump.
Previously, a T-SQL database restore used to fail if the target server already contains the domain mappings which are also present in the database getting restored.

Task: BABEL-4053
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>

### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
