### PR TITLE
Fix crash due to uninitialized rte->relid in temp table with trigger

### DIFF
--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -2522,6 +2522,7 @@ addRangeTableEntryForENR(ParseState *pstate,
 		case ENR_TSQL_TEMP:
 			rte->inh = rv->inh;
 			rte->rtekind = RTE_RELATION;
+			rte->relid = enrmd->reliddesc;
 			rte->rellockmode = isLockedRefname(pstate, refname) ? RowShareLock : AccessShareLock;
 			perminfo = addRTEPermissionInfo(&pstate->p_rteperminfos, rte);
 			perminfo->requiredPerms = ACL_SELECT;


### PR DESCRIPTION
### Description

Fixing a crash in temp tables with trigger. `rte->relid` was uninitialized in `addRangeTableEntryForENR` when dealing with TSQL temp tables, causing an assert to fail. 
 
### Issues Resolved

BABEL-5071
BABEL-4992
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
