### PR TITLE
Restrict dropping of specific extended stored procedures

### DIFF
--- a/src/include/commands/defrem.h
+++ b/src/include/commands/defrem.h
@@ -78,8 +78,10 @@ extern void interpret_function_parameter_list(ParseState *pstate,
 
 typedef bool (*check_lang_as_clause_hook_type)(const char *lang, List *as, char **prosrc_str_p, char **probin_str_p);
 typedef void (*write_stored_proc_probin_hook_type)(CreateFunctionStmt *stmt, Oid languageOid, char** probin_str_p);
+typedef void (*check_restricted_stored_procedure_hook_type)(Oid proc_id);
 extern PGDLLEXPORT check_lang_as_clause_hook_type check_lang_as_clause_hook;
 extern PGDLLEXPORT write_stored_proc_probin_hook_type write_stored_proc_probin_hook;
+extern PGDLLEXPORT check_restricted_stored_procedure_hook_type check_restricted_stored_procedure_hook;
 
 /* commands/operatorcmds.c */
 extern ObjectAddress DefineOperator(List *names, List *parameters);


### PR DESCRIPTION
### Description
This commit adds a check to prevent dropping of specific extended stored procedures:
- xp_qv
- xp_instance_regread
- sp_addlinkedsrvlogin
- sp_droplinkedsrvlogin
- sp_dropserver
- sp_enum_oledb_providers
- sp_testlinkedserver

These procedures are critical and should not be dropped accidentally.

Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2708
 
### Issues Resolved

Task: BABEL-5080, BABEL-4390
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
