### PR TITLE
Support db_datareader/db_datawriter

### DIFF
--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -1124,9 +1124,9 @@ addFromClauseForLogicalDatabaseDump(PQExpBuffer buf, TableInfo *tbinfo)
 						  "ON a.database_name = b.name COLLATE \"C\" "
 						  "WHERE b.dbid = %d "
 						  "AND a.rolname NOT IN "
-						  "('master_dbo', 'master_db_owner', 'master_guest', "
-						  "'msdb_dbo', 'msdb_db_owner', 'msdb_guest', "
-						  "'tempdb_dbo', 'tempdb_db_owner', 'tempdb_guest') ",
+						   "('master_dbo', 'master_db_owner', 'master_guest', 'master_db_datareader', 'master_db_datawriter', "
+						  "'msdb_dbo', 'msdb_db_owner', 'msdb_guest', 'msdb_db_datareader', 'msdb_db_datawriter', "
+						  "'tempdb_dbo', 'tempdb_db_owner', 'tempdb_guest', 'tempdb_db_datareader', 'tempdb_db_datawriter') ",
 						  fmtQualifiedDumpable(tbinfo), bbf_db_id);
 	}
 	else
@@ -1170,9 +1170,9 @@ addFromClauseForPhysicalDatabaseDump(PQExpBuffer buf, TableInfo *tbinfo)
 	{
 		appendPQExpBuffer(buf, " FROM ONLY %s a "
 						  "WHERE a.rolname NOT IN "
-						  "('master_dbo', 'master_db_owner', 'master_guest', "
-						  "'tempdb_dbo', 'tempdb_db_owner', 'tempdb_guest', "
-						  "'msdb_dbo', 'msdb_db_owner', 'msdb_guest')",
+						  "('master_dbo', 'master_db_owner', 'master_guest', 'master_db_datareader', 'master_db_datawriter', "
+						  "'tempdb_dbo', 'tempdb_db_owner', 'tempdb_guest', 'tempdb_db_datareader', 'tempdb_db_datawriter', "
+						  "'msdb_dbo', 'msdb_db_owner', 'msdb_guest', 'msdb_db_datareader', 'msdb_db_datawriter')",
 						  fmtQualifiedDumpable(tbinfo));
 	}
 	else if(strcmp(tbinfo->dobj.name, "babelfish_authid_login_ext") == 0)

--- a/src/bin/pg_dump/dumpall_babel_utils.c
+++ b/src/bin/pg_dump/dumpall_babel_utils.c
@@ -36,9 +36,9 @@ typedef enum {
 static babelfish_status bbf_status = NONE;
 
 static char default_bbf_roles[] = "('sysadmin', 'bbf_role_admin', "
-								  "'master_dbo', 'master_db_owner', 'master_guest', "
-								  "'msdb_dbo', 'msdb_db_owner', 'msdb_guest', "
-								  "'tempdb_dbo', 'tempdb_db_owner', 'tempdb_guest')";
+								  "'master_dbo', 'master_db_owner', 'master_guest', 'master_db_datareader', 'master_db_datawriter', "
+								  "'msdb_dbo', 'msdb_db_owner', 'msdb_guest', 'msdb_db_datareader', 'msdb_db_datawriter', "
+								  "'tempdb_dbo', 'tempdb_db_owner', 'tempdb_guest', 'tempdb_db_datareader', 'tempdb_db_datawriter')";
 
 /*
  * Run a query, return the results, exit program on failure.


### PR DESCRIPTION
### Description

We need to skip dumping these fixed roles db_datareader/db_datawriter for inbuilt databases like master, tempdb, msdb.

Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3018 

### Issues Resolved

Task: BABEL-3883
Signed-off-by: Shalini Lohia <lshalini@amazon.com>
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
