### PR TITLE
Disable shared cache invalidation for temp table

### DIFF
--- a/src/backend/access/heap/heapam.c
+++ b/src/backend/access/heap/heapam.c
@@ -2007,7 +2007,7 @@ heap_insert(Relation relation, HeapTuple tup, CommandId cid,
 	 * the heaptup data structure is all in local memory, not in the shared
 	 * buffer.
 	 */
-	CacheInvalidateHeapTuple(relation, heaptup, NULL);
+	CacheInvalidateHeapTuple(relation, heaptup, NULL, false);
 
 	/* Note: speculative insertions are counted too, even if aborted later */
 	pgstat_count_heap_insert(relation, 1);
@@ -2452,7 +2452,7 @@ heap_multi_insert(Relation relation, TupleTableSlot **slots, int ntuples,
 	if (IsCatalogRelation(relation))
 	{
 		for (i = 0; i < ntuples; i++)
-			CacheInvalidateHeapTuple(relation, heaptuples[i], NULL);
+			CacheInvalidateHeapTuple(relation, heaptuples[i], NULL, false);
 	}
 
 	/* copy t_self fields back to the caller's slots */
@@ -2928,7 +2928,7 @@ l1:
 	 * boundary. We have to do this before releasing the buffer because we
 	 * need to look at the contents of the tuple.
 	 */
-	CacheInvalidateHeapTuple(relation, &tp, NULL);
+	CacheInvalidateHeapTuple(relation, &tp, NULL, false);
 
 	/* Now we can release the buffer */
 	ReleaseBuffer(buffer);
@@ -3874,7 +3874,7 @@ l2:
 	 * both tuple versions in one call to inval.c so we can avoid redundant
 	 * sinval messages.)
 	 */
-	CacheInvalidateHeapTuple(relation, &oldtup, heaptup);
+	CacheInvalidateHeapTuple(relation, &oldtup, heaptup, false);
 
 	/* Now we can release the buffer(s) */
 	if (newbuf != buffer)
@@ -6000,7 +6000,7 @@ heap_inplace_update(Relation relation, HeapTuple tuple)
 	 * bothering with index updates either, so that's true a fortiori.
 	 */
 	if (!IsBootstrapProcessingMode())
-		CacheInvalidateHeapTuple(relation, tuple, NULL);
+		CacheInvalidateHeapTuple(relation, tuple, NULL, false);
 }
 
 #define		FRM_NOOP				0x0001

