### PR TITLE
Reset proconfig for functions even when babelfish is installed

### DIFF
--- a/src/backend/utils/fmgr/fmgr.c
+++ b/src/backend/utils/fmgr/fmgr.c
@@ -919,7 +919,8 @@ fmgr_security_definer(PG_FUNCTION_ARGS)
 	{
 		AtEOXact_GUC(true, pltsql_save_nestlevel);
 	}
-
+	if (fcache->proconfig)
+		AtEOXact_GUC(true, save_nestlevel);
 	if (set_sql_dialect)
 	{
 		sql_dialect = sql_dialect_value_old;
@@ -928,8 +929,6 @@ fmgr_security_definer(PG_FUNCTION_ARGS)
 		if (sql_dialect_value == pg_dialect)
 			non_tsql_proc_entry_hook(non_tsql_proc_count * -1, sys_func_count * -1);
 	}
-	else if (fcache->proconfig)
-		AtEOXact_GUC(true, save_nestlevel);
 	if (OidIsValid(fcache->userid))
 		SetUserIdAndSecContext(save_userid, save_sec_context);
 	if (fmgr_hook && !set_sql_dialect)


### PR DESCRIPTION
### Description

If babelfish is installed the `set_sql_dialect` hook is installed. That means we are never resetting the proconfig values for functions with proconfig.
One major symptom of this is mVU failure when there are other extensions installed which executes a trigger which changes search path as part of proconfig.
 
### Issues Resolved

[BABEL-4982]
 
#### Engine PR: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/382

#### Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2641

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
