### PR TITLE
Add pg_attrdef to ENR for BBF table variables and temp tables

### DIFF
--- a/src/include/utils/queryenvironment.h
+++ b/src/include/utils/queryenvironment.h
@@ -41,7 +41,8 @@ typedef enum ENRCatalogTupleType
 	ENR_CATTUP_SHDEPEND,
 	ENR_CATTUP_INDEX,
 	ENR_CATTUP_SEQUENCE,
-	ENR_CATTUP_END
+	ENR_CATTUP_ATTR_DEF_REL,
+	ENR_CATTUP_END,
 } ENRCatalogTupleType;
 
 typedef enum ENRTupleOperationType


### PR DESCRIPTION
Table Variables and Temp Tables can have identity columns which adds entries to pg_attrdef. If the table is in ENR, then pg_attrdef entry should also be in ENR otherwise we would have catalog inconsistency.

Task: BABEL-4752

### Description

[Describe what this change achieves]
 
### Issues Resolved

[List any issues this PR will resolve]
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
