### PR TITLE
Support dump/restore of Partition Function and Partition Scheme catalogs

### DIFF
--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -1483,19 +1483,19 @@ fixCursorForBbfSqlvariantTableData( Archive *fout,
 			quote_all_identifiers ? "\"sys\".\"sql_variant\"[]" : "sys.sql_variant[]") == 0) /* array of sql_variant */
 		{
 			/*
-			 * We need additional handling for array of sql_variant because each values in the
-			 * array will have different basetype and bytelength. Here instead of adding a normal
-			 * column for basetype and bytelength as extra columns, we will add array of it which
-			 * will be constructed by invoking sys.sql_variant_property and sys.datalength function
-			 * on each values of the array.
+			 * We need additional handling for an array of sql_variant because each value in the
+			 * array will have a different base type and byte length. Here, instead of adding normal
+			 * columns for base type and byte length as extra columns, we will add arrays of them which
+			 * will be constructed by invoking the sys.sql_variant_property and sys.datalength functions
+			 * on each value of the array.
 			 */
 			appendPQExpBufferStr(buf, ", (SELECT array_agg(sys.SQL_VARIANT_PROPERTY(t1, 'BaseType')) FROM unnest(");
-			if (is_catalog_table) /* qualify the column names with table alias if it is a Babelfish catalog table */
+			if (is_catalog_table) /* qualify the column names with table alias if it is a babelfish catalog table */
 				appendPQExpBufferStr(buf, "a.");
 			appendPQExpBuffer(buf, "%s) AS t1)", fmtId(tbinfo->attnames[i]));
 
 			appendPQExpBufferStr(buf, ", (SELECT array_agg(sys.datalength(t2)) FROM unnest(");
-			if (is_catalog_table) /* qualify the column names with table alias if it is a Babelfish catalog table */
+			if (is_catalog_table) /* qualify the column names with table alias if it is a babelfish catalog table */
 				appendPQExpBufferStr(buf, "a.");
 			appendPQExpBuffer(buf, "%s) AS t2)", fmtId(tbinfo->attnames[i]));
 			appendPQExpBuffer(buf, ", 1"); /* to indicate if it is array or not */
@@ -1518,7 +1518,7 @@ fixCursorForBbfSqlvariantTableData( Archive *fout,
 static void
 castSqlvariantToBasetypeHelper(Archive *fout, char *value, char *type, int datalength)
 {
-	PQExpBuffer q; = createPQExpBuffer();
+	PQExpBuffer q;
 	int precision;
 	int scale;
 	int i;

--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -1391,8 +1391,8 @@ static bool
 hasSqlvariantColumn(TableInfo *tbinfo)
 {
 	for (int i = 0; i < tbinfo->numatts; i++)
-		if (pg_strcasecmp(tbinfo->atttypnames[i],
-				quote_all_identifiers ? "\"sys\".\"sql_variant\"" : "sys.sql_variant") == 0)
+		if (strstr(tbinfo->atttypnames[i],
+				quote_all_identifiers ? "\"sys\".\"sql_variant\"" : "sys.sql_variant"))
 					return true;
 	return false;
 }

--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -1254,14 +1254,14 @@ fixCursorForBbfCatalogTableData(Archive *fout, TableInfo *tbinfo, PQExpBuffer bu
 		if (is_bbf_sysdatabases_tab && strcmp(tbinfo->attnames[i], "owner") == 0)
 			continue;
 		/*
-		* 1. Skip dbid column for logical database dump, we will generate new 
-		*    database id during restore. We will still dump dbid for builtin 
-		*    databases since we don't need to regenerate it during restore as 
-		*    dbids are fixed for builtin databases.
-		* 2. Skip function_id and scheme_id column of babelfish_partition_function
-		*    and babelfish_partition_scheme catalog respectively for logical database dump,
-		*    we will generate new function_id and scheme_id during restore.
-		*/
+		 * 1. Skip dbid column for logical database dump, we will generate new 
+		 *    database id during restore. We will still dump dbid for builtin 
+		 *    databases since we don't need to regenerate it during restore as 
+		 *    dbids are fixed for builtin databases.
+		 * 2. Skip function_id and scheme_id column of babelfish_partition_function
+		 *    and babelfish_partition_scheme catalog respectively for logical database dump,
+		 *    we will generate new function_id and scheme_id during restore.
+		 */
 		else if (bbf_db_name != NULL)
 		{
 			if ((!is_builtin_db && strcmp(tbinfo->attnames[i], "dbid") == 0) || 


### PR DESCRIPTION
### Description

This commit adds support of Dump/Restore capabilities for Partition Function and Partition Scheme Catalogs. It also enables the ability to dump table columns that have array of sql_variant as the data type.

Signed-off-by: Sumit Jaiswal <sumiji@amazon.com>

Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2587
 
### Issues Resolved

Task: BABEL-5051
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
