### PR TITLE
Fix searchpath handling for tsql udfs inside fmgr (#353)

### DIFF
--- a/src/backend/catalog/namespace.c
+++ b/src/backend/catalog/namespace.c
@@ -4447,6 +4447,13 @@ check_search_path(char **newval, void **extra, GucSource source)
 	char	   *rawname;
 	List	   *namelist;
 
+	/* quick exit for babelfish when setting search path in fmgr_security_definer */
+	if (sql_dialect == SQL_DIALECT_TSQL && set_local_schema_for_func_hook
+		&& pltsql_check_search_path == false)
+	{
+		pltsql_check_search_path = true;
+		return true;
+	}
 	/* Need a modifiable copy of string */
 	rawname = pstrdup(*newval);
 

--- a/src/backend/utils/fmgr/fmgr.c
+++ b/src/backend/utils/fmgr/fmgr.c
@@ -48,6 +48,7 @@ PGDLLIMPORT non_tsql_proc_entry_hook_type non_tsql_proc_entry_hook = NULL;
 PGDLLIMPORT get_func_language_oids_hook_type get_func_language_oids_hook = NULL;
 PGDLLIMPORT pgstat_function_wrapper_hook_type pgstat_function_wrapper_hook = NULL;
 set_local_schema_for_func_hook_type set_local_schema_for_func_hook = NULL;
+bool pltsql_check_search_path = true;
 
 /*
  * Hashtable for fast lookup of external C functions
@@ -696,7 +697,7 @@ fmgr_security_definer(PG_FUNCTION_ARGS)
 	int			non_tsql_proc_count = 0;
 	void	   *newextra = NULL;
 	char 	   *cacheTupleProcname = NULL;
-	char	   *old_search_path = NULL;
+	int 	    pltsql_save_nestlevel;
 
 	if (get_func_language_oids_hook)
 		get_func_language_oids_hook(&pltsql_lang_oid, &pltsql_validator_oid);
@@ -788,13 +789,6 @@ fmgr_security_definer(PG_FUNCTION_ARGS)
 						GUC_ACTION_SAVE);
 	}
 
-	if (fcache->prosearchpath)
-	{
-		old_search_path = namespace_search_path;
-		namespace_search_path = fcache->prosearchpath;
-		assign_search_path(fcache->prosearchpath, newextra);
-	}
-
 	if (set_sql_dialect && IsTransactionState())
 	{
 		if ((fcache->prolang == pltsql_lang_oid) || (fcache->prolang == pltsql_validator_oid))
@@ -863,6 +857,16 @@ fmgr_security_definer(PG_FUNCTION_ARGS)
 			pfree(cacheTupleProcname);
 		}
 
+		if (fcache->prosearchpath)
+		{
+			pltsql_save_nestlevel = NewGUCNestLevel();
+			pltsql_check_search_path = false;
+			(void) set_config_option("search_path", fcache->prosearchpath,
+									PGC_USERSET, PGC_S_SESSION,
+									GUC_ACTION_SAVE, true, 0, false);
+			pltsql_check_search_path = true;
+		}
+
 		result = FunctionCallInvoke(fcinfo);
 
 		/*
@@ -901,23 +905,19 @@ fmgr_security_definer(PG_FUNCTION_ARGS)
 			sql_dialect = sql_dialect_value_old;
 			assign_sql_dialect(sql_dialect_value_old, newextra);
 		}
-		
-		if (old_search_path)
-		{
-			namespace_search_path = old_search_path;
-			assign_search_path(old_search_path, newextra);
-		}
 
+		if (fcache->prosearchpath)
+			pltsql_check_search_path = true;
+		
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
 
 	fcinfo->flinfo = save_flinfo;
 
-	if (old_search_path)
+	if (fcache->prosearchpath)
 	{
-		namespace_search_path = old_search_path;
-		assign_search_path(old_search_path, newextra);
+		AtEOXact_GUC(true, pltsql_save_nestlevel);
 	}
 
 	if (set_sql_dialect)

--- a/src/include/fmgr.h
+++ b/src/include/fmgr.h
@@ -804,6 +804,7 @@ extern PGDLLIMPORT fmgr_hook_type fmgr_hook;
 extern PGDLLEXPORT non_tsql_proc_entry_hook_type non_tsql_proc_entry_hook;
 extern PGDLLEXPORT get_func_language_oids_hook_type get_func_language_oids_hook;
 extern PGDLLEXPORT set_local_schema_for_func_hook_type set_local_schema_for_func_hook;
+extern bool pltsql_check_search_path;
 
 #define FmgrHookIsNeeded(fn_oid)							\
 	(!needs_fmgr_hook ? false : (*needs_fmgr_hook)(fn_oid))


### PR DESCRIPTION
### Description

#### Cherry Picked from: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/353

Currently we override the search_path for pltsql UDFs directly using the GUC variable & avoid set_config.
This leads to crash if there was another set_config('search_path... when we were in this overridden state.
Reason for crash is that the new set_config call may push the current value (the one we set in fmgr) onto
GUC stack. Now it pssoble that we exit the function call and released fcache, but fcache->prosearchpath
is still referenced in GUC stack.

To fix this we fallback to using set_config for setting the search_path & skip the check hook for search path
when setting from inside fmgr which helps with performance.
Also increase the GUC nest level since GUC_ACTION_SAVE is not possible on top of GUC_ACTION_SET
(user set), which is possible in this case. New nest level also means that we do not have to reset the search
path at the end of execution and let AtEOXact_GUC(commit=true) handle it.

We also move the set search path block in fmgr inside TRY, to ensure we reset the skip check search path
variable in case of errors.

### Issues Resolved

[BABEL-4877]

#### Engine PR: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/357
#### Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2552

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).