### PR TITLE
Handle case when NULL is passed as argument of special functions

### DIFF
--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -604,7 +604,7 @@ ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
 		}
 
 		if (sql_dialect == SQL_DIALECT_TSQL && report_proc_not_found_error_hook)
-			report_proc_not_found_error_hook(funcname, argnames, actual_arg_types, nargs, pstate, location, proc_call);
+			report_proc_not_found_error_hook(funcname, fargs, argnames, actual_arg_types, nargs, pstate, location, proc_call);
 
 		/*
 		 * No function, and no column either.  Since we're dealing with
@@ -1086,7 +1086,7 @@ func_select_candidate(int nargs,
 	    (dump_restore && strcmp(dump_restore, "on") == 0)) && /* execute hook if dialect is T-SQL or while restoring babelfish database */
 	    func_select_candidate_hook != NULL)
 	{
-		last_candidate = func_select_candidate_hook(NULL, nargs, input_typeids, candidates, false, false);
+		last_candidate = func_select_candidate_hook(NULL, NIL, nargs, input_typeids, candidates, false, false);
 		if (last_candidate)
 			return last_candidate; /* last_candiate->next should be already NULL */
 	}
@@ -1278,7 +1278,7 @@ func_select_candidate(int nargs,
 		(dump_restore && strcmp(dump_restore, "on") == 0)) && /* execute hook if dialect is T-SQL or while restoring babelfish database */
 		func_select_candidate_hook != NULL)
 	{
-		last_candidate = func_select_candidate_hook(NULL, nargs, input_typeids, candidates, true, false);
+		last_candidate = func_select_candidate_hook(NULL, NIL, nargs, input_typeids, candidates, true, false);
 		if (last_candidate)
 			return last_candidate; /* last_candiate->next should be already NULL */
 	}
@@ -1609,6 +1609,7 @@ func_get_detail(List *funcname,
 					func_select_candidate_hook != NULL)
 				{
 					best_candidate = func_select_candidate_hook(funcname, 
+																	fargs, 
 																	nargs, 
 																	argtypes, 
 																	current_candidates,

--- a/src/include/parser/parse_func.h
+++ b/src/include/parser/parse_func.h
@@ -74,11 +74,11 @@ extern void check_srf_call_placement(ParseState *pstate, Node *last_srf,
 /*
  * Hook interface to select a function from candidates
  */
-typedef FuncCandidateList (*func_select_candidate_hook_type) (List *names, int nargs, Oid *input_typeids, FuncCandidateList candidates, bool unknowns_resolved, bool is_special);
+typedef FuncCandidateList (*func_select_candidate_hook_type) (List *names, List *fargs, int nargs, Oid *input_typeids, FuncCandidateList candidates, bool unknowns_resolved, bool is_special);
 /* Hook interface to process function arguments using probin */
 typedef void (*make_fn_arguments_from_stored_proc_probin_hook_type)(ParseState *pstate,List *fargs,Oid *actual_arg_types,Oid *declared_arg_types,Oid funcid);
 extern PGDLLEXPORT make_fn_arguments_from_stored_proc_probin_hook_type make_fn_arguments_from_stored_proc_probin_hook;
-typedef void (*report_proc_not_found_error_hook_type) (List *names, List *argnames, Oid *input_typeids, int nargs, ParseState *pstate, int location, bool proc_call);
+typedef void (*report_proc_not_found_error_hook_type) (List *names, List *fargs, List *argnames, Oid *input_typeids, int nargs, ParseState *pstate, int location, bool proc_call);
 extern PGDLLEXPORT report_proc_not_found_error_hook_type report_proc_not_found_error_hook;
 
 #endif							/* PARSE_FUNC_H */


### PR DESCRIPTION
### Description

This PR contains following changes:
- extended definition of `report_proc_not_found_error_hook` and `func_select_candidate_hook` to include `fargs`, which will be used to handle scenario when NULL is passed as Argument to special functions.

Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2815

cherry-picked: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/415
Authored-by: Anikait Agrawal [agraani@amazon.com](mailto:agraani@amazon.com)
Signed-off-by: Anikait Agrawal [agraani@amazon.com](mailto:agraani@amazon.com)

### Issues Resolved
BABEL- 4118, BABEL- 3658
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
