### PR TITLE
[OSS-ONLY] Update automatic tag creation validation for Minor Version

### DIFF
--- a/.github/scripts/create-tag.sh
+++ b/.github/scripts/create-tag.sh
@@ -37,9 +37,9 @@ fi
 
 # check the tag format (need manual update when necessary)
 format=BABEL_
-if ! [[ "$new" =~ "$format"[0-9]_[0-9]_[0-9]__"PG"_[0-9]+_[0-9] ]]
+if ! [[ "$new" =~ "$format"[0-9]_[0-9]+_[0-9]__"PG"_[0-9]+_[0-9]+ ]]
 then
-    echo "Error: Invalid tag prefix, expected: ${format}<digit>_<digit>_<digit>__PG_<number>_<digit>"
+    echo "Error: Invalid tag prefix, expected: ${format}<digit>_<number>_<digit>__PG_<number>_<number>"
     exit 1
 fi
 


### PR DESCRIPTION
### Description

Till now we were considering a digit for tag for all versions. But it is possible that the minor version may go beyond 9, in that case the automatic tag creation workflow will fail at input tag validation step. This commit updates the validation to handle such cases

Signed-off-by: Shameem Ahmed [shmeeh@amazon.com](mailto:shmeeh@amazon.com)
 

 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
