### PR TITLE
Fix build failure due to deprecated artifact version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,13 +24,13 @@ jobs:
           make check-world
       - name: upload-test-summary
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: regression-summary
           path: src/test/regress/regression.out
       - name: upload-test-differences
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: regression-differences
           path: src/test/regress/regression.diffs


### PR DESCRIPTION
### Description
Build is failing due to deprecated artifact version for actions/upload-artifact and actions/download-artifact in the CI workflow.

((https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/))