### PR TITLE
Fix memory leak in remove_queryEnv

### DIFF
--- a/src/backend/utils/activity/pgstat_relation.c
+++ b/src/backend/utils/activity/pgstat_relation.c
@@ -26,6 +26,7 @@
 #include "utils/rel.h"
 #include "utils/timestamp.h"
 #include "catalog/catalog.h"
+#include "utils/guc.h"
 
 #include "parser/parser.h"
 #include "utils/queryenvironment.h"
@@ -173,7 +174,7 @@ void
 pgstat_create_relation(Relation rel)
 {
 	/* Skip pg_stat */
-	if (sql_dialect == SQL_DIALECT_TSQL && rel->rd_rel->relpersistence == RELPERSISTENCE_TEMP)
+	if (sql_dialect == SQL_DIALECT_TSQL && rel->rd_rel->relpersistence == RELPERSISTENCE_TEMP && temp_oid_buffer_size > 0)
 		return;
 	pgstat_create_transactional(PGSTAT_KIND_RELATION,
 								rel->rd_rel->relisshared ? InvalidOid : MyDatabaseId,
@@ -189,7 +190,7 @@ pgstat_drop_relation(Relation rel)
 	int			nest_level = GetCurrentTransactionNestLevel();
 	PgStat_TableStatus *pgstat_info;
 
-	if (sql_dialect == SQL_DIALECT_TSQL && rel->rd_rel->relpersistence == RELPERSISTENCE_TEMP)
+	if (sql_dialect == SQL_DIALECT_TSQL && rel->rd_rel->relpersistence == RELPERSISTENCE_TEMP && temp_oid_buffer_size > 0)
 		return;
 	pgstat_drop_transactional(PGSTAT_KIND_RELATION,
 							  rel->rd_rel->relisshared ? InvalidOid : MyDatabaseId,

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -98,10 +98,38 @@ create_queryEnv2(MemoryContext cxt, bool top_level)
 	return queryEnv;
 }
 
+/* Loop through structures in the ENR and make sure to free anything that needs to be freed. */
+static void free_ENR(EphemeralNamedRelation enr)
+{
+	for (int i = 0; i < ENR_CATTUP_END; i++)
+	{
+		List *uncommitted_cattups = enr->md.uncommitted_cattups[i];
+		List *cattups = enr->md.cattups[i];
+		ListCell *lc2, *lc3;
+
+		foreach(lc2, uncommitted_cattups)
+		{
+			ENRUncommittedTuple uncommitted_tup = (ENRUncommittedTuple) lfirst(lc2);
+
+			heap_freetuple(uncommitted_tup->tup);
+		}
+
+		foreach(lc3, cattups)
+		{
+			HeapTuple tup = (HeapTuple) lfirst(lc3);
+
+			heap_freetuple(tup);
+		}
+	}
+
+	pfree(enr->md.name);
+}
+
 /* Remove the current query environment and make its parent current. */
 void remove_queryEnv() {
 	MemoryContext			oldcxt;
 	QueryEnvironment		*tmp;
+	ListCell *lc;
 
 	/* We should never "free" top level query env as it's in stack memory. */
 	if (!currentQueryEnv || currentQueryEnv == topLevelQueryEnv)
@@ -109,6 +137,18 @@ void remove_queryEnv() {
 
 	tmp = currentQueryEnv->parentEnv;
 	oldcxt = MemoryContextSwitchTo(currentQueryEnv->memctx);
+
+	/* Clean up structures in currentQueryEnv */
+	foreach(lc, currentQueryEnv->dropped_namedRelList)
+	{
+		EphemeralNamedRelation enr = (EphemeralNamedRelation) lfirst(lc);
+		free_ENR(enr);
+		pfree(enr);
+	}
+
+	list_free(currentQueryEnv->dropped_namedRelList);
+	currentQueryEnv->dropped_namedRelList = NIL;
+
 	pfree(currentQueryEnv);
 	MemoryContextSwitchTo(oldcxt);
 
@@ -1144,7 +1184,7 @@ void ENRDropEntry(Oid id)
 	}
 	else
 	{
-		pfree(enr->md.name);
+		free_ENR(enr);
 		pfree(enr);
 	}
 	MemoryContextSwitchTo(oldcxt);
@@ -1184,7 +1224,7 @@ ENRCommitChanges(QueryEnvironment *queryEnv)
 	{
 		EphemeralNamedRelation enr = (EphemeralNamedRelation) lfirst(lc);
 
-		pfree(enr->md.name);
+		free_ENR(enr);
 		pfree(enr);
 	}
 
@@ -1315,7 +1355,7 @@ ENRRollbackChanges(QueryEnvironment *queryEnv)
 	{
 		EphemeralNamedRelation enr = (EphemeralNamedRelation) lfirst(lc);
 		queryEnv->namedRelList = list_delete(queryEnv->namedRelList, enr);
-		pfree(enr->md.name);
+		free_ENR(enr);
 		pfree(enr);
 	}
 	MemoryContextSwitchTo(oldcxt);


### PR DESCRIPTION
### Description

In remove_queryEnv we need to also free any tuples that have been created via `heap_copyTuple` in ENRs. Otherwise they will leak memory until the connection is closed. 

#387 orig pr
 
### Issues Resolved

BABEL-5033
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
