### PR TITLE
Added hook to set common typmod for case expression

### DIFF
--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -89,6 +89,7 @@ static List *ExpandChecksumStar(ParseState *pstate, FuncCall *fn, int location);
 
 lookup_param_hook_type lookup_param_hook = NULL;
 handle_constant_literals_hook_type handle_constant_literals_hook = NULL;
+set_common_typmod_case_expr_hook_type set_common_typmod_case_expr_hook = NULL;
 /*
  * transformExpr -
  *	  Analyze and transform expressions. Type checking and type casting is
@@ -1807,6 +1808,10 @@ transformCaseExpr(ParseState *pstate, CaseExpr *c)
 									exprLocation(pstate->p_last_srf))));
 
 	newc->location = c->location;
+
+	/* Following hook will be used to set the typmod of all the CASE Branches. */
+	if (sql_dialect == SQL_DIALECT_TSQL && set_common_typmod_case_expr_hook)
+		(*set_common_typmod_case_expr_hook)(pstate, resultexprs, newc);
 
 	return (Node *) newc;
 }

--- a/src/include/parser/parse_coerce.h
+++ b/src/include/parser/parse_coerce.h
@@ -135,4 +135,7 @@ typedef int32 (*select_common_typmod_hook_type) (ParseState *pstate, List *exprs
 typedef Node *(*handle_constant_literals_hook_type) (ParseState *pstate, Node *e);
 extern PGDLLEXPORT handle_constant_literals_hook_type handle_constant_literals_hook;
 
+typedef void (*set_common_typmod_case_expr_hook_type) (ParseState *pstate, List *exprs, CaseExpr *newc);
+extern PGDLLIMPORT set_common_typmod_case_expr_hook_type set_common_typmod_case_expr_hook;
+
 #endif							/* PARSE_COERCE_H */


### PR DESCRIPTION
### 1. Issue:

Return type of overall CASE expression when branch expression is of String Datatype, is evaluated to give typmod error message if the common type is CHAR/NCHAR.

eg. If the Common type evaluated is CHAR/NCHAR
```
SELECT CASE 1
    WHEN 1 THEN NULL
    WHEN 2 THEN CAST('char' AS CHAR(10))
END
GO

```
Output: Msg 33557097, Level 16, State 1, Server BABELFISH, Line 1
The string size for the given CHAR/NCHAR data is not defined. Please use an explicit CAST or CONVERT to CHAR(n)/NCHAR(n).

Expected output: 
CHAR
NULL

### 2. Changes made to fix the issues

Implementing a hook that calculates the resultant typmod for the CASE expression, and also set typmod for all the CASE branches when .

Task: BABEL-5103, BABEL-4332
Authored-by: yashneet vinayak [yashneet@amazon.com](mailto:yashneet@amazon.com)
Signed-off-by: yashneet vinayak [yashneet@amazon.com](mailto:yashneet@amazon.com)

### Issues Resolved
Task: BABEL-5103, BABEL-4332

Extension side PR link: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/2995

cherry-pick: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/452

### Test Scenarios Covered ###
* **Use case based -**Yes


* **Boundary conditions -**Yes


* **Arbitrary inputs -**Yes


* **Negative test cases -**


* **Minor version upgrade tests -**Yes


* **Major version upgrade tests -**Yes


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**Yes



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).