### PR TITLE
Dump physical database aclprivs for fixed database roles

### DIFF
--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -1971,3 +1971,56 @@ dumpBabelfishConstrIndex(Archive *fout, const IndxInfo *indxinfo,
 	appendPQExpBuffer(delq, "DROP CONSTRAINT %s;\n",
 					  fmtId(constrinfo->dobj.name));
 }
+
+void
+dumpBabelPhysicalDatabaseACLs(Archive *fout)
+{
+	PQExpBuffer	query;
+	char *escaped_bbf_db_name;
+
+	if (!isBabelfishDatabase(fout) || fout->dopt->binary_upgrade)
+		return;
+
+	if (bbf_db_name)
+	{
+		escaped_bbf_db_name = pg_malloc(2 * strlen(bbf_db_name) + 1);
+		PQescapeString(escaped_bbf_db_name, bbf_db_name, strlen(bbf_db_name));
+	}
+	else
+		escaped_bbf_db_name = "";
+
+	query = createPQExpBuffer();
+
+	appendPQExpBuffer(query,
+					"DO $$"
+					"\nDECLARE"
+					"\n	rolname TEXT;"
+					"\n	original_name TEXT;"
+					"\nBEGIN"
+					"\n	SET LOCAL ROLE sysadmin;"
+					"\n	FOR rolname, original_name IN ("
+					"\n		SELECT a.rolname, a.orig_username FROM sys.babelfish_authid_user_ext a"
+					"\n			WHERE orig_username IN ('dbo') AND"
+					"\n			database_name NOT IN ('master', 'tempdb', 'msdb') AND"
+					"\n			('%s' = '' OR database_name = '%s')"
+					"\n	) LOOP"
+					"\n		CASE WHEN original_name = 'dbo' THEN"
+					"\n			EXECUTE format('GRANT CREATE, CONNECT, TEMPORARY ON DATABASE \"%%s\" TO \"%%s\"; ', CURRENT_DATABASE(), rolname);"
+					"\n		END CASE;"
+					"\n	END LOOP;"
+					"\n	RESET ROLE;"
+					"\nEND$$;\n\n", escaped_bbf_db_name, escaped_bbf_db_name);
+
+	ArchiveEntry(fout, nilCatalogId, createDumpId(),
+				 ARCHIVE_OPTS(.tag = "BABELFISHGRANTDATABASEPRIVSTOFIXEDROLES",
+							  .description = "BABELFISHGRANTDATABASEPRIVSTOFIXEDROLES",
+							  .section = SECTION_POST_DATA,
+							  .createStmt = query->data));
+
+	destroyPQExpBuffer(query);
+
+	if (bbf_db_name)
+		pg_free(escaped_bbf_db_name);
+
+	return;
+}

--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -1996,7 +1996,7 @@ dumpBabelPhysicalDatabaseACLs(Archive *fout)
 
 	if (bbf_db_name)
 		appendPQExpBuffer(query,
-					"\n			 AND database_name = '%s')", escaped_bbf_db_name);
+					"\n			 AND database_name = '%s'", escaped_bbf_db_name);
 
 	appendPQExpBuffer(query,
 					"\n	) LOOP"

--- a/src/bin/pg_dump/dump_babel_utils.h
+++ b/src/bin/pg_dump/dump_babel_utils.h
@@ -36,6 +36,7 @@ extern void updateExtConfigArray(Archive *fout, char ***extconfigarray, int ncon
 extern void prepareForBabelfishDatabaseDump(Archive *fout, SimpleStringList *schema_include_patterns);
 extern void setBabelfishDependenciesForLogicalDatabaseDump(Archive *fout);
 extern void dumpBabelGUCs(Archive *fout);
+extern void dumpBabelPhysicalDatabaseACLs(Archive *fout);
 extern void fixCopyCommand(Archive *fout, PQExpBuffer copyBuf, TableInfo *tbinfo, bool isFrom);
 extern bool bbfIsDumpWithInsert(Archive *fout, TableInfo *tbinfo);
 extern void addFromClauseForBabelfishCatalogTable(PQExpBuffer buf, TableInfo *tbinfo);

--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -993,6 +993,8 @@ main(int argc, char **argv)
 	for (i = 0; i < numObjs; i++)
 		dumpDumpableObject(fout, dobjs[i]);
 
+	dumpBabelPhysicalDatabaseACLs(fout);
+
 	/*
 	 * Set up options info to ensure we dump what we want.
 	 */


### PR DESCRIPTION
### Description

We were not dumping the acls on physical database granted to fixed database roles of user defined databases in babelfish dump and restore. As a result after bbf dump CREATE SCHEMA. would fail we permission denied error.

As a fix, dump a DO block which will run all the grant statements again for the fixed database roles for user defined logical databases. While running these grants we will switch to sysadmin because it has all the necessary permissions to grant and so that DROP DATABASE also works correctly. We internally switch to sysadmin when executing revoke commands during drop db commands, which would only work if grantor was also sysadmin.

#### Engine PR : https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/456
#### Extension PR : https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3003 

### Issues Resolved

[BABEL-5294]

#### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com> 

### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
