### PR TITLE
[BABEL] Object should be owned by schema owner by default

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -830,6 +830,11 @@ DefineRelation(CreateStmt *stmt, char relkind, Oid ownerId,
 	if (!OidIsValid(ownerId))
 		ownerId = GetUserId();
 
+	if (pltsql_get_object_owner_hook)
+	{
+		ownerId = (*pltsql_get_object_owner_hook)(namespaceId, ownerId);
+	}
+
 	/*
 	 * Parse and validate reloptions, if any.
 	 */

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -826,14 +826,14 @@ DefineRelation(CreateStmt *stmt, char relkind, Oid ownerId,
 				(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 				 errmsg("only shared relations can be placed in pg_global tablespace")));
 
-	/* Identify user ID that will own the table */
-	if (!OidIsValid(ownerId))
-		ownerId = GetUserId();
-
-	if (pltsql_get_object_owner_hook)
+	if (pltsql_get_object_owner_hook && !OidIsValid(ownerId))
 	{
 		ownerId = (*pltsql_get_object_owner_hook)(namespaceId, ownerId);
 	}
+
+	/* Identify user ID that will own the table */
+	if (!OidIsValid(ownerId))
+		ownerId = GetUserId();
 
 	/*
 	 * Parse and validate reloptions, if any.

--- a/src/backend/utils/adt/acl.c
+++ b/src/backend/utils/adt/acl.c
@@ -126,6 +126,7 @@ static void RoleMembershipCacheCallback(Datum arg, int cacheid, uint32 hashvalue
 
 bbf_get_sysadmin_oid_hook_type bbf_get_sysadmin_oid_hook = NULL;
 get_bbf_admin_oid_hook_type get_bbf_admin_oid_hook = NULL;
+pltsql_get_object_owner_hook_type pltsql_get_object_owner_hook = NULL;
 
 
 /*

--- a/src/include/utils/acl.h
+++ b/src/include/utils/acl.h
@@ -284,4 +284,7 @@ extern PGDLLEXPORT bbf_get_sysadmin_oid_hook_type bbf_get_sysadmin_oid_hook;
 typedef Oid (*get_bbf_admin_oid_hook_type) (void);
 extern PGDLLEXPORT get_bbf_admin_oid_hook_type get_bbf_admin_oid_hook;
 
+typedef Oid (*pltsql_get_object_owner_hook_type) (Oid, Oid);
+extern PGDLLEXPORT pltsql_get_object_owner_hook_type pltsql_get_object_owner_hook;
+
 #endif							/* ACL_H */


### PR DESCRIPTION
### Description

Engine PR : https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/465
Extension PR.: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3063
 
### Issues Resolved

[BABEL-5361]
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
