### PR TITLE
Fix error when trying to drop columns from temp tables.

### DIFF
--- a/src/backend/catalog/dependency.c
+++ b/src/backend/catalog/dependency.c
@@ -1383,8 +1383,14 @@ deleteOneObject(const ObjectAddress *object, Relation *depRel, int flags)
 	DeleteSecurityLabel(object);
 	DeleteInitPrivs(object);
 
-	// Delete from ENR - noop if not found from ENR
-	ENRDropEntry(object->objectId);
+	/*
+	 * If objectSubId != 0, then this is a column. There are no ENR entries
+	 * for individual columns, so skip ENRDropEntry in this case (or else we
+	 * will delete the entire table instead of just the column). Note that this
+	 * is a no-op if the objectId is not found from ENR.
+	 */
+	if (object->objectSubId == 0)
+		ENRDropEntry(object->objectId);
 
 	/*
 	 * CommandCounterIncrement here to ensure that preceding changes are all

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -435,9 +435,9 @@ bool ENRgetSystableScan(Relation rel, Oid indexId, int nkeys, ScanKey key, List 
 				* Search through the entire ENR relation list for everything
 				* that has a relation (non-recursive) to this object.
 				* If indexId is DependDependerIndexId, we try to mimic
-				* SELECT * FROM pg_depend WHERE classid=v1 AND objid=v2
+				* SELECT * FROM pg_depend WHERE classid=v1 AND objid=v2 (AND objsubid = v3 if applicable)
 				* Otherwise if it is DependReferenceIndexId we try to mimic
-				* SELECT * FROM pg_depend WHERE refclassid=v1 AND refobjid=v2
+				* SELECT * FROM pg_depend WHERE refclassid=v1 AND refobjid=v2 (AND refobjsubid = v3 if applicable)
 				* So we cannot return right away if there is a match.
 				*/
 				ListCell   *lc;
@@ -445,7 +445,8 @@ bool ENRgetSystableScan(Relation rel, Oid indexId, int nkeys, ScanKey key, List 
 					Form_pg_depend tup = (Form_pg_depend) GETSTRUCT((HeapTuple) lfirst(lc));
 					if (indexId == DependDependerIndexId &&
 						tup->classid == (Oid)v1 &&
-						tup->objid == (Oid)v2)
+						tup->objid == (Oid)v2 &&
+						(nkeys == 2 || tup->objsubid == (int32)v3))
 					{
 						*tuplist = list_insert_nth(*tuplist, index++, lfirst(lc));
 						*tuplist_flags |= SYSSCAN_ENR_NEEDFREE;
@@ -453,7 +454,8 @@ bool ENRgetSystableScan(Relation rel, Oid indexId, int nkeys, ScanKey key, List 
 					}
 					else if (indexId == DependReferenceIndexId &&
 						tup->refclassid == (Oid)v1 &&
-						tup->refobjid == (Oid)v2)
+						tup->refobjid == (Oid)v2 &&
+						(nkeys == 2 || tup->refobjsubid == (int32)v3))
 					{
 						*tuplist = list_insert_nth(*tuplist, index++, lfirst(lc));
 						*tuplist_flags |= SYSSCAN_ENR_NEEDFREE;


### PR DESCRIPTION
Our original code for ENRgetSystableScan did not take into account the fact that pg_depend scans can use up to three keys. Fix the issue by making sure to use the third key if it is supplied.

Also fix the logic around performing the deletion so that we don't try to drop the entire ENR table when deleting columns.

Backport to PG15 as well.

Task: BABEL-4912

### Description

[Describe what this change achieves]
 
### Issues Resolved

[List any issues this PR will resolve]
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
