### PR TITLE
Fixed unexpected error print by insert execute

### DIFF
--- a/src/backend/commands/functioncmds.c
+++ b/src/backend/commands/functioncmds.c
@@ -2562,7 +2562,13 @@ ExecuteCallStmt(CallStmt *stmt, ParamListInfo params, bool atomic, DestReceiver 
 		TupleTableSlot *slot;
 
 		if (fcinfo->isnull)
+		{
+			if (stmt->relation && stmt->attrnos)
+			/* insert exec babelfish */
+				return;
+			
 			elog(ERROR, "procedure returned null record");
+		}
 
 		/*
 		 * Ensure there's an active snapshot whilst we execute whatever's


### PR DESCRIPTION
Insert Execute will print unexpected error msg like : 'procedure returned null record' when the procedure executed return 0 rows of records.

This commit fixed this issue that will let the insert execute finish normaly without printing out error message in such case.

Task: BABEL-5306

### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
