### PR TITLE
Fix memory leak in remove_queryEnv

### DIFF
--- a/src/backend/utils/activity/pgstat_relation.c
+++ b/src/backend/utils/activity/pgstat_relation.c
@@ -26,6 +26,7 @@
 #include "utils/rel.h"
 #include "utils/timestamp.h"
 #include "catalog/catalog.h"
+#include "utils/guc.h"
 
 #include "parser/parser.h"
 #include "utils/queryenvironment.h"
@@ -173,7 +174,7 @@ void
 pgstat_create_relation(Relation rel)
 {
 	/* Skip pg_stat */
-	if (sql_dialect == SQL_DIALECT_TSQL && rel->rd_rel->relpersistence == RELPERSISTENCE_TEMP)
+	if (sql_dialect == SQL_DIALECT_TSQL && rel->rd_rel->relpersistence == RELPERSISTENCE_TEMP && temp_oid_buffer_size > 0)
 		return;
 	pgstat_create_transactional(PGSTAT_KIND_RELATION,
 								rel->rd_rel->relisshared ? InvalidOid : MyDatabaseId,
@@ -189,7 +190,7 @@ pgstat_drop_relation(Relation rel)
 	int			nest_level = GetCurrentTransactionNestLevel();
 	PgStat_TableStatus *pgstat_info;
 
-	if (sql_dialect == SQL_DIALECT_TSQL && rel->rd_rel->relpersistence == RELPERSISTENCE_TEMP)
+	if (sql_dialect == SQL_DIALECT_TSQL && rel->rd_rel->relpersistence == RELPERSISTENCE_TEMP && temp_oid_buffer_size > 0)
 		return;
 	pgstat_drop_transactional(PGSTAT_KIND_RELATION,
 							  rel->rd_rel->relisshared ? InvalidOid : MyDatabaseId,

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -102,6 +102,7 @@ create_queryEnv2(MemoryContext cxt, bool top_level)
 void remove_queryEnv() {
 	MemoryContext			oldcxt;
 	QueryEnvironment		*tmp;
+	ListCell *lc;
 
 	/* We should never "free" top level query env as it's in stack memory. */
 	if (!currentQueryEnv || currentQueryEnv == topLevelQueryEnv)
@@ -109,6 +110,45 @@ void remove_queryEnv() {
 
 	tmp = currentQueryEnv->parentEnv;
 	oldcxt = MemoryContextSwitchTo(currentQueryEnv->memctx);
+
+	/* Clean up structures in currentQueryEnv */
+	foreach(lc, currentQueryEnv->dropped_namedRelList)
+	{
+		EphemeralNamedRelation enr = (EphemeralNamedRelation) lfirst(lc);
+
+		for (int i = 0; i < ENR_CATTUP_END; i++)
+		{
+			List *uncommitted_cattups = enr->md.uncommitted_cattups[i];
+			ListCell *lc2;
+
+			foreach(lc2, uncommitted_cattups)
+			{
+				ENRUncommittedTuple uncommitted_tup = (ENRUncommittedTuple) lfirst(lc2);
+
+				heap_freetuple(uncommitted_tup->tup);
+			}
+		}
+
+		for (int i = 0; i < ENR_CATTUP_END; i++)
+		{
+			List *cattups = enr->md.cattups[i];
+			ListCell *lc2;
+
+			foreach(lc2, cattups)
+			{
+				HeapTuple tup = (HeapTuple) lfirst(lc2);
+
+				heap_freetuple(tup);
+			}
+		}
+
+		pfree(enr->md.name);
+		pfree(enr);
+	}
+
+	list_free(currentQueryEnv->dropped_namedRelList);
+	currentQueryEnv->dropped_namedRelList = NIL;
+
 	pfree(currentQueryEnv);
 	MemoryContextSwitchTo(oldcxt);
 


### PR DESCRIPTION
### Description

In remove_queryEnv we need to also free any tuples that have been created via `heap_copyTuple` in ENRs. Otherwise they will leak memory until the connection is closed. 

Clean test run here: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2669

I tested this by cherry-picking to GitFarm and replacing the binaries on a mammoth instance, which showed significant memory usage improvement on the same test that Kristian ran during validation.
 
### Issues Resolved

BABEL-5033
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
