### PR TITLE
Revert optimisation added related to scope_identity() and @@IDENTITY

### DIFF
--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -948,8 +948,6 @@ exprIsNullConstant(Node *arg)
 static void
 bbf_rewrite_function_call(ParseState *pstate, Node **lexpr, Node **rexpr)
 {
-	Var       *col_expr;
-	FuncCall  *new_call;
 	FuncExpr  *func_expr = (FuncExpr *) (*rexpr);
 	char      *func_name = get_func_name(func_expr->funcid);
 
@@ -974,32 +972,7 @@ bbf_rewrite_function_call(ParseState *pstate, Node **lexpr, Node **rexpr)
 			}
 		}
 	}
-
-	if ((IsA(*lexpr, Var) && IsA(*rexpr, FuncExpr)))
-	{
-		col_expr = (Var*) *lexpr;
-		func_expr = (FuncExpr*) *rexpr;
-	}
-	else if (IsA(*lexpr, FuncExpr) && IsA(*rexpr, Var))
-	{
-		col_expr = (Var*) *rexpr;
-		func_expr = (FuncExpr*) *lexpr;
-	}
-	else
-		return;
-
-	func_name = get_func_name(func_expr->funcid);
-	if (strcmp(func_name, "babelfish_get_last_identity_numeric") != 0 &&
-			strcmp(func_name, "scope_identity") != 0)
-		return;
-	if (col_expr->vartype != INT2OID && col_expr->vartype != INT4OID && col_expr->vartype != INT8OID)
-		return;
-
-	new_call = makeFuncCall(list_make1(makeString("babelfish_get_last_identity")), NULL, COERCE_EXPLICIT_CALL, -1);
-	if (IsA(*rexpr, FuncExpr))
-		*rexpr = transformFuncCall(pstate, new_call);
-	else
-		*lexpr = transformFuncCall(pstate, new_call);
+	return;
 }
 
 static Node *


### PR DESCRIPTION
### Description

As part of commit ec9fda039c972f0ef7884d2eb176c988266cff64, we made some parsing level changes for quals which involves scope_identity() or @@IDENTITY in order to let optimiser choose index scan in certain situation.

With extension commit 80905a001c2e13a07f8c33e865401a3abce68c1d merged, we found that above commit has introduced correctness issue. So this commit fixes that issue by reverting above mentioned changes. Please also note that this will not cause any performance regression as optimiser will now choose index scan with the extension commit 80905a001c2e13a07f8c33e865401a3abce68c1d. 

Task: BABEL-4876
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
