### PR TITLE
Fix differences in T-SQL COALESCE function while calling the function with variables and constants together

### DIFF
--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -3187,8 +3187,17 @@ eval_const_expressions_mutator(Node *node,
 				{
 					Node	   *e;
 
-					e = eval_const_expressions_mutator((Node *) lfirst(arg),
-													   context);
+					/*
+					 * T-SQL Coalesce is handled differently, constant expressions
+					 * are evaluated at runtime. Hence, skipping eval_const_expressions_mutator()
+					 * at this step.
+					 */
+					if (sql_dialect == SQL_DIALECT_TSQL && !coalesceexpr->tsql_is_null 
+						&& lfirst(arg) != NULL && ((Node *) lfirst(arg))->type == T_CoerceViaIO)
+						e = (Node *) lfirst(arg);
+					else
+						e = eval_const_expressions_mutator((Node *) lfirst(arg),
+													   		context);
 
 					/*
 					 * We can remove null constants from the list. For a


### PR DESCRIPTION
### Description

This commit will fix the following issue with T-SQL COALESCE function : 

1. When the arguments contain the mix of variables and constants as shown below, the below query should return 4 as it is the first non-null value. But BBF throws error as we try to evaluate the constant ('dfidhfgi') at the compile time in this case.
```
DECLARE @abc int = 4 ;
select COALESCE(@abc, 'dfidhfgi')
```
 
### Issues Resolved

BABEL-726
Extension PR : https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2635
Signed-off-by: Sai Rohan Basa [bsrohan@amazon.com](mailto:bsrohan@amazon.com)
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
