### PR TITLE
Support CTE/JOIN usage for PIVOT operator (PG15)

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -1628,6 +1628,7 @@ _copyFuncExpr(const FuncExpr *from)
 	COPY_SCALAR_FIELD(inputcollid);
 	COPY_NODE_FIELD(args);
 	COPY_LOCATION_FIELD(location);
+	COPY_NODE_FIELD(context);
 
 	return newnode;
 }
@@ -2827,6 +2828,7 @@ _copyFuncCall(const FuncCall *from)
 	COPY_SCALAR_FIELD(func_variadic);
 	COPY_SCALAR_FIELD(funcformat);
 	COPY_LOCATION_FIELD(location);
+	COPY_NODE_FIELD(context);
 
 	return newnode;
 }

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -306,6 +306,7 @@ _equalFuncExpr(const FuncExpr *a, const FuncExpr *b)
 	COMPARE_SCALAR_FIELD(inputcollid);
 	COMPARE_NODE_FIELD(args);
 	COMPARE_LOCATION_FIELD(location);
+	COMPARE_NODE_FIELD(context);
 
 	return true;
 }
@@ -2489,6 +2490,7 @@ _equalFuncCall(const FuncCall *a, const FuncCall *b)
 	COMPARE_SCALAR_FIELD(func_variadic);
 	COMPARE_COERCIONFORM_FIELD(funcformat);
 	COMPARE_LOCATION_FIELD(location);
+	COMPARE_NODE_FIELD(context);
 
 	return true;
 }

--- a/src/backend/nodes/makefuncs.c
+++ b/src/backend/nodes/makefuncs.c
@@ -531,6 +531,7 @@ makeFuncExpr(Oid funcid, Oid rettype, List *args,
 	funcexpr->inputcollid = inputcollid;
 	funcexpr->args = args;
 	funcexpr->location = -1;
+	funcexpr->context = NULL;
 
 	return funcexpr;
 }
@@ -597,6 +598,7 @@ makeFuncCall(List *name, List *args, CoercionForm funcformat, int location)
 	n->func_variadic = false;
 	n->funcformat = funcformat;
 	n->location = location;
+	n->context = NULL;
 	return n;
 }
 

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -2907,6 +2907,7 @@ _outFuncCall(StringInfo str, const FuncCall *node)
 	WRITE_BOOL_FIELD(func_variadic);
 	WRITE_ENUM_FIELD(funcformat, CoercionForm);
 	WRITE_LOCATION_FIELD(location);
+	WRITE_NODE_FIELD(context);
 }
 
 static void

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -778,6 +778,7 @@ _readFuncExpr(void)
 	READ_OID_FIELD(inputcollid);
 	READ_NODE_FIELD(args);
 	READ_LOCATION_FIELD(location);
+	local_node->context = NULL;
 
 	READ_DONE();
 }

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -2525,6 +2525,7 @@ eval_const_expressions_mutator(Node *node,
 				newexpr->inputcollid = expr->inputcollid;
 				newexpr->args = args;
 				newexpr->location = expr->location;
+				newexpr->context = expr->context;
 				return (Node *) newexpr;
 			}
 		case T_OpExpr:
@@ -4465,6 +4466,7 @@ evaluate_function(Oid funcid, Oid result_type, int32 result_typmod,
 	newexpr->inputcollid = input_collid;
 	newexpr->args = args;
 	newexpr->location = -1;
+	newexpr->context = NULL;
 
 	return evaluate_expr((Expr *) newexpr, result_type, result_typmod,
 						 result_collid);
@@ -4577,6 +4579,7 @@ inline_function(Oid funcid, Oid result_type, Oid result_collid,
 	fexpr->inputcollid = input_collid;
 	fexpr->args = args;
 	fexpr->location = -1;
+	fexpr->context = NULL;
 
 	/* Fetch the function body */
 	tmp = SysCacheGetAttr(PROCOID,

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -88,7 +88,7 @@ pre_transform_setop_tree_hook_type pre_transform_setop_tree_hook = NULL;
 /* Hook to reset a query's targetlist after modification in pre_transfrom_sort_clause */
 pre_transform_setop_sort_clause_hook_type pre_transform_setop_sort_clause_hook = NULL;
 
-/* Hooks for transform TSQL pivot clause in select stmt */
+/* Hook to transform TSQL pivot clause in select stmt */
 transform_pivot_clause_hook_type transform_pivot_clause_hook = NULL;
 
 static Query *transformOptionalSelectInto(ParseState *pstate, Node *parseTree);

--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -765,6 +765,10 @@ ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
 		/* funccollid and inputcollid will be set by parse_collate.c */
 		funcexpr->args = fargs;
 		funcexpr->location = location;
+		funcexpr->context = NULL;
+		
+		if (fn != NULL)
+			funcexpr->context = copyObject(fn->context);
 
 		retval = (Node *) funcexpr;
 	}

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -462,6 +462,8 @@ extern Datum ExecMakeFunctionResultSet(SetExprState *fcache,
 									   MemoryContext argContext,
 									   bool *isNull,
 									   ExprDoneCond *isDone);
+typedef void (*pass_pivot_data_to_fcinfo_hook_type)(FunctionCallInfo fcinfo, Expr *expr);
+extern PGDLLEXPORT pass_pivot_data_to_fcinfo_hook_type pass_pivot_data_to_fcinfo_hook;
 
 /*
  * prototypes from functions in execScan.c

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -390,6 +390,7 @@ typedef struct FuncCall
 	bool		func_variadic;	/* last argument was labeled VARIADIC */
 	CoercionForm funcformat;	/* how to display this node */
 	int			location;		/* token location, or -1 if unknown */
+	Node 	   *context;		/* pass necessary info through planner and executor */
 } FuncCall;
 
 /*

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -502,6 +502,7 @@ typedef struct FuncExpr
 	Oid			inputcollid;	/* OID of collation that function should use */
 	List	   *args;			/* arguments to the function */
 	int			location;		/* token location, or -1 if unknown */
+    Node       *context;		/* pass necessary info through planner and executor */
 } FuncExpr;
 
 /*


### PR DESCRIPTION
### Description

This commit fixed an issue that CTE and JOIN cannot be used with pivot operator.

We added 1 field (`Node *context`) in FuncExpr Struct to store pivot additional information. FuncExpr will carry the pivot information to ExecMakeTableFunctionResult. In this function, we pass the pivot information into two newly added FunctionCallInfo that we can retrieve at bbf_pivot function.  

### Issues Resolved

Task: BABEL-4713, BABEL-4714, BABEL-4795
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
