### PR TITLE
[OSS-ONLY] Bump BabelfishDump RPM release

### DIFF
--- a/BabelfishDump.spec
+++ b/BabelfishDump.spec
@@ -20,14 +20,14 @@
 %global macrosdir %(d=%{_rpmconfigdir}/macros.d; [ -d $d ] || d=%{_sysconfdir}/rpm; echo $d)
 
 %define _trivial .0
-%define _buildid .2
+%define _buildid .1
 
 %undefine _missing_build_ids_terminate_build
 
 Name: BabelfishDump
 Summary: Postgresql dump utilities modified for Babelfish
 Version: 16.3
-Release: 1%{?dist}%{?_trivial}%{?_buildid}
+Release: 2%{?dist}%{?_trivial}%{?_buildid}
 License: PostgreSQL
 Url: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish
 

--- a/BabelfishDump.spec
+++ b/BabelfishDump.spec
@@ -20,7 +20,7 @@
 %global macrosdir %(d=%{_rpmconfigdir}/macros.d; [ -d $d ] || d=%{_sysconfdir}/rpm; echo $d)
 
 %define _trivial .0
-%define _buildid .1
+%define _buildid .2
 
 %undefine _missing_build_ids_terminate_build
 
@@ -151,6 +151,9 @@ LD_LIBRARY_PATH=%{_builddir}/%{name}/src/interfaces/libpq $RPM_BUILD_ROOT/usr/bi
 %{_bindir}/bbf_dumpall
 
 %changelog
+* Mon Jun 17 2024 Rishabh Tanwar <ritanwar@amazon.com> - 16.3-2
+- Improve catalog handling in bbf_dump
+
 * Mon May 20 2024 Rishabh Tanwar <ritanwar@amazon.com> - 16.3-1
 - Update bug report and documentation links for BabelfishDump
 


### PR DESCRIPTION
### Description
Bump BabelfishDump RPM release to 16.3-2 which contains fix
for backward compatibility issue.
 
Task: OSS-ONLY
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>

### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
