### PR TITLE
Extend the ability of planner_node_transformer_hook to store the context of expression being process

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -1172,7 +1172,6 @@ preprocess_expression(PlannerInfo *root, Node *expr, int kind)
 		printf("After canonicalize_qual()\n");
 		pprint(expr);
 #endif
-
 	}
 
 	/*

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -1168,6 +1168,11 @@ preprocess_expression(PlannerInfo *root, Node *expr, int kind)
 		printf("After canonicalize_qual()\n");
 		pprint(expr);
 #endif
+
+	/* Reset context of expression */
+	if(EXPRKIND_TARGET == kind && planner_node_transformer_hook)
+		expr = planner_node_transformer_hook(root, NULL, -1);
+
 	}
 
 	/*

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -1157,6 +1157,10 @@ preprocess_expression(PlannerInfo *root, Node *expr, int kind)
 	if (kind != EXPRKIND_RTFUNC)
 		expr = eval_const_expressions(root, expr);
 
+	/* Reset context of expression */
+	if(EXPRKIND_TARGET == kind && planner_node_transformer_hook)
+		(void) planner_node_transformer_hook(root, NULL, -1);
+
 	/*
 	 * If it's a qual or havingQual, canonicalize it.
 	 */
@@ -1168,10 +1172,6 @@ preprocess_expression(PlannerInfo *root, Node *expr, int kind)
 		printf("After canonicalize_qual()\n");
 		pprint(expr);
 #endif
-
-	/* Reset context of expression */
-	if(EXPRKIND_TARGET == kind && planner_node_transformer_hook)
-		expr = planner_node_transformer_hook(root, NULL, -1);
 
 	}
 


### PR DESCRIPTION
…

### Description

Extend the ability of planner_node_transformer_hook to store the context of expression being process. This saved context will be used during planning to transform declared variable either as a Param (if it appears in TargetList) or as a const (all the other places). 
 
### Issues Resolved

Extension: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3011
Task: BABEL-5188
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>

### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
