### PR TITLE
[OSS-ONLY] Update bug report and documentation links for BabelfishDump

### DIFF
--- a/BabelfishDump.spec
+++ b/BabelfishDump.spec
@@ -151,6 +151,9 @@ LD_LIBRARY_PATH=%{_builddir}/%{name}/src/interfaces/libpq $RPM_BUILD_ROOT/usr/bi
 %{_bindir}/bbf_dumpall
 
 %changelog
+* Mon May 20 2024 Rishabh Tanwar <ritanwar@amazon.com> - 16.3-1
+- Update bug report and documentation links for BabelfishDump
+
 * Tue Apr 02 2024 Rishabh Tanwar <ritanwar@amazon.com> - 16.3-1
 - Do not dump babelfish_domain_mapping catalog table for database-level dump
 

--- a/BabelfishDump.spec
+++ b/BabelfishDump.spec
@@ -82,6 +82,14 @@ sed -i "s/pg_dump (PostgreSQL)/bbf_dump (pg_dump compatible with Babelfish for P
 sed -i "s/bbf_dump (PostgreSQL)/bbf_dump (pg_dump compatible with Babelfish for PostgreSQL)/g" src/bin/pg_dump/pg_dumpall.c
 sed -i "s/bbf_dumpall (PostgreSQL)/bbf_dumpall (pg_dumpall compatible with Babelfish for PostgreSQL)/g" src/bin/pg_dump/pg_dumpall.c
 
+# Update bug report and package links
+sed -i 's|PACKAGE_BUGREPORT|"https://github.com/babelfish-for-postgresql/babelfish_extensions/issues"|g' src/bin/pg_dump/pg_dump.c
+sed -i 's|PACKAGE_BUGREPORT|"https://github.com/babelfish-for-postgresql/babelfish_extensions/issues"|g' src/bin/pg_dump/pg_dumpall.c
+sed -i 's|PACKAGE_NAME|"Babelfish"|g' src/bin/pg_dump/pg_dump.c
+sed -i 's|PACKAGE_NAME|"Babelfish"|g' src/bin/pg_dump/pg_dumpall.c
+sed -i 's|PACKAGE_URL|"https://github.com/babelfish-for-postgresql/babelfish-for-postgresql/wiki"|g' src/bin/pg_dump/pg_dump.c
+sed -i 's|PACKAGE_URL|"https://github.com/babelfish-for-postgresql/babelfish-for-postgresql/wiki"|g' src/bin/pg_dump/pg_dumpall.c
+
 %build
 # Building BabelfishDump
 


### PR DESCRIPTION
### Description
Previously, bug report and documentation links for BabelfishDump utilities in
`--help` was pointing to PostgreSQL instead of Babelfish.
Fixed this by updating the links with corresponding Babelfish bug report
and documentation links.
Updated output of `--help` command:
```
...
Report bugs to <https://github.com/babelfish-for-postgresql/babelfish_extensions/issues>.
Babelfish home page: <https://github.com/babelfish-for-postgresql/babelfish-for-postgresql/wiki>
```

Task: OSS-ONLY
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
