### PR TITLE
Fix behavioural differences due to return type and handle constant string literal inputs differently for T-SQL COALESCE function

### DIFF
--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -88,6 +88,7 @@ static Node *make_nulltest_from_distinct(ParseState *pstate,
 static List *ExpandChecksumStar(ParseState *pstate, FuncCall *fn, int location);
 
 lookup_param_hook_type lookup_param_hook = NULL;
+handle_constant_literals_hook_type handle_constant_literals_hook = NULL;
 /*
  * transformExpr -
  *	  Analyze and transform expressions. Type checking and type casting is
@@ -2263,7 +2264,9 @@ transformCoalesceExpr(ParseState *pstate, CoalesceExpr *c)
 	}
 
 	if (sql_dialect == SQL_DIALECT_TSQL && select_common_type_hook && c->tsql_is_null)
-		newc->coalescetype = (*select_common_type_hook)(pstate, newargs);
+		newc->coalescetype = (*select_common_type_hook)(pstate, newargs, "ISNULL");
+	else if (sql_dialect == SQL_DIALECT_TSQL && select_common_type_hook)
+		newc->coalescetype = (*select_common_type_hook)(pstate, newargs, "TSQL_COALESCE");
 	else
 		newc->coalescetype = select_common_type(pstate, newargs, "COALESCE", NULL);
 	/* coalescecollid will be set by parse_collate.c */
@@ -2273,6 +2276,15 @@ transformCoalesceExpr(ParseState *pstate, CoalesceExpr *c)
 	{
 		Node	   *e = (Node *) lfirst(args);
 		Node	   *newe;
+
+		/*
+		 *	T-SQL treats constant string literals as VARCHAR. Hence,
+		 *	coercing into VARCHAR before coercing it to the common type.
+		 */
+		if (sql_dialect == SQL_DIALECT_TSQL && !c->tsql_is_null && handle_constant_literals_hook)
+		{
+			e = (*handle_constant_literals_hook)(pstate, e);
+		}
 
 		newe = coerce_to_common_type(pstate, e,
 									 newc->coalescetype,

--- a/src/include/parser/parse_coerce.h
+++ b/src/include/parser/parse_coerce.h
@@ -130,7 +130,10 @@ typedef Node *(*coerce_string_literal_hook_type) (ParseCallbackState *pcbstate,
 typedef void (*validate_implicit_conversion_from_string_literal_hook_type) (Const *newcon, const char *value);
 
 /* Generic hook to override the behavior of select_common_type(...) */
-typedef Oid (*select_common_type_hook_type) (ParseState *pstate, List *exprs);
+typedef Oid (*select_common_type_hook_type) (ParseState *pstate, List *exprs, const char *context);
 extern PGDLLIMPORT select_common_type_hook_type select_common_type_hook;
+
+typedef Node *(*handle_constant_literals_hook_type) (ParseState *pstate, Node *e);
+extern PGDLLEXPORT handle_constant_literals_hook_type handle_constant_literals_hook;
 
 #endif							/* PARSE_COERCE_H */


### PR DESCRIPTION
### Description

Behavioural differences mentioned below have been found out better PG Coalesce and T-SQL Coalesce function.
1. Consistency in return datatype i.e., for the same set of input datatypes T-SQL should return consistent return datatype as shown in below example
```
-- T-SQL
select coalesce(cast(8 as smallint), cast(1 as bit))
go
~~START~~
smallint
8
~~END~~
select coalesce(cast(1 as bit), cast(8 as smallint))
go
~~START~~
smallint
1
~~END~~

-- BBF

select coalesce(cast(8 as smallint), cast(1 as bit))
go
~~START~~
smallint
8
~~END~~
select coalesce(cast(1 as bit), cast(8 as smallint))
go
~~START~~
bit
1
~~END~~
```
2. When the input is constant string literal i.e., T-SQL should take short circuit evaluation meaning unnecessary arguments should not be evaluated
```
-- T-SQL
1> SELECT COALESCE(NULL, 1, 2, 'I am a string')
2> go
           
-----------
          1

(1 rows affected)

-- BBF
1> SELECT COALESCE(NULL, 1, 2, 'I am a string')
2> go
Msg 22, Level 16, State 1, Server BABEL, Line 1
invalid input syntax for integer: "I am a string"
```

This commit contains the following changes : 

1. Whenever the caller is T-SQL COALESCE, then call the select_common_type_hook with 'TSQL_COALESCE' context.
2. If the input is a constant string literal, first we convert the UNKNOWN node to VARCHAR node and then coerce it to the common type. This change also handles empty or white space strings according to the way T-SQL handles.

### Issues Resolved

[BABEL-726]

Extension PR : https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2507

Signed-off-by: Sai Rohan Basa [bsrohan@amazon.com](mailto:bsrohan@amazon.com)


 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
