### PR TITLE
Fix a regression issue caused by typo in union modification 

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -2345,8 +2345,8 @@ transformSetOperationTree(ParseState *pstate, SelectStmt *stmt,
 			if (rcoltype != UNKNOWNOID)
 				rcolnode = coerce_to_common_type(pstate, rcolnode,
 												 rescoltype, context);
-			else if ((IsA(lcolnode, Const) ||
-					 IsA(lcolnode, Param)) && sql_dialect != SQL_DIALECT_TSQL)
+			else if ((IsA(rcolnode, Const) ||
+					 IsA(rcolnode, Param)) && sql_dialect != SQL_DIALECT_TSQL)
 			{
 				rcolnode = coerce_to_common_type(pstate, rcolnode,
 												 rescoltype, context);

--- a/src/test/regress/expected/prepare.out
+++ b/src/test/regress/expected/prepare.out
@@ -179,6 +179,17 @@ SELECT name, statement, parameter_types FROM pg_prepared_statements
       |     SELECT * FROM road WHERE thepath = $1;                       | 
 (5 rows)
 
+CREATE TABLE union_type (id int primary key, name varchar(20));
+PREPARE q9
+AS
+WITH temp1 AS (
+    SELECT * from union_type
+    UNION
+    SELECT
+        $1 AS id,
+        $2 AS name
+)
+SELECT * from temp1;
 -- test DEALLOCATE ALL;
 DEALLOCATE ALL;
 SELECT name, statement, parameter_types FROM pg_prepared_statements
@@ -187,3 +198,4 @@ SELECT name, statement, parameter_types FROM pg_prepared_statements
 ------+-----------+-----------------
 (0 rows)
 
+DROP table union_type;

--- a/src/test/regress/sql/prepare.sql
+++ b/src/test/regress/sql/prepare.sql
@@ -74,7 +74,22 @@ PREPARE q7(unknown) AS
 SELECT name, statement, parameter_types FROM pg_prepared_statements
     ORDER BY name;
 
+CREATE TABLE union_type (id int primary key, name varchar(20));
+
+PREPARE q9
+AS
+WITH temp1 AS (
+    SELECT * from union_type
+    UNION
+    SELECT
+        $1 AS id,
+        $2 AS name
+)
+SELECT * from temp1;
+
 -- test DEALLOCATE ALL;
 DEALLOCATE ALL;
 SELECT name, statement, parameter_types FROM pg_prepared_statements
     ORDER BY name;
+
+DROP table union_type;


### PR DESCRIPTION

Previously in the pr : https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/140 We modified the union corece behavior of union select in babelfish, but a typo wrongly changed the postgres behavior and caused a regression, we'll fix the typo in this commit.

Task: MANFRED-22834


### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
