### PR TITLE
Fix memory leak in remove_queryEnv

### DIFF
--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -97,6 +97,33 @@ create_queryEnv2(MemoryContext cxt, bool top_level)
 	return queryEnv;
 }
 
+/* Loop through structures in the ENR and make sure to free anything that needs to be freed. */
+static void free_ENR(EphemeralNamedRelation enr)
+{
+	for (int i = 0; i < ENR_CATTUP_END; i++)
+	{
+		List *uncommitted_cattups = enr->md.uncommitted_cattups[i];
+		List *cattups = enr->md.cattups[i];
+		ListCell *lc2, *lc3;
+
+		foreach(lc2, uncommitted_cattups)
+		{
+			ENRUncommittedTuple uncommitted_tup = (ENRUncommittedTuple) lfirst(lc2);
+
+			heap_freetuple(uncommitted_tup->tup);
+		}
+
+		foreach(lc3, cattups)
+		{
+			HeapTuple tup = (HeapTuple) lfirst(lc3);
+
+			heap_freetuple(tup);
+		}
+	}
+
+	pfree(enr->md.name);
+}
+
 /* Remove the current query environment and make its parent current. */
 void remove_queryEnv() {
 	MemoryContext			oldcxt;
@@ -114,34 +141,7 @@ void remove_queryEnv() {
 	foreach(lc, currentQueryEnv->dropped_namedRelList)
 	{
 		EphemeralNamedRelation enr = (EphemeralNamedRelation) lfirst(lc);
-
-		for (int i = 0; i < ENR_CATTUP_END; i++)
-		{
-			List *uncommitted_cattups = enr->md.uncommitted_cattups[i];
-			ListCell *lc2;
-
-			foreach(lc2, uncommitted_cattups)
-			{
-				ENRUncommittedTuple uncommitted_tup = (ENRUncommittedTuple) lfirst(lc2);
-
-				heap_freetuple(uncommitted_tup->tup);
-			}
-		}
-
-		for (int i = 0; i < ENR_CATTUP_END; i++)
-		{
-			List *cattups = enr->md.cattups[i];
-			ListCell *lc2;
-
-			foreach(lc2, cattups)
-			{
-				HeapTuple tup = (HeapTuple) lfirst(lc2);
-
-				heap_freetuple(tup);
-			}
-		}
-
-		pfree(enr->md.name);
+		free_ENR(enr);
 		pfree(enr);
 	}
 
@@ -1146,7 +1146,7 @@ void ENRDropEntry(Oid id)
 	}
 	else
 	{
-		pfree(enr->md.name);
+		free_ENR(enr);
 		pfree(enr);
 	}
 	MemoryContextSwitchTo(oldcxt);
@@ -1186,7 +1186,7 @@ ENRCommitChanges(QueryEnvironment *queryEnv)
 	{
 		EphemeralNamedRelation enr = (EphemeralNamedRelation) lfirst(lc);
 
-		pfree(enr->md.name);
+		free_ENR(enr);
 		pfree(enr);
 	}
 
@@ -1317,7 +1317,7 @@ ENRRollbackChanges(QueryEnvironment *queryEnv)
 	{
 		EphemeralNamedRelation enr = (EphemeralNamedRelation) lfirst(lc);
 		queryEnv->namedRelList = list_delete(queryEnv->namedRelList, enr);
-		pfree(enr->md.name);
+		free_ENR(enr);
 		pfree(enr);
 	}
 	MemoryContextSwitchTo(oldcxt);


### PR DESCRIPTION
### Description

In remove_queryEnv we need to also free any tuples that have been created via `heap_copyTuple` in ENRs. Otherwise they will leak memory until the connection is closed. 

#387 - 4x PR
 
### Issues Resolved

BABEL-5033
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
