### PR TITLE
Support adding users to db_owner role

### DIFF
--- a/src/bin/pg_dump/dumpall_babel_utils.c
+++ b/src/bin/pg_dump/dumpall_babel_utils.c
@@ -218,8 +218,7 @@ getBabelfishRolesQuery(PGconn *conn, PQExpBuffer buf, char *role_catalog,
 		pfree(babel_init_user);
 	}
 	appendPQExpBufferStr(buf,
-						 "SELECT rolname FROM sys.babelfish_authid_user_ext "
-						 "UNION ");
+						 "SELECT rolname FROM sys.babelfish_authid_user_ext ");
 	/* Only dump users of the specific logical database we are currently dumping. */
 	if (bbf_db_name != NULL)
 	{
@@ -230,15 +229,13 @@ getBabelfishRolesQuery(PGconn *conn, PQExpBuffer buf, char *role_catalog,
 		char *escaped_bbf_db_name = pg_malloc(2 * strlen(bbf_db_name) + 1);
 
 		PQescapeString(escaped_bbf_db_name, bbf_db_name, strlen(bbf_db_name));
-		appendPQExpBuffer(buf,
-						  "WHERE database_name = '%s' "
-						  "UNION ",
-						  escaped_bbf_db_name);
+		appendPQExpBuffer(buf, "WHERE database_name = '%s' ", escaped_bbf_db_name);
 		pfree(escaped_bbf_db_name);
 	}
 
 	/* Append roles associated with db_owner members which are not present in bbf catalogs */
 	appendPQExpBuffer(buf,
+					  "UNION "
 					  "SELECT pr.rolname "
 					  "FROM ( "
 					  "SELECT DISTINCT pr.rolname AS member_role "
@@ -337,9 +334,7 @@ getBabelfishRoleMembershipQuery(PGconn *conn, PQExpBuffer buf,
 							 "SELECT 'sysadmin' AS rolname UNION "
 							 "SELECT 'bbf_role_admin' AS rolname UNION ");
 	appendPQExpBuffer(buf,
-					  "SELECT rolname FROM sys.babelfish_authid_user_ext "
-					  "UNION ");
-
+					  "SELECT rolname FROM sys.babelfish_authid_user_ext ");
 	/* Only dump users of the specific logical database we are currently dumping. */
 	if (bbf_db_name != NULL)
 	{
@@ -350,15 +345,13 @@ getBabelfishRoleMembershipQuery(PGconn *conn, PQExpBuffer buf,
 		char *escaped_bbf_db_name = pg_malloc(2 * strlen(bbf_db_name) + 1);
 
 		PQescapeString(escaped_bbf_db_name, bbf_db_name, strlen(bbf_db_name));
-		appendPQExpBuffer(buf,
-						  "WHERE database_name = '%s' "
-						  "UNION ",
-						  escaped_bbf_db_name);
+		appendPQExpBuffer(buf, "WHERE database_name = '%s' ", escaped_bbf_db_name);
 		pfree(escaped_bbf_db_name);
 	}
 
 		/* Append roles associated with db_owner members which are not present in bbf catalogs */
 	appendPQExpBuffer(buf,
+					  "UNION "
 					  "SELECT pr.rolname "
 					  "FROM ( "
 					  "SELECT DISTINCT pr.rolname AS member_role "

--- a/src/bin/pg_dump/dumpall_babel_utils.c
+++ b/src/bin/pg_dump/dumpall_babel_utils.c
@@ -218,7 +218,8 @@ getBabelfishRolesQuery(PGconn *conn, PQExpBuffer buf, char *role_catalog,
 		pfree(babel_init_user);
 	}
 	appendPQExpBufferStr(buf,
-						 "SELECT rolname FROM sys.babelfish_authid_user_ext ");
+						 "SELECT rolname FROM sys.babelfish_authid_user_ext "
+						 "UNION ");
 	/* Only dump users of the specific logical database we are currently dumping. */
 	if (bbf_db_name != NULL)
 	{
@@ -229,9 +230,43 @@ getBabelfishRolesQuery(PGconn *conn, PQExpBuffer buf, char *role_catalog,
 		char *escaped_bbf_db_name = pg_malloc(2 * strlen(bbf_db_name) + 1);
 
 		PQescapeString(escaped_bbf_db_name, bbf_db_name, strlen(bbf_db_name));
-		appendPQExpBuffer(buf, "WHERE database_name = '%s' ", escaped_bbf_db_name);
+		appendPQExpBuffer(buf,
+						  "WHERE database_name = '%s' "
+						  "UNION ",
+						  escaped_bbf_db_name);
 		pfree(escaped_bbf_db_name);
 	}
+
+	/* Append roles associated with db_owner members which are not present in bbf catalogs */
+	appendPQExpBuffer(buf,
+					  "SELECT pr.rolname "
+					  "FROM ( "
+					  "SELECT DISTINCT pr.rolname AS member_role "
+					  "FROM sys.babelfish_authid_user_ext ta "
+					  "JOIN pg_roles r ON r.rolname = ta.rolname "
+					  "JOIN pg_auth_members m ON r.oid = m.roleid "
+					  "JOIN pg_roles pr ON pr.oid = m.member "
+					  "WHERE pr.rolname != ta.rolname "
+					  "AND ta.orig_username = 'db_owner' ");
+
+	/* Only dump users of the specific logical database we are currently dumping. */
+	if (bbf_db_name != NULL)
+	{
+		/*
+		 * Get escaped bbf_db_name to handle special characters in it.
+		 * 2*strlen+1 bytes are required for PQescapeString according to the documentation.
+		 */
+		char *escaped_bbf_db_name = pg_malloc(2 * strlen(bbf_db_name) + 1);
+
+		PQescapeString(escaped_bbf_db_name, bbf_db_name, strlen(bbf_db_name));
+		appendPQExpBuffer(buf, "AND ta.database_name = '%s' ", escaped_bbf_db_name);
+		pfree(escaped_bbf_db_name);
+	}
+
+	appendPQExpBuffer(buf,
+					  ") AS db_owner_members "
+					  "JOIN pg_roles pr ON pr.rolname = db_owner_members.member_role || '_obj' ");
+
 	appendPQExpBuffer(buf, "), "
 					  "bbf_roles AS (SELECT rc.* FROM %s rc INNER JOIN bbf_catalog bcat "
 					  "ON rc.rolname = bcat.rolname) ", role_catalog);
@@ -302,7 +337,9 @@ getBabelfishRoleMembershipQuery(PGconn *conn, PQExpBuffer buf,
 							 "SELECT 'sysadmin' AS rolname UNION "
 							 "SELECT 'bbf_role_admin' AS rolname UNION ");
 	appendPQExpBuffer(buf,
-					  "SELECT rolname FROM sys.babelfish_authid_user_ext ");
+					  "SELECT rolname FROM sys.babelfish_authid_user_ext "
+					  "UNION ");
+
 	/* Only dump users of the specific logical database we are currently dumping. */
 	if (bbf_db_name != NULL)
 	{
@@ -313,9 +350,43 @@ getBabelfishRoleMembershipQuery(PGconn *conn, PQExpBuffer buf,
 		char *escaped_bbf_db_name = pg_malloc(2 * strlen(bbf_db_name) + 1);
 
 		PQescapeString(escaped_bbf_db_name, bbf_db_name, strlen(bbf_db_name));
-		appendPQExpBuffer(buf, "WHERE database_name = '%s' ", escaped_bbf_db_name);
+		appendPQExpBuffer(buf,
+						  "WHERE database_name = '%s' "
+						  "UNION ",
+						  escaped_bbf_db_name);
 		pfree(escaped_bbf_db_name);
 	}
+
+		/* Append roles associated with db_owner members which are not present in bbf catalogs */
+	appendPQExpBuffer(buf,
+					  "SELECT pr.rolname "
+					  "FROM ( "
+					  "SELECT DISTINCT pr.rolname AS member_role "
+					  "FROM sys.babelfish_authid_user_ext ta "
+					  "JOIN pg_roles r ON r.rolname = ta.rolname "
+					  "JOIN pg_auth_members m ON r.oid = m.roleid "
+					  "JOIN pg_roles pr ON pr.oid = m.member "
+					  "WHERE pr.rolname != ta.rolname "
+					  "AND ta.orig_username = 'db_owner' ");
+
+	/* Only dump users of the specific logical database we are currently dumping. */
+	if (bbf_db_name != NULL)
+	{
+		/*
+		 * Get escaped bbf_db_name to handle special characters in it.
+		 * 2*strlen+1 bytes are required for PQescapeString according to the documentation.
+		 */
+		char *escaped_bbf_db_name = pg_malloc(2 * strlen(bbf_db_name) + 1);
+
+		PQescapeString(escaped_bbf_db_name, bbf_db_name, strlen(bbf_db_name));
+		appendPQExpBuffer(buf, "AND ta.database_name = '%s' ", escaped_bbf_db_name);
+		pfree(escaped_bbf_db_name);
+	}
+
+	appendPQExpBuffer(buf,
+					  ") AS db_owner_members "
+					  "JOIN pg_roles pr ON pr.rolname = db_owner_members.member_role || '_obj' ");
+
 	appendPQExpBuffer(buf, "), "
 					  "bbf_roles AS (SELECT rc.* FROM %s rc INNER JOIN bbf_catalog bcat "
 					  "ON rc.rolname = bcat.rolname) ", role_catalog);


### PR DESCRIPTION
### Description

To support adding members to db_owner role, we are internally creating PG roles which would only own objects for their respective users that are added to db_owner role. Since these are internal roles, we do not persist them in Babelfish catalog but, it is necessary to dump them when taking a Babelfish data dump.

In this commit, we have modified the SQL to dump the roles and role memberships to also dump DDLs corresponding to these internal roles.

Task: BABEL-4899
Signed-off-by: Sharu Goel <goelshar@amazon.com>
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
