### PR TITLE
[OSS-ONLY] Update BabelfishDump RPM version to 16.3

### DIFF
--- a/BabelfishDump.spec
+++ b/BabelfishDump.spec
@@ -26,7 +26,7 @@
 
 Name: BabelfishDump
 Summary: Postgresql dump utilities modified for Babelfish
-Version: 16.2
+Version: 16.3
 Release: 1%{?dist}%{?_trivial}%{?_buildid}
 License: PostgreSQL
 Url: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish
@@ -143,13 +143,13 @@ LD_LIBRARY_PATH=%{_builddir}/%{name}/src/interfaces/libpq $RPM_BUILD_ROOT/usr/bi
 %{_bindir}/bbf_dumpall
 
 %changelog
-* Tue Apr 02 2024 Rishabh Tanwar <ritanwar@amazon.com> - 16.2-1
+* Tue Apr 02 2024 Rishabh Tanwar <ritanwar@amazon.com> - 16.3-1
 - Do not dump babelfish_domain_mapping catalog table for database-level dump
 
-* Fri Mar 22 2024 Rishabh Tanwar <ritanwar@amazon.com> - 16.2-1
+* Fri Mar 22 2024 Rishabh Tanwar <ritanwar@amazon.com> - 16.3-1
 - Support Babelfish schema-only and data-only dump/restore
 
-* Tue Mar 05 2024 Rishabh Tanwar <ritanwar@amazon.com> - 16.2-1
+* Tue Mar 05 2024 Rishabh Tanwar <ritanwar@amazon.com> - 16.3-1
 - Correctly dump the data of babelfish_extended_properties
 
 * Tue Jan 16 2024 Rishabh Tanwar <ritanwar@amazon.com> - 16.1-2


### PR DESCRIPTION
### Description
Update BabelfishDump RPM version to 16.3

Task: OSS-ONLY
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
