### PR TITLE
Add transactional support for ENR temp tables

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -627,7 +627,6 @@ AssignTransactionId(TransactionState s)
 
 	/* Assert that caller didn't screw up */
 	Assert(!FullTransactionIdIsValid(s->fullTransactionId));
-
 	Assert(s->state == TRANS_INPROGRESS);
 
 	if (AbortCurTransaction)

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -376,10 +376,6 @@ IsTransactionState(void)
 {
 	TransactionState s = CurrentTransactionState;
 
-	/* During ENR Rollback, we may need to call relation_open during TRANS_ABORT. */
-	if (temp_table_xact_support && ENRInRollback() && s->state == TRANS_ABORT)
-		return true;
-
 	/*
 	 * TRANS_DEFAULT and TRANS_ABORT are obviously unsafe states.  However, we
 	 * also reject the startup/shutdown states TRANS_START, TRANS_COMMIT,
@@ -632,9 +628,7 @@ AssignTransactionId(TransactionState s)
 	/* Assert that caller didn't screw up */
 	Assert(!FullTransactionIdIsValid(s->fullTransactionId));
 
-	/* In ENR Rollback, we may need to call relation_open during TRANS_ABORT. */
-	if (temp_table_xact_support && !ENRInRollback() && s->state != TRANS_ABORT)
-		Assert(s->state == TRANS_INPROGRESS);
+	Assert(s->state == TRANS_INPROGRESS);
 
 	if (AbortCurTransaction)
 	{
@@ -2254,6 +2248,9 @@ CommitTransaction(void)
 	/* Commit updates to the relation map --- do this as late as possible */
 	AtEOXact_RelationMap(true, is_parallel_worker);
 
+	if (temp_table_xact_support)
+		ENRCommitChanges(currentQueryEnv);
+
 	/*
 	 * set the current transaction state information appropriately during
 	 * commit processing
@@ -2761,6 +2758,9 @@ AbortTransaction(void)
 		elog(WARNING, "AbortTransaction while in %s state",
 			 TransStateAsString(s->state));
 	Assert(s->parent == NULL);
+
+	if (temp_table_xact_support)
+		ENRRollbackChanges(currentQueryEnv);
 
 	/*
 	 * set the current transaction state information appropriately during the
@@ -5111,6 +5111,9 @@ AbortSubTransaction(void)
 	if (s->state != TRANS_INPROGRESS)
 		elog(WARNING, "AbortSubTransaction while in %s state",
 			 TransStateAsString(s->state));
+
+	if (temp_table_xact_support)
+		ENRRollbackSubtransaction(s->subTransactionId, currentQueryEnv);
 
 	s->state = TRANS_ABORT;
 

--- a/src/backend/catalog/dependency.c
+++ b/src/backend/catalog/dependency.c
@@ -1384,7 +1384,7 @@ deleteOneObject(const ObjectAddress *object, Relation *depRel, int flags)
 	DeleteInitPrivs(object);
 
 	// Delete from ENR - noop if not found from ENR
-	ENRDropEntry(object->objectId);
+	ENRDropEntry(object->objectId, currentQueryEnv);
 
 	/*
 	 * CommandCounterIncrement here to ensure that preceding changes are all

--- a/src/backend/catalog/dependency.c
+++ b/src/backend/catalog/dependency.c
@@ -1384,7 +1384,7 @@ deleteOneObject(const ObjectAddress *object, Relation *depRel, int flags)
 	DeleteInitPrivs(object);
 
 	// Delete from ENR - noop if not found from ENR
-	ENRDropEntry(object->objectId, currentQueryEnv);
+	ENRDropEntry(object->objectId);
 
 	/*
 	 * CommandCounterIncrement here to ensure that preceding changes are all

--- a/src/backend/utils/misc/guc.c
+++ b/src/backend/utils/misc/guc.c
@@ -897,6 +897,11 @@ StaticAssertDecl(lengthof(config_type_names) == (PGC_ENUM + 1),
 				 "array length mismatch");
 
 /*
+ * Control tsql temp table xact support for ROLLBACK.  
+ */
+bool		temp_table_xact_support;
+
+/*
  * Unit conversion tables.
  *
  * There are two tables, one for memory units, and another for time units.

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -1099,20 +1099,7 @@ void ENRDropEntry(Oid id)
 	/* If we are dropping a committed ENR, wait until COMMIT to free it. */
 	if (temp_table_xact_support && enr->md.is_bbf_temp_table)
 	{
-		ListCell *lc;
 		enr->md.dropped_subid = GetCurrentSubTransactionId();
-		foreach(lc, currentQueryEnv->dropped_namedRelList)
-		{
-			EphemeralNamedRelation tmp_enr = (EphemeralNamedRelation) (lc);
-
-			if (strcmp(enr->md.name, tmp_enr->md.name) == 0 && tmp_enr->md.dropped_subid == enr->md.dropped_subid)
-			{
-				currentQueryEnv->dropped_namedRelList = foreach_delete_current(currentQueryEnv->dropped_namedRelList, lc);
-				pfree(tmp_enr->md.name);
-				pfree(tmp_enr);
-				break;
-			}
-		}
 		currentQueryEnv->dropped_namedRelList = lappend(currentQueryEnv->dropped_namedRelList, enr);
 	}
 	else

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -279,6 +279,8 @@ extern PGDLLIMPORT int temp_file_limit;
 
 extern PGDLLIMPORT int num_temp_buffers;
 
+extern PGDLLIMPORT bool temp_table_xact_support;
+
 extern PGDLLIMPORT char *cluster_name;
 extern PGDLLIMPORT char *ConfigFileName;
 extern PGDLLIMPORT char *HbaFileName;

--- a/src/include/utils/queryenvironment.h
+++ b/src/include/utils/queryenvironment.h
@@ -87,6 +87,8 @@ typedef struct EphemeralNamedRelationMetadataData
 
 	/* We must ignore transaction semantics for table variables. */
 	bool		is_table_variable;
+	/* is index */
+	bool		is_index;
 	/* We don't need to track uncommitted ENRs as they would be dropped entirely on ROLLBACK. */
 	bool		is_committed;
 	/* If this ENR is currently being rolled back, don't track changes to it. */

--- a/src/include/utils/queryenvironment.h
+++ b/src/include/utils/queryenvironment.h
@@ -87,8 +87,6 @@ typedef struct EphemeralNamedRelationMetadataData
 
 	/* We must ignore transaction semantics for table variables. */
 	bool		is_table_variable;
-	/* is index */
-	bool		is_index;
 	/* We don't need to track uncommitted ENRs as they would be dropped entirely on ROLLBACK. */
 	bool		is_committed;
 	/* If this ENR is currently being rolled back, don't track changes to it. */

--- a/src/include/utils/queryenvironment.h
+++ b/src/include/utils/queryenvironment.h
@@ -88,7 +88,7 @@ typedef struct EphemeralNamedRelationMetadataData
 	List		*cattups[ENR_CATTUP_END];
 
 	/* We must ignore transaction semantics for table variables. */
-	bool		is_not_bbf_temp_table;
+	bool		is_bbf_temp_table;
 	/* We don't need to track uncommitted ENRs as they would be dropped entirely on ROLLBACK. */
 	bool		is_committed;
 	/* If this ENR is currently being rolled back, don't track changes to it. */

--- a/src/include/utils/queryenvironment.h
+++ b/src/include/utils/queryenvironment.h
@@ -91,8 +91,6 @@ typedef struct EphemeralNamedRelationMetadataData
 	bool		is_committed;
 	/* If this ENR is currently being rolled back, don't track changes to it. */
 	bool		in_rollback;
-	/* Track whether this ENR has been dropped in the current transaction. */
-	bool		pending_drop;
 	/* List of uncommitted tuples. They must be processed on ROLLBACK, or cleared on commit. */
 	List		*uncommitted_cattups[ENR_CATTUP_END];
 } EphemeralNamedRelationMetadataData;

--- a/src/include/utils/queryenvironment.h
+++ b/src/include/utils/queryenvironment.h
@@ -88,7 +88,7 @@ typedef struct EphemeralNamedRelationMetadataData
 	List		*cattups[ENR_CATTUP_END];
 
 	/* We must ignore transaction semantics for table variables. */
-	bool		is_table_variable;
+	bool		is_not_bbf_temp_table;
 	/* We don't need to track uncommitted ENRs as they would be dropped entirely on ROLLBACK. */
 	bool		is_committed;
 	/* If this ENR is currently being rolled back, don't track changes to it. */

--- a/src/include/utils/queryenvironment.h
+++ b/src/include/utils/queryenvironment.h
@@ -140,7 +140,7 @@ extern bool ENRdropTuple(Relation rel, HeapTuple tup);
 extern bool ENRupdateTuple(Relation rel, HeapTuple tup);
 extern bool ENRgetSystableScan(Relation rel, Oid indexoid, int nkeys, ScanKey key, List **tuplist, int *tuplist_i, int *tuplist_flags);
 extern void ENRDropTempTables(QueryEnvironment *queryEnv);
-extern void ENRDropEntry(Oid id, QueryEnvironment *queryEnv);
+extern void ENRDropEntry(Oid id);
 extern void ENRDropCatalogEntry(Relation catalog_relation, Oid relid);
 extern bool has_existing_enr_relations(void);
 

--- a/src/include/utils/queryenvironment.h
+++ b/src/include/utils/queryenvironment.h
@@ -62,6 +62,8 @@ typedef struct ENRUncommittedTupleData
 	ENRTupleOperationType		optype;
 	/* A copy of the tuple itself */
 	HeapTuple 					tup;
+	/* Track if this was created in a specific subtransactionid so that it can be rolled back on savepoints. */
+	SubTransactionId subid;
 } ENRUncommittedTupleData;
 
 typedef ENRUncommittedTupleData *ENRUncommittedTuple;
