### PR TITLE
Improve catalog handling in bbf_dump (#385)

### DIFF
--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -29,7 +29,6 @@ extern bool isBabelfishConfigTable(Archive *fout, TableInfo *tbinfo);
 extern void fixOprRegProc(Archive *fout, const OprInfo *oprinfo, const char *oprleft, const char *oprright, char **oprregproc);
 extern void fixTsqlTableTypeDependency(Archive *fout, DumpableObject *func, DumpableObject *tabletype, char deptype);
 extern bool isTsqlTableType(Archive *fout, const TableInfo *tbinfo);
-extern int getTsqlTvfType(Archive *fout, const FuncInfo *finfo, char prokind, bool proretset);
 extern void fixAttoptionsBbfOriginalName(Archive *fout, Oid relOid, const TableInfo *tbinfo, int idx);
 extern void setOrResetPltsqlFuncRestoreGUCs(Archive *fout, PQExpBuffer q, const FuncInfo *finfo, char prokind, bool proretset, bool is_set);
 extern void dumpBabelfishSpecificConfig(Archive *AH, const char *dbname, PQExpBuffer outbuf);


### PR DESCRIPTION
### Description
Updated setBabelfishDependenciesForLogicalDatabaseDump to optionally set dependencies only when the catalog table exists, avoiding issues with asserting the number of tables when dumping older versions to preserve the backward compatibility. Refactored the code to enhance dump performance.

Task: BABEL-5029
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>

Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2671
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
