### PR TITLE
Support View usage for PIVOT operator (Deparsed psql-text)

### DIFF
--- a/src/backend/executor/execSRF.c
+++ b/src/backend/executor/execSRF.c
@@ -34,9 +34,6 @@
 #include "utils/memutils.h"
 #include "utils/typcache.h"
 
-/* Hook to set TSQL pivot data to fcinfo */
-pass_pivot_data_to_fcinfo_hook_type pass_pivot_data_to_fcinfo_hook = NULL;
-
 /* static function decls */
 static void init_sexpr(Oid foid, Oid input_collation, Expr *node,
 					   SetExprState *sexpr, PlanState *parent,
@@ -204,11 +201,6 @@ ExecMakeTableFunctionResult(SetExprState *setexpr,
 	{
 		/* Treat setexpr as a generic expression */
 		InitFunctionCallInfoData(*fcinfo, NULL, 0, InvalidOid, NULL, NULL);
-	}
-	
-	if (sql_dialect == SQL_DIALECT_TSQL && pass_pivot_data_to_fcinfo_hook)
-	{
-		(pass_pivot_data_to_fcinfo_hook)(fcinfo, setexpr->expr);
 	}
 		
 	/*

--- a/src/backend/nodes/makefuncs.c
+++ b/src/backend/nodes/makefuncs.c
@@ -534,7 +534,6 @@ makeFuncExpr(Oid funcid, Oid rettype, List *args,
 	funcexpr->inputcollid = inputcollid;
 	funcexpr->args = args;
 	funcexpr->location = -1;
-	funcexpr->context = NULL;
 
 	return funcexpr;
 }
@@ -601,7 +600,6 @@ makeFuncCall(List *name, List *args, CoercionForm funcformat, int location)
 	n->func_variadic = false;
 	n->funcformat = funcformat;
 	n->location = location;
-	n->context = NULL;
 	return n;
 }
 

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -2605,7 +2605,6 @@ eval_const_expressions_mutator(Node *node,
 				newexpr->inputcollid = expr->inputcollid;
 				newexpr->args = args;
 				newexpr->location = expr->location;
-				newexpr->context = expr->context;
 				return (Node *) newexpr;
 			}
 		case T_OpExpr:
@@ -4575,7 +4574,6 @@ evaluate_function(Oid funcid, Oid result_type, int32 result_typmod,
 	newexpr->inputcollid = input_collid;
 	newexpr->args = args;
 	newexpr->location = -1;
-	newexpr->context = NULL;
 
 	return evaluate_expr((Expr *) newexpr, result_type, result_typmod,
 						 result_collid);
@@ -4688,7 +4686,6 @@ inline_function(Oid funcid, Oid result_type, Oid result_collid,
 	fexpr->inputcollid = input_collid;
 	fexpr->args = args;
 	fexpr->location = -1;
-	fexpr->context = NULL;
 
 	/* Fetch the function body */
 	tmp = SysCacheGetAttrNotNull(PROCOID, func_tuple, Anum_pg_proc_prosrc);

--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -765,10 +765,6 @@ ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
 		/* funccollid and inputcollid will be set by parse_collate.c */
 		funcexpr->args = fargs;
 		funcexpr->location = location;
-		funcexpr->context = NULL;
-		
-		if (fn != NULL)
-			funcexpr->context = copyObject(fn->context);
 
 		retval = (Node *) funcexpr;
 	}

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -12107,7 +12107,7 @@ generate_relation_name(Oid relid, List *namespaces)
 	if (!need_qual)
 		need_qual = !RelationIsVisible(relid);
 
-	if (need_qual)
+	if (need_qual || sql_dialect == SQL_DIALECT_TSQL)
 		nspname = get_namespace_name_or_temp(reltup->relnamespace);
 	else
 		nspname = NULL;

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -473,9 +473,6 @@ extern Datum ExecMakeFunctionResultSet(SetExprState *fcache,
 									   MemoryContext argContext,
 									   bool *isNull,
 									   ExprDoneCond *isDone);
-typedef void (*pass_pivot_data_to_fcinfo_hook_type)(FunctionCallInfo fcinfo, Expr *expr);
-extern PGDLLEXPORT pass_pivot_data_to_fcinfo_hook_type pass_pivot_data_to_fcinfo_hook;
-
 /*
  * prototypes from functions in execScan.c
  */

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -432,7 +432,6 @@ typedef struct FuncCall
 	bool		func_variadic;	/* last argument was labeled VARIADIC */
 	CoercionForm funcformat;	/* how to display this node */
 	int			location;		/* token location, or -1 if unknown */
-	Node 	   *context;		/* pass necessary info through planner and executor */
 } FuncCall;
 
 /*

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -695,8 +695,6 @@ typedef struct FuncExpr
 	List	   *args;
 	/* token location, or -1 if unknown */
 	int			location;
-	/* pass necessary info through planner and executor */
-	Node 	   *context pg_node_attr(query_jumble_ignore, read_write_ignore, read_as(NULL));
 } FuncExpr;
 
 /*


### PR DESCRIPTION
### Description

Support create/select/drop view on stmt with pivot operator. 

We switched to deparsed psql-text approach for VIEW/JOIN/CTE, all pivot metadata will be passed to bbf_pivot function arguments, so we removed all funcCall/funcExpr context field related code.

Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2962

### Issues Resolved

Task: BABEL-4673
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
