### PR TITLE
Support View usage for PIVOT operator (Deparsed psql-text) BABEL3

### DIFF
--- a/src/backend/executor/execSRF.c
+++ b/src/backend/executor/execSRF.c
@@ -33,9 +33,6 @@
 #include "utils/memutils.h"
 #include "utils/typcache.h"
 
-/* Hook to set TSQL pivot data to fcinfo */
-pass_pivot_data_to_fcinfo_hook_type pass_pivot_data_to_fcinfo_hook = NULL;
-
 /* static function decls */
 static void init_sexpr(Oid foid, Oid input_collation, Expr *node,
 					   SetExprState *sexpr, PlanState *parent,
@@ -203,11 +200,6 @@ ExecMakeTableFunctionResult(SetExprState *setexpr,
 	{
 		/* Treat setexpr as a generic expression */
 		InitFunctionCallInfoData(*fcinfo, NULL, 0, InvalidOid, NULL, NULL);
-	}
-	
-	if (sql_dialect == SQL_DIALECT_TSQL && pass_pivot_data_to_fcinfo_hook)
-	{
-		(pass_pivot_data_to_fcinfo_hook)(fcinfo, setexpr->expr);
 	}
 		
 	/*

--- a/src/backend/nodes/copyfuncs.c
+++ b/src/backend/nodes/copyfuncs.c
@@ -1628,7 +1628,6 @@ _copyFuncExpr(const FuncExpr *from)
 	COPY_SCALAR_FIELD(inputcollid);
 	COPY_NODE_FIELD(args);
 	COPY_LOCATION_FIELD(location);
-	COPY_NODE_FIELD(context);
 
 	return newnode;
 }
@@ -2828,7 +2827,6 @@ _copyFuncCall(const FuncCall *from)
 	COPY_SCALAR_FIELD(func_variadic);
 	COPY_SCALAR_FIELD(funcformat);
 	COPY_LOCATION_FIELD(location);
-	COPY_NODE_FIELD(context);
 
 	return newnode;
 }
@@ -3353,6 +3351,13 @@ _copySelectStmt(const SelectStmt *from)
 	COPY_SCALAR_FIELD(all);
 	COPY_NODE_FIELD(larg);
 	COPY_NODE_FIELD(rarg);
+	COPY_SCALAR_FIELD(isPivot);
+	COPY_NODE_FIELD(srcSql);
+	COPY_NODE_FIELD(catSql);
+	COPY_NODE_FIELD(value_col_strlist);
+	COPY_NODE_FIELD(pivotCol);
+	COPY_NODE_FIELD(aggFunc);
+
 
 	return newnode;
 }

--- a/src/backend/nodes/equalfuncs.c
+++ b/src/backend/nodes/equalfuncs.c
@@ -306,7 +306,6 @@ _equalFuncExpr(const FuncExpr *a, const FuncExpr *b)
 	COMPARE_SCALAR_FIELD(inputcollid);
 	COMPARE_NODE_FIELD(args);
 	COMPARE_LOCATION_FIELD(location);
-	COMPARE_NODE_FIELD(context);
 
 	return true;
 }
@@ -1104,6 +1103,12 @@ _equalSelectStmt(const SelectStmt *a, const SelectStmt *b)
 	COMPARE_SCALAR_FIELD(all);
 	COMPARE_NODE_FIELD(larg);
 	COMPARE_NODE_FIELD(rarg);
+	COMPARE_SCALAR_FIELD(isPivot);
+	COMPARE_NODE_FIELD(srcSql);
+	COMPARE_NODE_FIELD(catSql);
+	COMPARE_NODE_FIELD(value_col_strlist);
+	COMPARE_NODE_FIELD(pivotCol);
+	COMPARE_NODE_FIELD(aggFunc);
 
 	return true;
 }
@@ -2490,7 +2495,6 @@ _equalFuncCall(const FuncCall *a, const FuncCall *b)
 	COMPARE_SCALAR_FIELD(func_variadic);
 	COMPARE_COERCIONFORM_FIELD(funcformat);
 	COMPARE_LOCATION_FIELD(location);
-	COMPARE_NODE_FIELD(context);
 
 	return true;
 }

--- a/src/backend/nodes/makefuncs.c
+++ b/src/backend/nodes/makefuncs.c
@@ -531,7 +531,6 @@ makeFuncExpr(Oid funcid, Oid rettype, List *args,
 	funcexpr->inputcollid = inputcollid;
 	funcexpr->args = args;
 	funcexpr->location = -1;
-	funcexpr->context = NULL;
 
 	return funcexpr;
 }
@@ -598,7 +597,6 @@ makeFuncCall(List *name, List *args, CoercionForm funcformat, int location)
 	n->func_variadic = false;
 	n->funcformat = funcformat;
 	n->location = location;
-	n->context = NULL;
 	return n;
 }
 

--- a/src/backend/nodes/outfuncs.c
+++ b/src/backend/nodes/outfuncs.c
@@ -2869,6 +2869,12 @@ _outSelectStmt(StringInfo str, const SelectStmt *node)
 	WRITE_BOOL_FIELD(all);
 	WRITE_NODE_FIELD(larg);
 	WRITE_NODE_FIELD(rarg);
+	WRITE_BOOL_FIELD(isPivot);
+	WRITE_NODE_FIELD(srcSql);
+	WRITE_NODE_FIELD(catSql);
+	WRITE_NODE_FIELD(value_col_strlist);
+	WRITE_NODE_FIELD(pivotCol);
+	WRITE_NODE_FIELD(aggFunc);
 }
 
 static void
@@ -2907,7 +2913,6 @@ _outFuncCall(StringInfo str, const FuncCall *node)
 	WRITE_BOOL_FIELD(func_variadic);
 	WRITE_ENUM_FIELD(funcformat, CoercionForm);
 	WRITE_LOCATION_FIELD(location);
-	WRITE_NODE_FIELD(context);
 }
 
 static void

--- a/src/backend/nodes/readfuncs.c
+++ b/src/backend/nodes/readfuncs.c
@@ -778,7 +778,6 @@ _readFuncExpr(void)
 	READ_OID_FIELD(inputcollid);
 	READ_NODE_FIELD(args);
 	READ_LOCATION_FIELD(location);
-	local_node->context = NULL;
 
 	READ_DONE();
 }

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -2529,7 +2529,6 @@ eval_const_expressions_mutator(Node *node,
 				newexpr->inputcollid = expr->inputcollid;
 				newexpr->args = args;
 				newexpr->location = expr->location;
-				newexpr->context = expr->context;
 				return (Node *) newexpr;
 			}
 		case T_OpExpr:
@@ -4478,7 +4477,6 @@ evaluate_function(Oid funcid, Oid result_type, int32 result_typmod,
 	newexpr->inputcollid = input_collid;
 	newexpr->args = args;
 	newexpr->location = -1;
-	newexpr->context = NULL;
 
 	return evaluate_expr((Expr *) newexpr, result_type, result_typmod,
 						 result_collid);
@@ -4591,7 +4589,6 @@ inline_function(Oid funcid, Oid result_type, Oid result_collid,
 	fexpr->inputcollid = input_collid;
 	fexpr->args = args;
 	fexpr->location = -1;
-	fexpr->context = NULL;
 
 	/* Fetch the function body */
 	tmp = SysCacheGetAttr(PROCOID,

--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -765,10 +765,6 @@ ParseFuncOrColumn(ParseState *pstate, List *funcname, List *fargs,
 		/* funccollid and inputcollid will be set by parse_collate.c */
 		funcexpr->args = fargs;
 		funcexpr->location = location;
-		funcexpr->context = NULL;
-		
-		if (fn != NULL)
-			funcexpr->context = copyObject(fn->context);
 
 		retval = (Node *) funcexpr;
 	}

--- a/src/backend/utils/adt/ruleutils.c
+++ b/src/backend/utils/adt/ruleutils.c
@@ -11897,7 +11897,7 @@ generate_relation_name(Oid relid, List *namespaces)
 	if (!need_qual)
 		need_qual = !RelationIsVisible(relid);
 
-	if (need_qual)
+	if (need_qual || sql_dialect == SQL_DIALECT_TSQL)
 		nspname = get_namespace_name_or_temp(reltup->relnamespace);
 	else
 		nspname = NULL;

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -462,9 +462,6 @@ extern Datum ExecMakeFunctionResultSet(SetExprState *fcache,
 									   MemoryContext argContext,
 									   bool *isNull,
 									   ExprDoneCond *isDone);
-typedef void (*pass_pivot_data_to_fcinfo_hook_type)(FunctionCallInfo fcinfo, Expr *expr);
-extern PGDLLEXPORT pass_pivot_data_to_fcinfo_hook_type pass_pivot_data_to_fcinfo_hook;
-
 /*
  * prototypes from functions in execScan.c
  */

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -390,7 +390,6 @@ typedef struct FuncCall
 	bool		func_variadic;	/* last argument was labeled VARIADIC */
 	CoercionForm funcformat;	/* how to display this node */
 	int			location;		/* token location, or -1 if unknown */
-	Node 	   *context;		/* pass necessary info through planner and executor */
 } FuncCall;
 
 /*

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -502,7 +502,6 @@ typedef struct FuncExpr
 	Oid			inputcollid;	/* OID of collation that function should use */
 	List	   *args;			/* arguments to the function */
 	int			location;		/* token location, or -1 if unknown */
-    Node       *context;		/* pass necessary info through planner and executor */
 } FuncExpr;
 
 /*


### PR DESCRIPTION
### Description

Support create/select/drop view on stmt with pivot operator. 

We switched to deparsed psql-text approach for VIEW/JOIN/CTE, all pivot metadata will be passed to bbf_pivot function arguments, so we removed all funcCall/funcExpr context field related code.

Extension PR:

### Issues Resolved

Task: BABEL-4673
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
