### PR TITLE
[OSS-ONLY] Update BabelfishDump RPM version to 16.2

### DIFF
--- a/BabelfishDump.spec
+++ b/BabelfishDump.spec
@@ -20,13 +20,13 @@
 %global macrosdir %(d=%{_rpmconfigdir}/macros.d; [ -d $d ] || d=%{_sysconfdir}/rpm; echo $d)
 
 %define _trivial .0
-%define _buildid .2
+%define _buildid .1
 
 %undefine _missing_build_ids_terminate_build
 
 Name: BabelfishDump
 Summary: Postgresql dump utilities modified for Babelfish
-Version: 16.1
+Version: 16.2
 Release: 1%{?dist}%{?_trivial}%{?_buildid}
 License: PostgreSQL
 Url: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish

--- a/BabelfishDump.spec
+++ b/BabelfishDump.spec
@@ -143,6 +143,15 @@ LD_LIBRARY_PATH=%{_builddir}/%{name}/src/interfaces/libpq $RPM_BUILD_ROOT/usr/bi
 %{_bindir}/bbf_dumpall
 
 %changelog
+* Tue Apr 02 2024 Rishabh Tanwar <ritanwar@amazon.com> - 16.2-1
+- Do not dump babelfish_domain_mapping catalog table for database-level dump
+
+* Fri Mar 22 2024 Rishabh Tanwar <ritanwar@amazon.com> - 16.2-1
+- Support Babelfish schema-only and data-only dump/restore
+
+* Tue Mar 05 2024 Rishabh Tanwar <ritanwar@amazon.com> - 16.2-1
+- Correctly dump the data of babelfish_extended_properties
+
 * Tue Jan 16 2024 Rishabh Tanwar <ritanwar@amazon.com> - 16.1-2
 - Updated BabelfishDump RPM version to 16.1
 


### PR DESCRIPTION
### Description
Update BabelfishDump RPM version to 16.2

Task: OSS-ONLY
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
