### PR TITLE
ExecProcessReturning is unexpectedly called twice for psql request ca…

### DIFF
--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -826,7 +826,7 @@ ExecInsert(ModifyTableContext *context,
 	}
 
 	/* Process RETURNING if present */
-	if (resultRelInfo->ri_projectReturning)
+	if (resultRelInfo->ri_projectReturning && sql_dialect == SQL_DIALECT_TSQL)
 		result = ExecProcessReturning(resultRelInfo, slot, planSlot);
 
 	/* INSTEAD OF ROW INSERT Triggers */
@@ -1220,7 +1220,7 @@ ExecInsert(ModifyTableContext *context,
 		ExecWithCheckOptions(WCO_VIEW_CHECK, resultRelInfo, slot, estate);
 
 	/* Process RETURNING if present */
-	if (resultRelInfo->ri_projectReturning)
+	if (resultRelInfo->ri_projectReturning && sql_dialect != SQL_DIALECT_TSQL)
 		result = ExecProcessReturning(resultRelInfo, slot, planSlot);
 
 	if (inserted_tuple)

--- a/src/test/regress/expected/babel_5343_returning.out
+++ b/src/test/regress/expected/babel_5343_returning.out
@@ -1,0 +1,21 @@
+CREATE TABLE toverflow(id SERIAL, col1 VARCHAR);
+INSERT INTO toverflow VALUES (default, 'hope') RETURNING xmax::text::int;
+ xmax 
+------
+    0
+(1 row)
+
+INSERT INTO toverflow VALUES (default, 'jack') RETURNING xmax;
+ xmax 
+------
+    0
+(1 row)
+
+SELECT * FROM toverflow ORDER BY id;
+ id | col1 
+----+------
+  1 | hope
+  2 | jack
+(2 rows)
+
+DROP TABLE toverflow;

--- a/src/test/regress/parallel_schedule
+++ b/src/test/regress/parallel_schedule
@@ -133,3 +133,6 @@ test: serializable
 # run tablespace test at the end because it drops the tablespace created during
 # setup that other tests may use.
 test: tablespace
+
+# Test Babel returning issue BABEL-5343
+test: babel_5343_returning

--- a/src/test/regress/sql/babel_5343_returning.sql
+++ b/src/test/regress/sql/babel_5343_returning.sql
@@ -1,0 +1,5 @@
+CREATE TABLE toverflow(id SERIAL, col1 VARCHAR);
+INSERT INTO toverflow VALUES (default, 'hope') RETURNING xmax::text::int;
+INSERT INTO toverflow VALUES (default, 'jack') RETURNING xmax;
+SELECT * FROM toverflow ORDER BY id;
+DROP TABLE toverflow;


### PR DESCRIPTION
### Description

In community postgresql, ExecProcessReturning is called once after the main process of ExecInsert. But due to some merging errors related to Babelfish and T-SQL, this function is wrongly called twice for psql requests. At the first call, the xmax is not initialized causing unexpected error raising.

The first intention of these pieces of codes is to call it in the first place only for T-SQL(CR-52326143). And then got wrongly cherry-picked in CR-57250041. Finally, the condition check gets removed in CR-65026879. We should keep the first intention of the codes, which also makes it consistent with the behaviour in ExecUpdate.

Task: BABEL-5343

Cherry-picked from [https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/488](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/488)

### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
