### PR TITLE
Re-enable "Fix concurrency issues with ENR temp tables."

### DIFF
--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1318,7 +1318,8 @@ heap_create_with_catalog(const char *relname,
 	 * it doesn't hurt to hold AccessExclusiveLock.  Do it here so callers
 	 * can't accidentally vary in their lock mode or acquisition timing.
 	 */
-	LockRelationOid(relid, AccessExclusiveLock);
+	if (!is_enr)
+		LockRelationOid(relid, AccessExclusiveLock);
 
 	/*
 	 * Determine the relation's initial permissions.

--- a/src/backend/storage/ipc/sinvaladt.c
+++ b/src/backend/storage/ipc/sinvaladt.c
@@ -27,6 +27,9 @@
 #include "storage/sinvaladt.h"
 #include "storage/spin.h"
 
+/* hooks */
+pltsql_is_local_only_inval_msg_hook_type pltsql_is_local_only_inval_msg_hook = NULL;
+
 /*
  * Conceptually, the shared cache invalidation messages are stored in an
  * infinite array, where maxMsgNum is the next array subscript to store a
@@ -491,6 +494,12 @@ SIInsertDataEntries(const SharedInvalidationMessage *data, int n)
 		max = segP->maxMsgNum;
 		while (nthistime-- > 0)
 		{
+			if (pltsql_is_local_only_inval_msg_hook && (*pltsql_is_local_only_inval_msg_hook)(data))
+			{
+				data++;
+				continue;
+			}
+
 			segP->buffer[max % MAXNUMMESSAGES] = *data++;
 			max++;
 		}

--- a/src/backend/storage/lmgr/lmgr.c
+++ b/src/backend/storage/lmgr/lmgr.c
@@ -27,6 +27,7 @@
 #include "storage/procarray.h"
 #include "storage/sinvaladt.h"
 #include "utils/inval.h"
+#include "utils/queryenvironment.h"
 
 
 /*
@@ -331,6 +332,9 @@ bool
 CheckRelationLockedByMe(Relation relation, LOCKMODE lockmode, bool orstronger)
 {
 	LOCKTAG		tag;
+
+	if (pltsql_get_tsql_enr_from_oid_hook && (*pltsql_get_tsql_enr_from_oid_hook)(RelationGetRelid(relation)))
+		return true;
 
 	SET_LOCKTAG_RELATION(tag,
 						 relation->rd_lockInfo.lockRelId.dbId,

--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -879,6 +879,27 @@ LockAcquireExtended(const LOCKTAG *locktag,
 						lockMethodTable->lockModeNames[lockmode]),
 				 errhint("Only RowExclusiveLock or less can be acquired on database objects during recovery.")));
 
+	if (pltsql_get_tsql_enr_from_oid_hook && locktag->locktag_type == LOCKTAG_RELATION && 
+		(*pltsql_get_tsql_enr_from_oid_hook)(locktag->locktag_field2))
+	{
+		/*
+		 * Normally, opening a relation with AccessExclusiveLock will automatically trigger for an XID
+		 * to be grabbed. Since we are overriding it here, make sure to still grab an XID.
+		 */
+		if (lockmode == AccessExclusiveLock)
+			GetCurrentTransactionId();
+		
+		/*
+		 * LOCKACQUIRE_ALREADY_CLEAR indicates that this lock is "cleared for use" - that is, the target of the
+		 * lock is completely up-to-date with all inval messages. Since this is a local-only ENR temp table,
+		 * there cannot be any other backends which have tried to invalidate this relation - so return as if
+		 * the lock has been cleared. This will prevent downstream consumers of this function from unnecessarily
+		 * trying to receive invalidation messages, or (worse) trying to manually clear the locallock, which
+		 * doesn't even exist.
+		 */
+		return LOCKACQUIRE_ALREADY_CLEAR;
+	}
+
 #ifdef LOCK_DEBUG
 	if (LOCK_DEBUG_ENABLED(locktag))
 		elog(LOG, "LockAcquire: lock [%u,%u] %s",
@@ -2025,6 +2046,10 @@ LockRelease(const LOCKTAG *locktag, LOCKMODE lockmode, bool sessionLock)
 	lockMethodTable = LockMethods[lockmethodid];
 	if (lockmode <= 0 || lockmode > lockMethodTable->numLockModes)
 		elog(ERROR, "unrecognized lock mode: %d", lockmode);
+	
+	if (pltsql_get_tsql_enr_from_oid_hook && locktag->locktag_type == LOCKTAG_RELATION && 
+		(*pltsql_get_tsql_enr_from_oid_hook)(locktag->locktag_field2))
+		return true;
 
 #ifdef LOCK_DEBUG
 	if (LOCK_DEBUG_ENABLED(locktag))

--- a/src/backend/utils/cache/inval.c
+++ b/src/backend/utils/cache/inval.c
@@ -127,6 +127,7 @@
 #include "utils/relmapper.h"
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
+#include "utils/queryenvironment.h"
 
 
 /*
@@ -459,6 +460,7 @@ AddRelcacheInvalidationMessage(InvalidationMsgsGroup *group,
 	msg.rc.id = SHAREDINVALRELCACHE_ID;
 	msg.rc.dbId = dbId;
 	msg.rc.relId = relId;
+	msg.rc.local_only = (pltsql_get_tsql_enr_from_oid_hook && (*pltsql_get_tsql_enr_from_oid_hook)(relId));
 	/* check AddCatcacheInvalidationMessage() for an explanation */
 	VALGRIND_MAKE_MEM_DEFINED(&msg, sizeof(msg));
 

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -48,6 +48,8 @@
 #include "utils/queryenvironment.h"
 #include "utils/rel.h"
 
+pltsql_get_tsql_enr_from_oid_hook_type pltsql_get_tsql_enr_from_oid_hook = NULL;
+
 /*
  * Private state of a query environment.
  */
@@ -286,7 +288,7 @@ get_ENR_withoid(QueryEnvironment *queryEnv, Oid id, EphemeralNameRelationType ty
 {
 	ListCell   *lc;
 
-	if (queryEnv == NULL)
+	if (queryEnv == NULL || !OidIsValid(id))
 		return NULL;
 
 	foreach(lc, queryEnv->namedRelList)

--- a/src/include/storage/sinval.h
+++ b/src/include/storage/sinval.h
@@ -80,6 +80,14 @@ typedef struct
 	int8		id;				/* type field --- must be first */
 	Oid			dbId;			/* database ID, or 0 if a shared relation */
 	Oid			relId;			/* relation ID, or 0 if whole relcache */
+	/* 
+	 * We need a way to mark whether this inval message is for a local ENR entry,
+	 * so that we can skip inserting it into the SI message queue.
+	 * Note that checking whether the relId is an ENR entry at the time of insertion
+	 * is insufficient, as during drops the ENR entry is deleted before we perform
+	 * SI queue insertion.
+	 */
+	bool		local_only;
 } SharedInvalRelcacheMsg;
 
 #define SHAREDINVALSMGR_ID		(-3)

--- a/src/include/storage/sinvaladt.h
+++ b/src/include/storage/sinvaladt.h
@@ -42,4 +42,7 @@ extern void SICleanupQueue(bool callerHasWriteLock, int minFree);
 
 extern LocalTransactionId GetNextLocalTransactionId(void);
 
+typedef bool (*pltsql_is_local_only_inval_msg_hook_type) (const SharedInvalidationMessage *msg);
+extern PGDLLIMPORT pltsql_is_local_only_inval_msg_hook_type pltsql_is_local_only_inval_msg_hook;
+
 #endif							/* SINVALADT_H */

--- a/src/include/utils/queryenvironment.h
+++ b/src/include/utils/queryenvironment.h
@@ -150,4 +150,7 @@ extern void ENRCommitChanges(QueryEnvironment *queryEnv);
 extern void ENRRollbackChanges(QueryEnvironment *queryEnv);
 extern void ENRRollbackSubtransaction(SubTransactionId subid, QueryEnvironment *queryEnv);
 
+typedef EphemeralNamedRelation (*pltsql_get_tsql_enr_from_oid_hook_type) (Oid oid);
+extern PGDLLIMPORT pltsql_get_tsql_enr_from_oid_hook_type pltsql_get_tsql_enr_from_oid_hook;
+
 #endif							/* QUERYENVIRONMENT_H */


### PR DESCRIPTION
### Description

https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/commit/5140f79a8ebbf37e0eea6527532f77cf7fa4d0c7 had a bug which caused a crash when aborting nested transactions with table variables due to missing a case when a lock was being acquired during table creation. Fix that case by adding a proper check for ENR-ness, and skip the lock acquisition in that case.
 
### Issues Resolved

BABEL-4913, BABEL-4892
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
