### PR TITLE
Include ordering for constraints on babelfish tables (#395)

### DIFF
--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -53,5 +53,8 @@ extern void castSqlvariantToBasetype(PGresult *res,
                                     int sqlvariant_pos);
 extern void dumpBabelRestoreChecks(Archive *fout);
 extern void babelfishDumpOpclassHelper(Archive *fout, const OpclassInfo *opcinfo, PQExpBuffer buff, bool *needComma);
+extern bool bbfShouldDumpIndex(Archive *fout, const IndxInfo *indxinfo);
+extern void dumpBabelfishConstrIndex(Archive *fout, const IndxInfo *indxinfo,
+                                     PQExpBuffer q, PQExpBuffer delq);
 
 #endif

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -7160,6 +7160,8 @@ getIndexes(Archive *fout, TableInfo tblinfo[], int numTables)
 				constrinfo->separate = true;
 
 				indxinfo[j].indexconstraint = constrinfo->dobj.dumpId;
+
+				bbf_selectDumpableObject((DumpableObject *) constrinfo, fout);
 			}
 			else
 			{
@@ -16373,7 +16375,7 @@ dumpIndex(Archive *fout, const IndxInfo *indxinfo)
 	 * emitted comment has to be shown as depending on the constraint, not the
 	 * index, in such cases.
 	 */
-	if (!is_constraint)
+	if (!is_constraint || bbfShouldDumpIndex(fout, indxinfo))
 	{
 		char	   *indstatcols = indxinfo->indstatcols;
 		char	   *indstatvals = indxinfo->indstatvals;
@@ -16451,6 +16453,9 @@ dumpIndex(Archive *fout, const IndxInfo *indxinfo)
 		}
 
 		appendPQExpBuffer(delq, "DROP INDEX %s;\n", qqindxname);
+
+		is_constraint = false;
+		dumpBabelfishConstrIndex(fout, indxinfo, q, delq);
 
 		if (indxinfo->dobj.dump & DUMP_COMPONENT_DEFINITION)
 			ArchiveEntry(fout, indxinfo->dobj.catId, indxinfo->dobj.dumpId,


### PR DESCRIPTION
### Description
Babelfish supports column ordering and NULLs ordering in table constraints but PG does not. It was implemented through special grammar rule and few dialect T-SQL dialect dependent logic in engine. Currently this is not handled in pg_dump so the information about column/nulls ordering gets lost during dump. Although, this information is available in the underlying index for a UNIQUE/PRIMARY KEY constraint but this information anyway gets lost since the underlying index does not get dumped for a UNIQUE/PRIMARY KEY constraint, instead it is dumped as a constraint.

To fix this issue, we will now dump the underlying index of a UNIQUE/PRIMARY KEY constraint and make use of ALTER TABLE ADD CONSTRAINT USING snytax to add that as constraint. Postgres disallows creation of an constraint using index like this for non default sort ordering as native pg_dump does not handle such constraints. So we will need to bypass that check for Babelfish dump/restore with this special handling in bbf_dump.

Task: BABEL-4888
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>

Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2718
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
