### PR TITLE
Support PgAudit with Babelfish and addition of PgAudit github action

### DIFF
--- a/src/backend/commands/event_trigger.c
+++ b/src/backend/commands/event_trigger.c
@@ -100,6 +100,7 @@ static void validate_table_rewrite_tags(const char *filtervar, List *taglist);
 static void EventTriggerInvoke(List *fn_oid_list, EventTriggerData *trigdata);
 static const char *stringify_grant_objtype(ObjectType objtype);
 static const char *stringify_adefprivs_objtype(ObjectType objtype);
+pltsql_get_object_identity_event_trigger_hook_type pltsql_get_object_identity_event_trigger_hook = NULL;
 
 /*
  * Create an event trigger.
@@ -1900,7 +1901,14 @@ pg_event_trigger_ddl_commands(PG_FUNCTION_ARGS)
 					 * rather than failing.  This can happen for example with
 					 * some subcommand combinations of ALTER TABLE.
 					 */
-					identity = getObjectIdentity(&addr, true);
+					if (pltsql_get_object_identity_event_trigger_hook)
+					{
+						identity = (*pltsql_get_object_identity_event_trigger_hook)(&addr);
+					}
+					else
+					{
+						identity = getObjectIdentity(&addr, true);
+					}
 					if (identity == NULL)
 						continue;
 

--- a/src/backend/tcop/utility.c
+++ b/src/backend/tcop/utility.c
@@ -1684,7 +1684,7 @@ ProcessUtilitySlow(ParseState *pstate,
 			case T_CreateTableAsStmt:
 				{
 					if(sql_dialect == SQL_DIALECT_TSQL && bbfSelectIntoUtility_hook)
-						(*bbfSelectIntoUtility_hook)(pstate, pstmt, queryString, NULL, params, qc);
+						(*bbfSelectIntoUtility_hook)(pstate, pstmt, queryString, NULL, params, qc, &address);
 					else{
 						address = ExecCreateTableAs(pstate, (CreateTableAsStmt *) parsetree,
 									params, queryEnv, qc);

--- a/src/include/commands/event_trigger.h
+++ b/src/include/commands/event_trigger.h
@@ -85,4 +85,7 @@ extern void EventTriggerCollectAlterTSConfig(AlterTSConfigurationStmt *stmt,
 											 Oid cfgId, Oid *dictIds, int ndicts);
 extern void EventTriggerCollectAlterDefPrivs(AlterDefaultPrivilegesStmt *stmt);
 
+typedef char* (*pltsql_get_object_identity_event_trigger_hook_type) (ObjectAddress* address);
+extern PGDLLIMPORT pltsql_get_object_identity_event_trigger_hook_type pltsql_get_object_identity_event_trigger_hook;
+
 #endif							/* EVENT_TRIGGER_H */

--- a/src/include/tcop/utility.h
+++ b/src/include/tcop/utility.h
@@ -16,6 +16,7 @@
 
 #include "tcop/cmdtag.h"
 #include "tcop/tcopprot.h"
+#include "catalog/objectaddress.h"
 
 typedef enum
 {
@@ -112,7 +113,7 @@ typedef bool (*bbfCustomProcessUtility_hook_type)(struct ParseState *pstate, Pla
 						  ParamListInfo params, QueryCompletion *qc);
 extern PGDLLIMPORT bbfCustomProcessUtility_hook_type bbfCustomProcessUtility_hook;
 typedef void (*bbfSelectIntoUtility_hook_type)(struct ParseState *pstate, PlannedStmt *pstmt, const char *queryString, QueryEnvironment *queryEnv, 
-						  ParamListInfo params, QueryCompletion *qc);
+						  ParamListInfo params, QueryCompletion *qc, ObjectAddress *address);
 extern PGDLLIMPORT bbfSelectIntoUtility_hook_type bbfSelectIntoUtility_hook;
 
 #endif							/* UTILITY_H */


### PR DESCRIPTION
### Description
Cherry Pick from : https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/441

Postgres event triggers can call pg_event_trigger_ddl_commands which in turn does a syscache lookup for the object that fired the event trigger. If the event is create babelfish temp table or table variable then the syscahe lookup will fail since ENR sys table scan is only allowed when dialect is TSQL but when executing pg_event_trigger_ddl_commands() dialect will be PSQL. As a fix we will temporarily switch the dialect to TSQL when doing a syscahe lookup inside pg_event_trigger_ddl_commands()
Extension PR link: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2981
Engine PR link: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/453
### Issues Resolved

[List any issues this PR will resolve]
### Task
 [BABEL-5269], [BABEL-5233]

Signed-off-by: Pranav Jain [pranavjc@amazon.com](mailto:pranavjc@amazon.com)
 
### Check List

- [ Pranav Jain] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
