### PR TITLE
Babel: Enable babelfishpg_tsql.dump_restore GUC while restoring roles

### DIFF
--- a/src/bin/pg_dump/dumpall_babel_utils.c
+++ b/src/bin/pg_dump/dumpall_babel_utils.c
@@ -138,6 +138,9 @@ dumpBabelRestoreChecks(FILE *OPF, PGconn *conn, int binary_upgrade)
 	res = executeQuery(conn, "SELECT setting::INT from pg_settings WHERE name = 'server_version_num';");
 	source_server_version_num = atoi(PQgetvalue(res, 0, 0));
 
+	/* SET babelfishpg_tsql.dump_restore GUC in the beginning */
+	appendPQExpBufferStr(qry, "SET babelfishpg_tsql.dump_restore = TRUE;\n");
+
 	/*
 	 * Temporarily enable ON_ERROR_STOP so that whole restore script
 	 * execution fails if the following do block raises an error.


### PR DESCRIPTION
### Description
Set babelfishpg_tsql.dump_restore GUC to true while restoring roles so
that we can use this to add special handling during restore.

Task: BABEL-5039
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
