### PR TITLE
Include ordering for constraints on babelfish tables

### DIFF
--- a/src/backend/parser/parse_utilcmd.c
+++ b/src/backend/parser/parse_utilcmd.c
@@ -61,6 +61,7 @@
 #include "rewrite/rewriteManip.h"
 #include "utils/acl.h"
 #include "utils/builtins.h"
+#include "utils/guc.h"
 #include "utils/lsyscache.h"
 #include "utils/partcache.h"
 #include "utils/rel.h"
@@ -2246,6 +2247,7 @@ transformIndexConstraint(Constraint *constraint, CreateStmtContext *cxt)
 		oidvector  *indclass;
 		Datum		indclassDatum;
 		int			i;
+		const char *bbf_dump_restore = GetConfigOption("babelfishpg_tsql.dump_restore", true, false);
 
 		/* Grammar should not allow this with explicit column list */
 		Assert(constraint->keys == NIL);
@@ -2384,10 +2386,11 @@ transformIndexConstraint(Constraint *constraint, CreateStmtContext *cxt)
 
 				defopclass = GetDefaultOpClass(attform->atttypid,
 											   index_rel->rd_rel->relam);
-				if (indclass->values[i] != defopclass ||
+				if ((indclass->values[i] != defopclass ||
 					attform->attcollation != index_rel->rd_indcollation[i] ||
 					attoptions != (Datum) 0 ||
-					index_rel->rd_indoption[i] != 0)
+					index_rel->rd_indoption[i] != 0) &&
+					(!bbf_dump_restore || strcmp(bbf_dump_restore, "on") != 0)) /* The dump/reload problem has been fixed for babelfish database */
 					ereport(ERROR,
 							(errcode(ERRCODE_WRONG_OBJECT_TYPE),
 							 errmsg("index \"%s\" column number %d does not have default sorting behavior", index_name, i + 1),

--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -464,6 +464,21 @@ bbf_selectDumpableObject(DumpableObject *dobj, Archive *fout)
 					finfo->dobj.dump = DUMP_COMPONENT_NONE;
 			}
 			break;
+		case DO_CONSTRAINT:
+			{
+				ConstraintInfo *constrinfo = (ConstraintInfo *) dobj;
+
+				/*
+				 * Do not dump UNIQUE/PRIMARY KEY constraint. We will dump the underlying
+				 * index and create the constraint using that index instead.
+				 * This is needed since in babelfish, a UNIQUE/PRIMARY KEY constraint can be
+				 * created with column and nulls ordering which is not possible using normal
+				 * ALTER TABLE ADD CONSTRAINT statement.
+				 */
+				if (constrinfo->contype == 'p' || constrinfo->contype == 'u')
+					constrinfo->dobj.dump = DUMP_COMPONENT_NONE;
+			}
+			break;
 		default:
 			break;
 	}

