### PR TITLE
Fix drop database issue after MVU to PG17

### DIFF
--- a/src/backend/catalog/aclchk.c
+++ b/src/backend/catalog/aclchk.c
@@ -5008,13 +5008,15 @@ RemoveRoleFromInitPriv(Oid roleid, Oid classid, Oid objid, int32 objsubid)
 	if (old_acl != NULL)
 	{
 		Oid sysadminOid;
+		const char *babelfish_db_name;
 
 		/*
 		 * For babelfish database, grantor will be sysadmin instead of object owner.
 		 */
 		if (bbf_get_sysadmin_oid_hook &&
 			classid == DatabaseRelationId &&
-			objid == get_database_oid(GetConfigOption("babelfishpg_tsql.database_name", true, false), true) &&
+			(babelfish_db_name = GetConfigOption("babelfishpg_tsql.database_name", true, false)) &&
+			objid == get_database_oid(babelfish_db_name, true) &&
 			is_member_of_role(GetUserId(), sysadminOid = (*bbf_get_sysadmin_oid_hook)()))
 		{
 			grantorId = sysadminOid;

--- a/src/backend/catalog/aclchk.c
+++ b/src/backend/catalog/aclchk.c
@@ -5010,10 +5010,11 @@ RemoveRoleFromInitPriv(Oid roleid, Oid classid, Oid objid, int32 objsubid)
 		Oid sysadminOid;
 
 		/*
-		 * For TSQL system roles, grantor will be sysadmin instead of owner.
+		 * For babelfish database, grantor will be sysadmin instead of object owner.
 		 */
 		if (bbf_get_sysadmin_oid_hook &&
 			classid == DatabaseRelationId &&
+			objid == get_database_oid(GetConfigOption("babelfishpg_tsql.database_name", true, false), true) &&
 			is_member_of_role(GetUserId(), sysadminOid = (*bbf_get_sysadmin_oid_hook)()))
 		{
 			grantorId = sysadminOid;

--- a/src/backend/catalog/aclchk.c
+++ b/src/backend/catalog/aclchk.c
@@ -4942,6 +4942,7 @@ RemoveRoleFromInitPriv(Oid roleid, Oid classid, Oid objid, int32 objsubid)
 	int			nnewmembers;
 	Oid		   *oldmembers;
 	Oid		   *newmembers;
+	Oid		   grantorId;
 
 	/* Search for existing pg_init_privs entry for the target object. */
 	rel = table_open(InitPrivsRelationId, RowExclusiveLock);
@@ -5005,14 +5006,30 @@ RemoveRoleFromInitPriv(Oid roleid, Oid classid, Oid objid, int32 objsubid)
 	 * Generate new ACL.  Grantor of rights is always the same as the owner.
 	 */
 	if (old_acl != NULL)
+	{
+		Oid sysadminOid;
+
+		/*
+		 * For TSQL system roles, grantor will be sysadmin instead of owner.
+		 */
+		if (bbf_get_sysadmin_oid_hook &&
+			classid == DatabaseRelationId &&
+			is_member_of_role(GetUserId(), sysadminOid = (*bbf_get_sysadmin_oid_hook)()))
+		{
+			grantorId = sysadminOid;
+		}
+		else
+			grantorId = ownerId;
+
 		new_acl = merge_acl_with_grant(old_acl,
 									   false,	/* is_grant */
 									   false,	/* grant_option */
 									   DROP_RESTRICT,
 									   list_make1_oid(roleid),
 									   ACLITEM_ALL_PRIV_BITS,
-									   ownerId,
+									   grantorId,
 									   ownerId);
+	}
 	else
 		new_acl = NULL;			/* this case shouldn't happen, probably */
 


### PR DESCRIPTION
### Description

After performing MVU to PG17, we weren't able to drop the existing database because a new dependency was getting added between the `dbo` system role and physical babelfish database. This dependency is getting introduced when running the TSQL upgrade script babelfishpg_tsql--3.4.0--4.0.0.sql, which grants permissions to the bbf_role_admin role. The new dependency is expected and is a result of a community change https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/commit/514a3de8b0e63aaa9e126c65b5b68bea20fbdde3. However, even though there is a function RemoveRoleFromInitPriv() to clean up these dependencies when executing DROP OWNED BY commands, it is not working correctly for system roles. This is because the function assumes the grantor of rights is always the same as the owner, which is not the case for system roles, where the grantor should be sysadmin.

This commit made changes to use sysadmin as grantor when generating ACLs for physical babelfish database while removing role from initial privileges.
 

Signed-off-by: Sumit Jaiswal <sumiji@amazon.com>

Related Task: BABEL-5410
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
