### PR TITLE
test fix for 25d639e

### DIFF
--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -2445,8 +2445,15 @@ _SPI_execute_plan(SPIPlanPtr plan, const SPIExecuteOptions *options,
 	 * not inside a subtransaction.  The latter two tests match whether
 	 * _SPI_commit() would allow a commit; see there for more commentary.
 	 */
-	allow_nonatomic = options->allow_nonatomic &&
-		!_SPI_current->atomic && !IsSubTransaction();
+	if (check_pltsql_support_tsql_transactions_hook && (*check_pltsql_support_tsql_transactions_hook)() && false)
+	{
+		allow_nonatomic = options->allow_nonatomic && !_SPI_current->atomic;
+	}
+	else
+	{
+		allow_nonatomic = options->allow_nonatomic &&
+			!_SPI_current->atomic && !IsSubTransaction();
+	}
 
 	/*
 	 * Setup error traceback support for ereport()

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -336,13 +336,13 @@ _SPI_rollback(bool chain)
 	MemoryContext oldcontext = CurrentMemoryContext;
 	SavedTransactionCharacteristics savetc;
 
-	/* see under SPI_commit() */
+	/* see comments in _SPI_commit() */
 	if (_SPI_current->atomic)
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_TRANSACTION_TERMINATION),
 				 errmsg("invalid transaction termination")));
 
-	/* see under SPI_commit() */
+	/* see comments in _SPI_commit() */
 	if (IsSubTransaction())
 		ereport(ERROR,
 				(errcode(ERRCODE_INVALID_TRANSACTION_TERMINATION),
@@ -597,8 +597,11 @@ SPI_inside_nonatomic_context(void)
 {
 	if (_SPI_current == NULL)
 		return false;			/* not in any SPI context at all */
+	/* these tests must match _SPI_commit's opinion of what's atomic: */
 	if (_SPI_current->atomic)
 		return false;			/* it's atomic (ie function not procedure) */
+	if (IsSubTransaction())
+		return false;			/* if within subtransaction, it's atomic */
 	return true;
 }
 
@@ -2438,9 +2441,12 @@ _SPI_execute_plan(SPIPlanPtr plan, const SPIExecuteOptions *options,
 
 	/*
 	 * We allow nonatomic behavior only if options->allow_nonatomic is set
-	 * *and* the SPI_OPT_NONATOMIC flag was given when connecting.
+	 * *and* the SPI_OPT_NONATOMIC flag was given when connecting and we are
+	 * not inside a subtransaction.  The latter two tests match whether
+	 * _SPI_commit() would allow a commit; see there for more commentary.
 	 */
-	allow_nonatomic = options->allow_nonatomic && !_SPI_current->atomic;
+	allow_nonatomic = options->allow_nonatomic &&
+		!_SPI_current->atomic && !IsSubTransaction();
 
 	/*
 	 * Setup error traceback support for ereport()

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -2445,7 +2445,7 @@ _SPI_execute_plan(SPIPlanPtr plan, const SPIExecuteOptions *options,
 	 * not inside a subtransaction.  The latter two tests match whether
 	 * _SPI_commit() would allow a commit; see there for more commentary.
 	 */
-	if (check_pltsql_support_tsql_transactions_hook && (*check_pltsql_support_tsql_transactions_hook)() && false)
+	if (check_pltsql_support_tsql_transactions_hook && (*check_pltsql_support_tsql_transactions_hook)())
 	{
 		allow_nonatomic = options->allow_nonatomic && !_SPI_current->atomic;
 	}

--- a/src/pl/plpgsql/src/expected/plpgsql_call.out
+++ b/src/pl/plpgsql/src/expected/plpgsql_call.out
@@ -597,6 +597,26 @@ NOTICE:  f_get_x(1)
 NOTICE:  f_print_x(1)
 NOTICE:  f_get_x(2)
 NOTICE:  f_print_x(2)
+-- test in non-atomic context, except exception block is locally atomic
+DO $$
+BEGIN
+ BEGIN
+  UPDATE t_test SET x = x + 1;
+  RAISE NOTICE 'f_get_x(%)', f_get_x();
+  CALL f_print_x(f_get_x());
+  UPDATE t_test SET x = x + 1;
+  RAISE NOTICE 'f_get_x(%)', f_get_x();
+  CALL f_print_x(f_get_x());
+ EXCEPTION WHEN division_by_zero THEN
+   RAISE NOTICE '%', SQLERRM;
+ END;
+  ROLLBACK;
+END
+$$;
+NOTICE:  f_get_x(1)
+NOTICE:  f_print_x(1)
+NOTICE:  f_get_x(2)
+NOTICE:  f_print_x(2)
 -- test in atomic context
 BEGIN;
 DO $$

--- a/src/pl/plpgsql/src/sql/plpgsql_call.sql
+++ b/src/pl/plpgsql/src/sql/plpgsql_call.sql
@@ -557,6 +557,23 @@ BEGIN
 END
 $$;
 
+-- test in non-atomic context, except exception block is locally atomic
+DO $$
+BEGIN
+ BEGIN
+  UPDATE t_test SET x = x + 1;
+  RAISE NOTICE 'f_get_x(%)', f_get_x();
+  CALL f_print_x(f_get_x());
+  UPDATE t_test SET x = x + 1;
+  RAISE NOTICE 'f_get_x(%)', f_get_x();
+  CALL f_print_x(f_get_x());
+ EXCEPTION WHEN division_by_zero THEN
+   RAISE NOTICE '%', SQLERRM;
+ END;
+  ROLLBACK;
+END
+$$;
+
 -- test in atomic context
 BEGIN;
 


### PR DESCRIPTION
### Description

Test fix for community commit https://github.com/postgres/postgres/commit/25d639e.

Pushing the patch first since this commit is not yet merged in babelfish engine fork and they trying out the fix

Community fixes an issue where stable functions in call arguments may use a stale snapshot. This breaks babelfish's transaction statements inside procedure since babelfish completely removes all snapshot whenever there is a full commit or rollback using `ForgetPortalSnapshots();`. But with this community change there would still be a snapshot referenced by the SPI connection executing the procedure, and leads to us erroring out in `ForgetPortalSnapshots();` 
```
elog(ERROR, "portal snapshots (%d) did not account for all active snapshots (%d)",
```
and erroring out in the middle of executing transaction commands leaves us in invalid transaction state, so later on we hit a fatal error.
```
FATAL:  RollbackAndReleaseCurrentSubTransaction: unexpected state SUBABORT_PENDING
```

As a fix we simply skip this patch when there are only pltsql functions/procedure in call stack.
This fix does not apply to babelfish since pltsql does not allow functions in procedure arguments.
When there is a non tsql proc/function in call stack we will use this patch. We also need not worry about commit and abort in this scenraio (ptsql -> plpgsql -> pltsql_inner_proc does a commit but outer plpgsql could still be holding a snapshot) since we use SPI_commit & SPI_rollback when non tsql functions are in call stack.


### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).