### PR TITLE
Support View usage for PIVOT operator (BABEL_3_X_DEV)

### DIFF
--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -3353,6 +3353,12 @@ _copySelectStmt(const SelectStmt *from)
 	COPY_SCALAR_FIELD(all);
 	COPY_NODE_FIELD(larg);
 	COPY_NODE_FIELD(rarg);
+	COPY_SCALAR_FIELD(isPivot);
+	COPY_NODE_FIELD(srcSql);
+	COPY_NODE_FIELD(catSql);
+	COPY_NODE_FIELD(value_col_strlist);
+	COPY_NODE_FIELD(pivotCol);
+	COPY_NODE_FIELD(aggFunc);
 
 	return newnode;
 }

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -1104,6 +1104,12 @@ _equalSelectStmt(const SelectStmt *a, const SelectStmt *b)
 	COMPARE_SCALAR_FIELD(all);
 	COMPARE_NODE_FIELD(larg);
 	COMPARE_NODE_FIELD(rarg);
+	COMPARE_SCALAR_FIELD(isPivot);
+	COMPARE_NODE_FIELD(srcSql);
+	COMPARE_NODE_FIELD(catSql);
+	COMPARE_NODE_FIELD(value_col_strlist);
+	COMPARE_NODE_FIELD(pivotCol);
+	COMPARE_NODE_FIELD(aggFunc);
 
 	return true;
 }

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -2869,6 +2869,12 @@ _outSelectStmt(StringInfo str, const SelectStmt *node)
 	WRITE_BOOL_FIELD(all);
 	WRITE_NODE_FIELD(larg);
 	WRITE_NODE_FIELD(rarg);
+	WRITE_BOOL_FIELD(isPivot);
+	WRITE_NODE_FIELD(srcSql);
+	WRITE_NODE_FIELD(catSql);
+	WRITE_NODE_FIELD(value_col_strlist);
+	WRITE_NODE_FIELD(pivotCol);
+	WRITE_NODE_FIELD(aggFunc);
 }
 
 static void

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -55,6 +55,8 @@ struct QueryEnvironment
 {
 	List	   *namedRelList;
 	List	   *dropped_namedRelList;
+	bool 	   inView;				/* indicate if the current query is inside a view */
+	char	   *viewName;			/* if current query is inside a view, store the view name */
 	struct QueryEnvironment *parentEnv;
 	MemoryContext	memctx;
 };
@@ -84,12 +86,18 @@ create_queryEnv2(MemoryContext cxt, bool top_level)
 		queryEnv = topLevelQueryEnv;
 		queryEnv->namedRelList = NIL;
 		queryEnv->dropped_namedRelList = NIL;
+		queryEnv->viewName = NULL;
+		queryEnv->inView = false;
 		queryEnv->parentEnv = NULL;
 		queryEnv->memctx = cxt;
 	} else {
 		oldcxt = MemoryContextSwitchTo(cxt);
 		queryEnv = (QueryEnvironment *) palloc0(sizeof(QueryEnvironment));
 		queryEnv->parentEnv = currentQueryEnv;
+		queryEnv->namedRelList = NIL;
+		queryEnv->dropped_namedRelList = NIL;
+		queryEnv->inView = false;
+		queryEnv->viewName = NULL;
 		queryEnv->memctx = cxt;
 		MemoryContextSwitchTo(oldcxt);
 	}
@@ -148,6 +156,9 @@ void remove_queryEnv() {
 
 	list_free(currentQueryEnv->dropped_namedRelList);
 	currentQueryEnv->dropped_namedRelList = NIL;
+
+	if (currentQueryEnv->viewName != NULL)
+		pfree(currentQueryEnv->viewName);
 
 	pfree(currentQueryEnv);
 	MemoryContextSwitchTo(oldcxt);
@@ -1530,4 +1541,55 @@ extern void ENRDropCatalogEntry(Relation catalog_relation, Oid relid)
 
 		queryEnv = queryEnv->parentEnv;
 	}
+}
+
+/*
+ * Set the view name for the current query environment.
+ */
+void setQueryEnvViewName(QueryEnvironment *queryEnv, const char *viewName)
+{
+	MemoryContext oldcxt;
+
+	if (queryEnv == NULL || viewName == NULL)
+		return;
+
+	Assert(queryEnv->memctx);
+	oldcxt = MemoryContextSwitchTo(queryEnv->memctx);
+
+	queryEnv->viewName = pstrdup(viewName);
+	
+	MemoryContextSwitchTo(oldcxt);
+}
+
+/*
+ *  Check if the query is inside a view
+ */
+bool checkQueryWithinView(QueryEnvironment *queryEnv)
+{
+	if (!queryEnv)
+		return false;
+
+	return queryEnv->inView;
+}
+
+/*
+ * Set QueryEnvironment inView flag
+ */
+void setQueryEnvInView(QueryEnvironment *queryEnv, bool inView)
+{
+	if (!queryEnv)
+		return;
+
+	queryEnv->inView = inView;
+}
+
+/*
+ *  Get the view name for the current query environment
+ */
+char *getQueryEnvViewName(QueryEnvironment *queryEnv)
+{
+	if (!queryEnv)
+		return NULL;
+
+	return queryEnv->viewName;
 }