--- a/src/backend/commands/typecmds.c
+++ b/src/backend/commands/typecmds.c
@@ -2920,7 +2920,7 @@ AlterDomainDropConstraint(List *names, const char *constrName,
 	 * dependent plans get rebuilt.  Since this command doesn't change the
 	 * domain's pg_type row, that won't happen automatically; do it manually.
 	 */
-	CacheInvalidateHeapTuple(rel, tup, NULL);
+	CacheInvalidateHeapTuple(rel, tup, NULL, false);
 
 	ObjectAddressSet(address, TypeRelationId, domainoid);
 
@@ -3036,7 +3036,7 @@ AlterDomainAddConstraint(List *names, Node *newConstraint,
 	 * dependent plans get rebuilt.  Since this command doesn't change the
 	 * domain's pg_type row, that won't happen automatically; do it manually.
 	 */
-	CacheInvalidateHeapTuple(typrel, tup, NULL);
+	CacheInvalidateHeapTuple(typrel, tup, NULL, false);
 
 	ObjectAddressSet(address, TypeRelationId, domainoid);
 

--- a/src/backend/utils/cache/inval.c
+++ b/src/backend/utils/cache/inval.c
@@ -907,16 +907,16 @@ xactGetCommittedInvalidationMessages(SharedInvalidationMessage **msgs,
 	/* Must be at top of stack */
 	Assert(transInvalInfo->my_level == 1 && transInvalInfo->parent == NULL);
 
+	/* If we are localOnlyInval, we can skip writing to WAL */
+	if (transInvalInfo->localOnlyInval)
+		return 0;
+
 	/*
 	 * Relcache init file invalidation requires processing both before and
 	 * after we send the SI messages.  However, we need not do anything unless
 	 * we committed.
 	 */
 	*RelcacheInitFileInval = transInvalInfo->RelcacheInitFileInval;
-
-	/* If we are localOnlyInval, we can skip writing to WAL */
-	if (transInvalInfo->localOnlyInval)
-		return 0;
 
 	/*
 	 * Collect all the pending messages into a single contiguous array of

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -1091,7 +1091,7 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 					if (enr->md.is_bbf_temp_table && temp_table_xact_support)
 						ENRAddUncommittedTupleData(enr, catalog_oid, op, newtup, in_enr_rollback);
 					*list_ptr = list_insert_nth(*list_ptr, insert_at, newtup);
-					CacheInvalidateHeapTuple(catalog_rel, newtup, NULL);
+					CacheInvalidateHeapTuple(catalog_rel, newtup, NULL, true);
 					break;
 				case ENR_OP_UPDATE:
 					/*
@@ -1106,14 +1106,14 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 					oldtup = lfirst(lc);
 					if (enr->md.is_bbf_temp_table && temp_table_xact_support)
 						ENRAddUncommittedTupleData(enr, catalog_oid, op, oldtup, in_enr_rollback);
-					CacheInvalidateHeapTuple(catalog_rel, oldtup, tup);
+					CacheInvalidateHeapTuple(catalog_rel, oldtup, tup, true);
 					lfirst(lc) = heap_copytuple(tup);
 					break;
 				case ENR_OP_DROP:
 					if (enr->md.is_bbf_temp_table && temp_table_xact_support)
 						ENRAddUncommittedTupleData(enr, catalog_oid, op, tup, in_enr_rollback);
 					if (!skip_cache_inval)
-						CacheInvalidateHeapTuple(catalog_rel, tup, NULL);
+						CacheInvalidateHeapTuple(catalog_rel, tup, NULL, true);
 					tmp = lfirst(lc);
 					*list_ptr = list_delete_ptr(*list_ptr, tmp);
 					heap_freetuple(tmp);
@@ -1519,7 +1519,7 @@ extern void ENRDropCatalogEntry(Relation catalog_relation, Oid relid)
 				if (temp_table_xact_support)
 					ENRAddUncommittedTupleData(enr, catalog_oid, ENR_OP_DROP, htup, false);
 
-				CacheInvalidateHeapTuple(catalog_relation, htup, NULL);
+				CacheInvalidateHeapTuple(catalog_relation, htup, NULL, true);
 				heap_freetuple(htup); // heap_copytuple was called during ADD
 			}
 

--- a/src/include/utils/inval.h
+++ b/src/include/utils/inval.h
@@ -36,7 +36,8 @@ extern void CommandEndInvalidationMessages(void);
 
 extern void CacheInvalidateHeapTuple(Relation relation,
 									 HeapTuple tuple,
-									 HeapTuple newtuple);
+									 HeapTuple newtuple,
+									 bool isEnr);
 
 extern void CacheInvalidateCatalog(Oid catalogId);
 


### PR DESCRIPTION
### Description

Since we have moved temp table metadata into local memory, we don't need to add cache invalidations to shared memory when they concern temp tables. 

Manual Testing: 

Tracking with `pg_waldump` to see whether any cache inval messages show up in WAL when we create temp tables/manipulate metadata showed none are created. 
 
### Issues Resolved

BABEL-5012

This change is similar to a previous patch from Surendra that we ended up not committing - originally the idea was that it might improve performance and we didn't end up finding a significant improvement in performance. Turns out we need the change for proper concurrency support with temp tables. The only difference is that we also exclude those inval messages from going into WAL 
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
