### PR TITLE
Merge 4_X changes back to 5_X

### DIFF
--- a/.github/scripts/create-tag.sh
+++ b/.github/scripts/create-tag.sh
@@ -37,9 +37,9 @@ fi
 
 # check the tag format (need manual update when necessary)
 format=BABEL_
-if ! [[ "$new" =~ "$format"[0-9]_[0-9]_[0-9]__"PG"_[0-9]+_[0-9] ]]
+if ! [[ "$new" =~ "$format"[0-9]_[0-9]+_[0-9]__"PG"_[0-9]+_[0-9]+ ]]
 then
-    echo "Error: Invalid tag prefix, expected: ${format}<digit>_<digit>_<digit>__PG_<number>_<digit>"
+    echo "Error: Invalid tag prefix, expected: ${format}<digit>_<number>_<digit>__PG_<number>_<number>"
     exit 1
 fi
 

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -1182,6 +1182,10 @@ preprocess_expression(PlannerInfo *root, Node *expr, int kind)
 	if (kind != EXPRKIND_RTFUNC)
 		expr = eval_const_expressions(root, expr);
 
+	/* Reset context of expression */
+	if(EXPRKIND_TARGET == kind && planner_node_transformer_hook)
+		(void) planner_node_transformer_hook(root, NULL, -1);
+
 	/*
 	 * If it's a qual or havingQual, canonicalize it.
 	 */


### PR DESCRIPTION
### Description

This is a cherry-pick PR which merges newer 4_X engine commits into 5_X.
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
