### PR TITLE
Fix the incorrect string limit when declaring NVARCHAR(Max)

### DIFF
--- a/src/backend/utils/adt/jsonpath_exec.c
+++ b/src/backend/utils/adt/jsonpath_exec.c
@@ -573,7 +573,7 @@ tsql_openjson_with_columnize(Jsonb *jb, char *col_info)
 		if (token)
 		{
 			token = strtok(NULL, ")");
-			if (token)
+			if (token && atoi(token) > 0)
 				col_size = atoi(token);
 		}
 	}


### PR DESCRIPTION
### Description

Previously, the limit on the max length of NVARCHAR(Max) was 4000, longer characters will be truncated. But NVARCHAR(MAX) should be capable of handling strings far longer than 4,000 characters. This pr change the col_size to default INT_MAX.
 
### Issues Resolved

[BABEL-5054](https://jira.rds.a2z.com/browse/BABEL-5054)
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
