### PR TITLE
Fix uninitialized value in register_ENR with triggers

### DIFF
--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -145,6 +145,8 @@ register_ENR(QueryEnvironment *queryEnv, EphemeralNamedRelation enr)
 
 	if (enr->md.name[0] == '#')
 		enr->md.is_bbf_temp_table = true;
+	else
+		enr->md.is_bbf_temp_table = false;
 
 	if (enr->md.is_bbf_temp_table && GetCurrentSubTransactionId() != InvalidSubTransactionId)
 		enr->md.created_subid = GetCurrentSubTransactionId();


### PR DESCRIPTION
### Description

SPI_register_trigger_data does not use `palloc0`, so we don't have a guarantee that `enr->md` is zeroed. 

Before change Valgrind will complain:

```
== VALGRINDERROR-BEGIN
==00:01:15:17.181 7193== Conditional jump or move depends on uninitialised value(s)
==00:01:15:17.181 7193==    at 0xBB71BD: register_ENR (queryenvironment.c:149)
==00:01:15:17.181 7193==    by 0x7A528A: SPI_register_relation (spi.c:3338)
==00:01:15:17.181 7193==    by 0x7A5488: SPI_register_trigger_data (spi.c:3419)
==00:01:15:17.181 7193==    by 0x1253A8C1: pltsql_exec_trigger (pl_exec.c:1101)
==00:01:15:17.181 7193==    by 0x1252DF28: pltsql_call_handler (pl_handler.c:4799)
```

After change all is clean.
 
### Issues Resolved

BABEL-4993
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
