### PR TITLE
Fix crash when trying to alter temp table column type.

### DIFF
--- a/src/backend/commands/cluster.c
+++ b/src/backend/commands/cluster.c
@@ -734,8 +734,14 @@ make_new_heap(Oid OIDOldHeap, Oid NewTableSpace, Oid NewAccessMethod,
 	 * a shared rel.  However, we do make the new heap mapped if the source is
 	 * mapped.  This simplifies swap_relation_files, and is absolutely
 	 * necessary for rebuilding pg_class, for reasons explained there.
+	 *
+	 * We also must ensure that these temp tables are properly named in TSQL
+	 * so that the metadata is properly cleaned up after in this function.
 	 */
-	snprintf(NewHeapName, sizeof(NewHeapName), "pg_temp_%u", OIDOldHeap);
+	if (sql_dialect == SQL_DIALECT_TSQL && relpersistence == RELPERSISTENCE_TEMP && get_ENR_withoid(currentQueryEnv, OIDOldHeap, ENR_TSQL_TEMP))
+		snprintf(NewHeapName, sizeof(NewHeapName), "#pg_temp_%u", OIDOldHeap);
+	else
+		snprintf(NewHeapName, sizeof(NewHeapName), "pg_temp_%u", OIDOldHeap);
 
 	OIDNewHeap = heap_create_with_catalog(NewHeapName,
 										  namespaceid,

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -102,6 +102,7 @@
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
 #include "utils/partcache.h"
+#include "utils/queryenvironment.h"
 #include "utils/relcache.h"
 #include "utils/ruleutils.h"
 #include "utils/snapmgr.h"
@@ -13047,7 +13048,14 @@ ATExecAlterColumnType(AlteredTableInfo *tab, Relation rel,
 			elog(ERROR, "found unexpected dependency for column: %s",
 				 getObjectDescription(&foundObject, false));
 
-		CatalogTupleDelete(depRel, &depTup->t_self);
+		if (scan->enr)
+		{
+			ENRdropTuple(depRel, depTup);
+		}
+		else 
+		{
+			CatalogTupleDelete(depRel, &depTup->t_self);
+		}
 	}
 
 	systable_endscan(scan);


### PR DESCRIPTION
### Description
In cases where a temp table column is being altered so that only the size changes (e.g. char(20) -> char(5)), the code path needs to drop the pg_depend entry from the normal catalog table (to be later recreated using the new target type). However, for ENR temp tables all catalog tuples are stored in currentQueryEnv and not actually in the catalogs themselves. Thus, the code would not be able to find the tuple for deletion, leading to an assertion error. Fix the issue by using ENRDropTuple() instead of CatalogTupleDelete() so that the code drops the tuple in the correct place.

Backport of https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/442

Note that there are additional changes compared to the original commit from https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/442 to allow this change to work with pg15, as there are commits which are present in pg16 which have not been backported to pg15 which are required for this change to work properly.
 
### Issues Resolved

BABEL-5273
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
