### PR TITLE
Pop error context stack when string literal hook returns not null node

### DIFF
--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -330,12 +330,13 @@ coerce_type(ParseState *pstate, Node *node,
 			/*
 			 * T-SQL has different rules for string literal datatype coercions
 			 */
-			result = (*coerce_string_literal_hook) (&pcbstate, targetTypeId,
+			result = (*coerce_string_literal_hook) (targetTypeId,
 												  targetTypeMod, baseTypeMod,
 												  newcon, DatumGetCString(con->constvalue),
 												  ccontext, cformat, location);
 			if (result)
 			{
+				cancel_parser_errposition_callback(&pcbstate);
 				ReleaseSysCache(baseType);
 				return result;
 			}

--- a/src/include/parser/parse_coerce.h
+++ b/src/include/parser/parse_coerce.h
@@ -114,8 +114,7 @@ typedef bool (*determine_datatype_precedence_hook_type) (Oid typeId1, Oid typeId
 /*
  * T-SQL has different rules for string literal datatype coercions
  */
-typedef Node *(*coerce_string_literal_hook_type) (ParseCallbackState *pcbstate,
-												  Oid targetTypeId,
+typedef Node *(*coerce_string_literal_hook_type) (Oid targetTypeId,
 												  int32 targetTypeMod,
 												  int32 baseTypeMod,
 												  Const *newcon,


### PR DESCRIPTION
### Description

In coerce_type function the parser error callback is [set as an error context callback](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/86f9c45d263a1da7ad16a7b60620452016410743/src/backend/parser/parse_coerce.c#L316) before calling coerce_string_literal_hook. When this hook return non null Node, then [early return](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/86f9c45d263a1da7ad16a7b60620452016410743/src/backend/parser/parse_coerce.c#L340) from this function happens. Error context is not restored in this case, parser error callback remains in error context stack and is overwritten by subsequent routines. This can cause crashes if error needs to be reported and context stack callbacks are called from error reporting code.

It is not clear whether it makes sense to add a crash snippet from the issue below to the extension test suite. If it is necessary, please advise whether to put it into existing test or create a new one.
 
### Cherry Picked From: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/397

### Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2735

### Issues Resolved

https://github.com/babelfish-for-postgresql/babelfish_extensions/issues/2693
 
### Sign Off

Author: Alex Kasko [alex@staticlibs.net](mailto:alex@staticlibs.net)
Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
