### PR TITLE
Revert "Fix concurrency issues with ENR temp tables. (#394)"

### DIFF
--- a/src/backend/storage/ipc/sinvaladt.c
+++ b/src/backend/storage/ipc/sinvaladt.c
@@ -27,9 +27,6 @@
 #include "storage/sinvaladt.h"
 #include "storage/spin.h"
 
-/* hooks */
-pltsql_is_local_only_inval_msg_hook_type pltsql_is_local_only_inval_msg_hook = NULL;
-
 /*
  * Conceptually, the shared cache invalidation messages are stored in an
  * infinite array, where maxMsgNum is the next array subscript to store a
@@ -494,12 +491,6 @@ SIInsertDataEntries(const SharedInvalidationMessage *data, int n)
 		max = segP->maxMsgNum;
 		while (nthistime-- > 0)
 		{
-			if (pltsql_is_local_only_inval_msg_hook && (*pltsql_is_local_only_inval_msg_hook)(data))
-			{
-				data++;
-				continue;
-			}
-
 			segP->buffer[max % MAXNUMMESSAGES] = *data++;
 			max++;
 		}

--- a/src/backend/storage/lmgr/lmgr.c
+++ b/src/backend/storage/lmgr/lmgr.c
@@ -27,7 +27,6 @@
 #include "storage/procarray.h"
 #include "storage/sinvaladt.h"
 #include "utils/inval.h"
-#include "utils/queryenvironment.h"
 
 
 /*
@@ -332,9 +331,6 @@ bool
 CheckRelationLockedByMe(Relation relation, LOCKMODE lockmode, bool orstronger)
 {
 	LOCKTAG		tag;
-
-	if (pltsql_get_tsql_enr_from_oid_hook && (*pltsql_get_tsql_enr_from_oid_hook)(RelationGetRelid(relation)))
-		return true;
 
 	SET_LOCKTAG_RELATION(tag,
 						 relation->rd_lockInfo.lockRelId.dbId,

--- a/src/backend/utils/cache/inval.c
+++ b/src/backend/utils/cache/inval.c
@@ -127,7 +127,6 @@
 #include "utils/relmapper.h"
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
-#include "utils/queryenvironment.h"
 
 
 /*
@@ -460,7 +459,6 @@ AddRelcacheInvalidationMessage(InvalidationMsgsGroup *group,
 	msg.rc.id = SHAREDINVALRELCACHE_ID;
 	msg.rc.dbId = dbId;
 	msg.rc.relId = relId;
-	msg.rc.local_only = (pltsql_get_tsql_enr_from_oid_hook && (*pltsql_get_tsql_enr_from_oid_hook)(relId));
 	/* check AddCatcacheInvalidationMessage() for an explanation */
 	VALGRIND_MAKE_MEM_DEFINED(&msg, sizeof(msg));
 

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -48,8 +48,6 @@
 #include "utils/queryenvironment.h"
 #include "utils/rel.h"
 
-pltsql_get_tsql_enr_from_oid_hook_type pltsql_get_tsql_enr_from_oid_hook = NULL;
-
 /*
  * Private state of a query environment.
  */
@@ -288,7 +286,7 @@ get_ENR_withoid(QueryEnvironment *queryEnv, Oid id, EphemeralNameRelationType ty
 {
 	ListCell   *lc;
 
-	if (queryEnv == NULL || !OidIsValid(id))
+	if (queryEnv == NULL)
 		return NULL;
 
 	foreach(lc, queryEnv->namedRelList)

--- a/src/include/storage/sinval.h
+++ b/src/include/storage/sinval.h
@@ -80,14 +80,6 @@ typedef struct
 	int8		id;				/* type field --- must be first */
 	Oid			dbId;			/* database ID, or 0 if a shared relation */
 	Oid			relId;			/* relation ID, or 0 if whole relcache */
-	/* 
-	 * We need a way to mark whether this inval message is for a local ENR entry,
-	 * so that we can skip inserting it into the SI message queue.
-	 * Note that checking whether the relId is an ENR entry at the time of insertion
-	 * is insufficient, as during drops the ENR entry is deleted before we perform
-	 * SI queue insertion.
-	 */
-	bool		local_only;
 } SharedInvalRelcacheMsg;
 
 #define SHAREDINVALSMGR_ID		(-3)

--- a/src/include/storage/sinvaladt.h
+++ b/src/include/storage/sinvaladt.h
@@ -42,7 +42,4 @@ extern void SICleanupQueue(bool callerHasWriteLock, int minFree);
 
 extern LocalTransactionId GetNextLocalTransactionId(void);
 
-typedef bool (*pltsql_is_local_only_inval_msg_hook_type) (const SharedInvalidationMessage *msg);
-extern PGDLLIMPORT pltsql_is_local_only_inval_msg_hook_type pltsql_is_local_only_inval_msg_hook;
-
 #endif							/* SINVALADT_H */

--- a/src/include/utils/queryenvironment.h
+++ b/src/include/utils/queryenvironment.h
@@ -150,7 +150,4 @@ extern void ENRCommitChanges(QueryEnvironment *queryEnv);
 extern void ENRRollbackChanges(QueryEnvironment *queryEnv);
 extern void ENRRollbackSubtransaction(SubTransactionId subid, QueryEnvironment *queryEnv);
 
-typedef EphemeralNamedRelation (*pltsql_get_tsql_enr_from_oid_hook_type) (Oid oid);
-extern PGDLLIMPORT pltsql_get_tsql_enr_from_oid_hook_type pltsql_get_tsql_enr_from_oid_hook;
-
 #endif							/* QUERYENVIRONMENT_H */


### PR DESCRIPTION
This reverts commit 5140f79a8ebbf37e0eea6527532f77cf7fa4d0c7.

### Description

This change was merged earlier today with all tests passing, but it appears to be crashing when I run it locally. Reverting for now until the fix can be addressed. 
 
### Issues Resolved

I'm seeing a crash in the `table_variable_xact_nested` test.
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
