### PR TITLE
Resolve 'str' maybe unitialized error

### DIFF
--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -1592,7 +1592,7 @@ babelfishDumpOpclassHelper(Archive *fout, const OpclassInfo *opcinfo, PQExpBuffe
 	int			i_opfname;
 	char		*opfnamespace;
 	char		*opfname;
-	const char	*str;
+	const char	*str = NULL;
 	const char 	*opclass = fmtQualifiedDumpable(opcinfo);
 
 
@@ -1741,7 +1741,9 @@ babelfishDumpOpclassHelper(Archive *fout, const OpclassInfo *opcinfo, PQExpBuffe
 				"FUNCTION 1 sys.numeric_int8_cmp(numeric, int8) ";
 	}
 
-	appendPQExpBufferStr(buff, str);
+	if(str != NULL)
+		appendPQExpBufferStr(buff, str);
+
 	/*
 	 * set needComma to true so that original pg_dump does not dump unnecessary option
 	 * Check when STORAGE option will be dumped in dumpOpclass(...).  


### PR DESCRIPTION
### Description

This change initializes the ```str``` variable in the ```babelfishDumpOpclassHelper``` function to prevent this error from being thrown ```error: 'str' may be used uninitialized in this function [-Werror=maybe-uninitialized] ```
 
### Issues Resolved

No jira

cherry-picked: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/358
 
### Check List

- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
