### PR TITLE
[OSS-ONLY] Fix crash in InitializeParallelDSM due to MyProcPort not set

### DIFF
--- a/src/backend/access/transam/parallel.c
+++ b/src/backend/access/transam/parallel.c
@@ -297,7 +297,7 @@ InitializeParallelDSM(ParallelContext *pcxt)
 		shm_toc_estimate_keys(&pcxt->estimator, 1);
 
 		/* Estimate how much we'll need for the babelfish fixed parallel state */
-		if (MyProcPort->is_tds_conn && bbf_InitializeParallelDSM_hook)
+		if (MyProcPort && MyProcPort->is_tds_conn && bbf_InitializeParallelDSM_hook)
 			(*bbf_InitializeParallelDSM_hook) (pcxt, true);
 	}
 
@@ -343,7 +343,7 @@ InitializeParallelDSM(ParallelContext *pcxt)
 	fps->xact_ts = GetCurrentTransactionStartTimestamp();
 	fps->stmt_ts = GetCurrentStatementStartTimestamp();
 	fps->serializable_xact_handle = ShareSerializableXact();
-	fps->babelfish_context = MyProcPort->is_tds_conn;
+	fps->babelfish_context = MyProcPort ? MyProcPort->is_tds_conn : false;
 	SpinLockInit(&fps->mutex);
 	fps->last_xlog_end = 0;
 	shm_toc_insert(pcxt->toc, PARALLEL_KEY_FIXED, fps);
@@ -475,7 +475,7 @@ InitializeParallelDSM(ParallelContext *pcxt)
 		shm_toc_insert(pcxt->toc, PARALLEL_KEY_ENTRYPOINT, entrypointstate);
 
 		/* Initialize babelfish fixed-size state in shared memory. */
-		if (MyProcPort->is_tds_conn && bbf_InitializeParallelDSM_hook)
+		if (MyProcPort && MyProcPort->is_tds_conn && bbf_InitializeParallelDSM_hook)
 			(*bbf_InitializeParallelDSM_hook) (pcxt, false);
 	}
 

--- a/src/backend/catalog/objectaddress.c
+++ b/src/backend/catalog/objectaddress.c
@@ -992,7 +992,7 @@ get_object_address(ObjectType objtype, Node *object,
 													   &relation, missing_ok);
 				break;
 			case OBJECT_TRIGGER:
-				if(get_trigger_object_address_hook && MyProcPort->is_tds_conn && sql_dialect == SQL_DIALECT_TSQL){
+				if(get_trigger_object_address_hook && MyProcPort && MyProcPort->is_tds_conn && sql_dialect == SQL_DIALECT_TSQL){
 						address = (*get_trigger_object_address_hook)(castNode(List, object),
 															&relation, missing_ok,false);
 				}

--- a/src/backend/libpq/pqmq.c
+++ b/src/backend/libpq/pqmq.c
@@ -311,7 +311,7 @@ pq_parse_errornotice(StringInfo msg, ErrorData *edata)
 				edata->funcname = pstrdup(value);
 				break;
 			case PG_DIAG_MESSAGE_ID:
-				if (MyProcPort->is_tds_conn)
+				if (MyProcPort && MyProcPort->is_tds_conn)
 				{
 					edata->message_id = (const char *) pstrdup(value);
 				}

--- a/src/backend/tcop/postgres.c
+++ b/src/backend/tcop/postgres.c
@@ -473,7 +473,10 @@ ReadCommand(StringInfo inBuf)
 	int			result;
 
 	if (whereToSendOutput == DestRemote)
+	{
+		Assert(MyProcPort != NULL);
 		result = MyProcPort->protocol_config->fn_read_command(inBuf);
+	}
 	else
 		result = InteractiveBackend(inBuf);
 	return result;


### PR DESCRIPTION
### Description

Crash in InitializeParallelDSM during VACUUM by a bg worker

InitializeParallelDSM was crashing when a cron job was scheduled to vacuum a table, index or index build/reindexing as there are done by maintenance worker. This change was pushed into serval branches. 

This is happenning because for maintenance worker MyProcPort is not set which is why we were getting segfault. With this commit, we have updated the condition to check whether MyProcPort is set or not.
 

Signed-off-by: Shameem Ahmed [shmeeh@amazon.com](mailto:shmeeh@amazon.com)
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