--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -1884,7 +1884,7 @@ bbfShouldDumpIndex(Archive *fout, const IndxInfo *indxinfo)
 {
 	ConstraintInfo *constrinfo = NULL;
 
-	if (!isBabelfishDatabase(fout) || ndxinfo->indexconstraint == 0)
+	if (!isBabelfishDatabase(fout) || indxinfo->indexconstraint == 0)
 		return false;
 
 	constrinfo = (ConstraintInfo *) findObjectByDumpId(indxinfo->indexconstraint);

--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -53,7 +53,7 @@ extern void castSqlvariantToBasetype(PGresult *res,
                                     int sqlvariant_pos);
 extern void dumpBabelRestoreChecks(Archive *fout);
 extern void babelfishDumpOpclassHelper(Archive *fout, const OpclassInfo *opcinfo, PQExpBuffer buff, bool *needComma);
-extern bool bbfShouldDumpIndex(Archive *fout, const IndxInfo *indxinfo, bool *is_constraint);
+extern bool bbfShouldDumpIndex(Archive *fout, const IndxInfo *indxinfo);
 extern void dumpBabelfishConstrIndex(Archive *fout, const IndxInfo *indxinfo,
                                      PQExpBuffer q, PQExpBuffer delq);
 

--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -53,5 +53,8 @@ extern void castSqlvariantToBasetype(PGresult *res,
                                     int sqlvariant_pos);
 extern void dumpBabelRestoreChecks(Archive *fout);
 extern void babelfishDumpOpclassHelper(Archive *fout, const OpclassInfo *opcinfo, PQExpBuffer buff, bool *needComma);
+extern bool bbfShouldDumpIndex(Archive *fout, const IndxInfo *indxinfo, bool *is_constraint);
+extern void dumpBabelfishConstrIndex(Archive *fout, const IndxInfo *indxinfo,
+                                     PQExpBuffer q, PQExpBuffer delq);
 
 #endif

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -16552,7 +16552,7 @@ dumpIndex(Archive *fout, const IndxInfo *indxinfo)
 	 * emitted comment has to be shown as depending on the constraint, not the
 	 * index, in such cases.
 	 */
-	if (!is_constraint || bbfShouldDumpIndex(fout, indxinfo, &is_constraint))
+	if (!is_constraint || bbfShouldDumpIndex(fout, indxinfo))
 	{
 		char	   *indstatcols = indxinfo->indstatcols;
 		char	   *indstatvals = indxinfo->indstatvals;
@@ -16631,6 +16631,7 @@ dumpIndex(Archive *fout, const IndxInfo *indxinfo)
 
 		appendPQExpBuffer(delq, "DROP INDEX %s;\n", qqindxname);
 
+		is_constraint = false;
 		dumpBabelfishConstrIndex(fout, indxinfo, q, delq);
 
 		if (indxinfo->dobj.dump & DUMP_COMPONENT_DEFINITION)

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -7333,6 +7333,8 @@ getIndexes(Archive *fout, TableInfo tblinfo[], int numTables)
 				constrinfo->separate = true;
 
 				indxinfo[j].indexconstraint = constrinfo->dobj.dumpId;
+
+				bbf_selectDumpableObject((DumpableObject *) constrinfo, fout);
 			}
 			else
 			{
@@ -16550,7 +16552,7 @@ dumpIndex(Archive *fout, const IndxInfo *indxinfo)
 	 * emitted comment has to be shown as depending on the constraint, not the
 	 * index, in such cases.
 	 */
-	if (!is_constraint)
+	if (!is_constraint || bbfShouldDumpIndex(fout, indxinfo, &is_constraint))
 	{
 		char	   *indstatcols = indxinfo->indstatcols;
 		char	   *indstatvals = indxinfo->indstatvals;
@@ -16628,6 +16630,8 @@ dumpIndex(Archive *fout, const IndxInfo *indxinfo)
 		}
 
 		appendPQExpBuffer(delq, "DROP INDEX %s;\n", qqindxname);
+
+		dumpBabelfishConstrIndex(fout, indxinfo, q, delq);
 
 		if (indxinfo->dobj.dump & DUMP_COMPONENT_DEFINITION)
 			ArchiveEntry(fout, indxinfo->dobj.catId, indxinfo->dobj.dumpId,


### PR DESCRIPTION
### Description
Babelfish supports column ordering and NULLs ordering in table constraints but PG
does not. It was implemented through special grammar rule and few dialect T-SQL dialect
dependent logic in engine. Currently this is not handled in pg_dump so the information
about column/nulls ordering gets lost during dump. Although, this information is available
in the underlying index for a UNIQUE/PRIMARY KEY constraint but this information anyway
gets lost since the underlying index does not get dumped for a UNIQUE/PRIMARY KEY constraint,
instead it is dumped as a constraint.

To fix this issue, we will now dump the underlying index of a UNIQUE/PRIMARY KEY constraint
and make use of ALTER TABLE ADD CONSTRAINT USING snytax to add that as constraint.
Postgres disallows creation of an constraint using index like this for non default sort ordering as
native pg_dump does not handle such constraints. So we will need to bypass that check for
Babelfish dump/restore with this special handling in bbf_dump.

Task: BABEL-4888
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>

Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2688
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
