### PR TITLE
[OSS-ONLY] Update BabelfishDump RPM version to 16.4 and Include changelog

### DIFF
--- a/BabelfishDump.spec
+++ b/BabelfishDump.spec
@@ -151,6 +151,9 @@ LD_LIBRARY_PATH=%{_builddir}/%{name}/src/interfaces/libpq $RPM_BUILD_ROOT/usr/bi
 %{_bindir}/bbf_dumpall
 
 %changelog
+* Mon Aug 5 2024 Masahiko Sawada <msawada@postgresql.com> - 16.4-1
+- [CVE-2024-7348] Restrict accesses to non-system views and foreign tables during pg_dump.
+
 * Mon Jul 8 2024 Rishabh Tanwar <ritanwar@amazon.com> - 16.4-1
 - Include ordering for constraints on babelfish tables
 

--- a/BabelfishDump.spec
+++ b/BabelfishDump.spec
@@ -26,8 +26,8 @@
 
 Name: BabelfishDump
 Summary: Postgresql dump utilities modified for Babelfish
-Version: 16.3
-Release: 2%{?dist}%{?_trivial}%{?_buildid}
+Version: 16.4
+Release: 1%{?dist}%{?_trivial}%{?_buildid}
 License: PostgreSQL
 Url: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish
 
@@ -151,6 +151,12 @@ LD_LIBRARY_PATH=%{_builddir}/%{name}/src/interfaces/libpq $RPM_BUILD_ROOT/usr/bi
 %{_bindir}/bbf_dumpall
 
 %changelog
+* Mon Jul 8 2024 Rishabh Tanwar <ritanwar@amazon.com> - 16.4-1
+- Include ordering for constraints on babelfish tables
+
+* Fri Jun 21 2024 Sumit Jaiswal <sumiji@amazon.com> - 16.4-1
+- Support dump/restore of Partition Function and Partition Scheme catalogs
+
 * Mon Jun 17 2024 Rishabh Tanwar <ritanwar@amazon.com> - 16.3-2
 - Improve catalog handling in bbf_dump
 


### PR DESCRIPTION
### Description
Update BabelfishDump RPM version to 16.4 and Include changelog.

Task: BABEL-5197
Signed-off-by: Rishabh Tanwar ritanwar@amazon.com
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
