### PR TITLE
Fix engine crash in tsql_openjson_with_get_subjsonb

### DIFF
--- a/src/backend/utils/adt/jsonpath_exec.c
+++ b/src/backend/utils/adt/jsonpath_exec.c
@@ -486,8 +486,17 @@ tsql_openjson_with_get_subjsonb(PG_FUNCTION_ARGS)
 	vars = (Jsonb *) DirectFunctionCall1(jsonb_in, CStringGetDatum("{}"));
 	(void) executeJsonPath(jp, vars, jb, false, &found, false);
 
-	if (JsonValueListLength(&found) >= 1)
-		sub_jb = JsonbValueToJsonb(JsonValueListHead(&found));
+	if (JsonValueListLength(&found) >= 1) {
+		JsonbValue *jv = JsonValueListHead(&found);
+		/*
+		 * List may contain NULL values
+		 * Need to check before passing to JsonbValueToJsonb
+		 */
+		if(jv)
+			sub_jb = JsonbValueToJsonb(jv);
+		else
+			sub_jb = (Jsonb *) DirectFunctionCall1(jsonb_in, CStringGetDatum("null"));
+	}
 	else
 		sub_jb = (Jsonb *) DirectFunctionCall1(jsonb_in, CStringGetDatum("null"));
 
@@ -526,24 +535,39 @@ tsql_openjson_with_columnize(Jsonb *jb, char *col_info)
 			asjson;
 	col_path = NULL; col_type = NULL; strict = false; as = false; asjson = false;
 	token = strtok(col_info, " ");
+
+	if (strncasecmp(token, "strict", 6) == 0)
+	{
+		strict = true;
+		if(strlen(token) == 6)
+			token = strtok(NULL, " ");
+		else
+			token = token + 6;
+	}
+	else if (strncasecmp(token, "lax", 3) == 0)
+	{
+		strict = false;
+		if(strlen(token) == 3)
+			token = strtok(NULL, " ");
+		else
+			token = token + 3;
+	}
+
 	while (token != NULL)
 	{
-		if (strncmp(token, "strict", 6) == 0)
-			strict = true;
-		else if (strncmp(token, "lax", 3) == 0)
-			strict = false;
-		else if (col_path == NULL)
+		if (col_path == NULL)
 			col_path = token;
 		else if (col_type == NULL)
 			col_type = token;
-		else if (strncmp(token, "AS", 2) == 0)
+		else if (strncasecmp(token, "AS", 2) == 0)
 			as = true;
-		else if (as && strncmp(token, "JSON", 4) == 0)
+		else if (as && strncasecmp(token, "JSON", 4) == 0)
 			asjson = true;
 		token = strtok(NULL, " ");
 	}
 
-	if (strlen(col_type) >= 3) /* Get column size restriction, if it exists */
+	/* Get column size restriction, if it exists */
+	if (col_type && strlen(col_type) >= 3)
 	{
 		token = strtok(col_type, "(");
 		if (token)
@@ -577,6 +601,14 @@ tsql_openjson_with_columnize(Jsonb *jb, char *col_info)
 
 	/* get tuple set using executeJsonPath */
 	jp = DatumGetJsonPathP(DirectFunctionCall1(jsonpath_in, CStringGetDatum(col_path)));
+
+	/*
+	 * In case where there is no space between 'strict/lax' and the column path
+	 * jsonpath_in will automatically set the header to strict. We need to change
+	 * the header to prevent unintended 'strict' calls to openjson
+	 */
+	if(!strict)
+		jp->header |= JSONPATH_LAX;
 
 	(void) executeJsonPath(jp, vars, jb, false, &found, false);
 
@@ -872,10 +904,12 @@ executeItemOptUnwrapTarget(JsonPathExecContext *cxt, JsonPathItem *jsp,
 						found->list = list_make2(found->singleton, NULL);
 						found->singleton = NULL;
 					}
-					else if (!found->list)
-						found->list = list_make1(NULL); /* Since JsonValueList uses a NULL singleton as shortcut, need to manually insert null value into list */
-					else
+					else if (found->list)
 						found->list = lappend(found->list, NULL);
+					else {
+						/* Since JsonValueList uses a NULL singleton as shortcut, need to manually insert null value into list */
+						found->list = list_make1(NULL);
+					}
 					res = jperOk;
 				}
 			}


### PR DESCRIPTION
### Description
This change resolves two engine crashes in `tsql_openjson_with_get_subjsonb`. The first crash was related to the way that `strict` and `lax` modes were handled in openjson column paths. In the case where a user did not put a space between `strict/lax` and the column name, it would cause the column type to be left NULL, resulting in a NULL entry into strlen and a crash. This change handles strict/lax modes properly, and adds a null check for column type to prevent crashes. The second crash was caused by a null value being passed into a json result list. In cases where a given json path did not exist, we would represent this by create a list of one null element. This element would be passed into the `JsonbValueToJsonb` function and result in crash. This commit removes the null entry from the list to prevent this crash from happening. 
 
### Issues Resolved
BABEL-3820
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
