### PR TITLE
Fix BBF PIVOT cannot use CTE as source table (PG15)

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -1433,7 +1433,7 @@ transformSelectStmt(ParseState *pstate, SelectStmt *stmt)
 	qry->commandType = CMD_SELECT;
 
 	/* process the WITH clause independently of all else */
-	if (stmt->withClause)
+	if (stmt->withClause && ( sql_dialect == SQL_DIALECT_PG || transform_pivot_clause_hook == NULL || !stmt->isPivot))
 	{
 		qry->hasRecursive = stmt->withClause->recursive;
 		qry->cteList = transformWithClause(pstate, stmt->withClause);


### PR DESCRIPTION
Fixed BBF PIVOT stmt cannot use CTE as source table



### Description

Fixed BBF PIVOT stmt cannot use CTE as source table
 
### Issues Resolved

BABEL-4959 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