--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -1014,14 +1014,16 @@ setBabelfishDependenciesForLogicalDatabaseDump(Archive *fout)
 	/*
 	 * Now get the OIDs for following desired catalog tables:
 	 * sys.babelfish_namespace_ext
-	 * babelfish_extended_properties
-	 * babelfish_schema_permissions
+	 * sys.babelfish_pivot_view
+	 * sys.babelfish_extended_properties
+	 * sys.babelfish_schema_permissions
 	 */
 	appendPQExpBufferStr(query,
 						 "SELECT oid "
 						 "FROM pg_class "
 						 "WHERE relname in ('babelfish_schema_permissions', "
 						 "'babelfish_namespace_ext', "
+						 "'babelfish_pivot_view', "
 						 "'babelfish_extended_properties') "
 						 "AND relnamespace = 'sys'::regnamespace "
 						 "ORDER BY relname;");
@@ -1078,6 +1080,7 @@ addFromClauseForLogicalDatabaseDump(PQExpBuffer buf, TableInfo *tbinfo)
 						  fmtQualifiedDumpable(tbinfo), bbf_db_id);
 	}
 	else if (strcmp(tbinfo->dobj.name, "babelfish_view_def") == 0 ||
+			 strcmp(tbinfo->dobj.name, "babelfish_pivot_view") == 0 ||
 			 strcmp(tbinfo->dobj.name, "babelfish_extended_properties") == 0 ||
 			 strcmp(tbinfo->dobj.name, "babelfish_schema_permissions") == 0)
 		appendPQExpBuffer(buf, " FROM ONLY %s a WHERE a.dbid = %d",
@@ -1153,6 +1156,7 @@ addFromClauseForPhysicalDatabaseDump(PQExpBuffer buf, TableInfo *tbinfo)
 	else if(strcmp(tbinfo->dobj.name, "babelfish_domain_mapping") == 0 ||
 			strcmp(tbinfo->dobj.name, "babelfish_function_ext") == 0 ||
 			strcmp(tbinfo->dobj.name, "babelfish_view_def") == 0 ||
+			strcmp(tbinfo->dobj.name, "babelfish_pivot_view") == 0 ||
 			strcmp(tbinfo->dobj.name, "babelfish_server_options") == 0 ||
 			strcmp(tbinfo->dobj.name, "babelfish_extended_properties") == 0 ||
 			strcmp(tbinfo->dobj.name, "babelfish_schema_permissions") == 0)

--- a/src/include/commands/view.h
+++ b/src/include/commands/view.h
@@ -26,5 +26,8 @@ typedef void (*store_view_definition_hook_type) (const char *queryString, Object
 extern PGDLLIMPORT store_view_definition_hook_type	store_view_definition_hook;
 
 typedef void (*inherit_view_constraints_from_table_hook_type) (ColumnDef  *col, Oid tableOid, AttrNumber colId);
-extern PGDLLIMPORT inherit_view_constraints_from_table_hook_type inherit_view_constraints_from_table_hook;
+extern PGDLLEXPORT inherit_view_constraints_from_table_hook_type inherit_view_constraints_from_table_hook;
+
+typedef Query *(*parse_analyze_babelfish_view_hook_type) (ViewStmt *stmt, RawStmt *rawstmt, const char *queryString);
+extern PGDLLEXPORT parse_analyze_babelfish_view_hook_type parse_analyze_babelfish_view_hook;
 #endif							/* VIEW_H */

--- a/src/include/utils/queryenvironment.h
+++ b/src/include/utils/queryenvironment.h
@@ -150,4 +150,10 @@ extern void ENRCommitChanges(QueryEnvironment *queryEnv);
 extern void ENRRollbackChanges(QueryEnvironment *queryEnv);
 extern void ENRRollbackSubtransaction(SubTransactionId subid, QueryEnvironment *queryEnv);
 
+extern void setQueryEnvViewName(QueryEnvironment *queryEnv, const char *viewName);
+extern char *getQueryEnvViewName(QueryEnvironment *queryEnv);
+extern bool checkQueryWithinView(QueryEnvironment *queryEnv);
+extern void setQueryEnvInView(QueryEnvironment *queryEnv, bool inView);
+
+
 #endif							/* QUERYENVIRONMENT_H */


### PR DESCRIPTION
### Description
Support create/select/drop view on stmt with pivot operator. 
We also introduced a new catalog `babel_pivot_view catalog`. When a view is created on a pivot stmt, two corresponding helper views will also get created. 
Those two helper views have the following naming format:
- pvt_sv_[uuid] (sv_5aef8eaa36c846a98e6e84e38ee70872)
- pvt_cv_[uuid] (cv_5aef8eaa36c846a98e6e84e38ee70872)

Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2809
 
### Issues Resolved
BABEL-4673
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
