### PR TITLE
Babel: Re-enable the hash assert

### DIFF
--- a/src/include/common/hashfn_unstable.h
+++ b/src/include/common/hashfn_unstable.h
@@ -348,7 +348,7 @@ fasthash_accum_cstring(fasthash_state *hs, const char *str)
 	{
 		len = fasthash_accum_cstring_aligned(hs, str);
 		Assert(len_check == len);
-		// TODO: Assert(hs_check.hash == hs->hash);
+		Assert(hs_check.hash == hs->hash);
 		return len;
 	}
 #endif							/* SIZEOF_VOID_P */


### PR DESCRIPTION
### Description
The assert in `fasthash_accum_cstring` was previously disabled due to
crash during restore. Re-enable this assert since the related testcase has
been updated to fix the issue.

Task: BABEL-5421
Signed-off-by: Rishabh Tanwar <ritanwar@amazon.com>
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