@@ -91,6 +93,9 @@ typedef struct EphemeralNamedRelationMetadataData
 	bool		is_committed;
 	/* If this ENR is currently being rolled back, don't track changes to it. */
 	bool		in_rollback;
+	/* Track if this was created/dropped in a specific subtransactionid so that it can be rolled back on savepoints. */
+	SubTransactionId created_subid;
+	SubTransactionId dropped_subid;
 	/* List of uncommitted tuples. They must be processed on ROLLBACK, or cleared on commit. */
 	List		*uncommitted_cattups[ENR_CATTUP_END];
 } EphemeralNamedRelationMetadataData;
@@ -142,5 +147,7 @@ extern bool has_existing_enr_relations(void);
 extern bool ENRTupleIsDropped(Relation rel, HeapTuple tup);
 extern void ENRCommitChanges(QueryEnvironment *queryEnv);
 extern void ENRRollbackChanges(QueryEnvironment *queryEnv);
+extern void ENRRollbackSubtransaction(SubTransactionId subid, QueryEnvironment *queryEnv);
+extern bool ENRInRollback(void);
 
 #endif							/* QUERYENVIRONMENT_H */

--- a/src/include/utils/queryenvironment.h
+++ b/src/include/utils/queryenvironment.h
@@ -148,6 +148,5 @@ extern bool ENRTupleIsDropped(Relation rel, HeapTuple tup);
 extern void ENRCommitChanges(QueryEnvironment *queryEnv);
 extern void ENRRollbackChanges(QueryEnvironment *queryEnv);
 extern void ENRRollbackSubtransaction(SubTransactionId subid, QueryEnvironment *queryEnv);
-extern bool ENRInRollback(void);
 
 #endif							/* QUERYENVIRONMENT_H */


### PR DESCRIPTION
### Description

ENR temp tables were not sensitive to transactional behavior. We add it here by introducing a new structure which will track uncommitted ENR tuples and process them accordingly, depending on if the active transaction is committed or rolled back. 

Tests are added in babelfish-for-postgresql/babelfish_extensions#2605

4x: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/348
 
### Issues Resolved

BABEL-4864
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
