### PR TITLE
Add sanity checks for ENR entries.

### DIFF
--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -805,11 +805,12 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 					{
 						Form_pg_class classForm = (Form_pg_class) GETSTRUCT(tup);
 
-						Assert(!classForm->relisshared);
-						Assert(classForm->relpersistence == RELPERSISTENCE_TEMP);
-						Assert(!classForm->relhastriggers);
-						Assert(!classForm->relrowsecurity);
-						Assert(!classForm->relispartition);
+						if ((classForm->relisshared) ||
+							(classForm->relpersistence != RELPERSISTENCE_TEMP) ||
+							(classForm->relhastriggers) ||
+							(classForm->relrowsecurity) ||
+							(classForm->relispartition))
+							elog(ERROR, "Invalid pg_class ENR entry.");
 					}
 				}
 				break;
@@ -832,8 +833,13 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 								 * When adding entries to pg_depend, do an additional sanity check
 								 * to verify we aren't creating links to non-ENR catalogs.
 								 */
-								if (op == ENR_OP_ADD && (!IsENRRelationOid(tf1->classid, true) || !IsENRRelationOid(tf1->refclassid, true)))
-									elog(ERROR, "Unexpected catalog OID %d referenced in ENR.", tf1->classid);
+								if (op == ENR_OP_ADD)
+								{
+									if (!IsENRRelationOid(tf1->classid, true))
+										elog(ERROR, "Unexpected catalog OID %d referenced in ENR.", tf1->classid);
+									else if (!IsENRRelationOid(tf1->refclassid, true))
+										elog(ERROR, "Unexpected catalog OID %d referenced in ENR.", tf1->refclassid);
+								}
 
 								break;
 							}
@@ -863,9 +869,13 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 								 * When adding entries to pg_shdepend, do an additional check
 								 * to verify we aren't creating links to non-ENR catalogs.
 								 */
-								if (op == ENR_OP_ADD && (!IsENRRelationOid(tf1->classid, true) || !IsENRRelationOid(tf1->refclassid, true)))
-									elog(ERROR, "Unexpected catalog OID %d referenced in ENR.", tf1->classid);
-
+								if (op == ENR_OP_ADD)
+								{
+									if (!IsENRRelationOid(tf1->classid, true))
+										elog(ERROR, "Unexpected catalog OID %d referenced in ENR.", tf1->classid);
+									else if (!IsENRRelationOid(tf1->refclassid, true))
+										elog(ERROR, "Unexpected catalog OID %d referenced in ENR.", tf1->refclassid);
+								}
 								break;
 							}
 						}
@@ -884,7 +894,8 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 					{
 						Form_pg_index indexForm = (Form_pg_index) GETSTRUCT(tup);
 
-						Assert(!indexForm->indisreplident);
+						if(indexForm->indisreplident)
+							elog(ERROR, "Invalid pg_index ENR entry.");
 					}
 				}
 				break;

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -832,11 +832,8 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 								 * When adding entries to pg_depend, do an additional sanity check
 								 * to verify we aren't creating links to non-ENR catalogs.
 								 */
-								if (op == ENR_OP_ADD)
-								{
-									Assert(IsENRRelationOid(tf1->classid, true));
-									Assert(IsENRRelationOid(tf1->refclassid, true));
-								}
+								if (op == ENR_OP_ADD && (!IsENRRelationOid(tf1->classid, true) || !IsENRRelationOid(tf1->refclassid, true)))
+									elog(ERROR, "Unexpected catalog OID %d referenced in ENR.", tf1->classid);
 
 								break;
 							}
@@ -866,11 +863,8 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 								 * When adding entries to pg_shdepend, do an additional check
 								 * to verify we aren't creating links to non-ENR catalogs.
 								 */
-								if (op == ENR_OP_ADD)
-								{
-									Assert(IsENRRelationOid(tf1->classid, true));
-									Assert(IsENRRelationOid(tf1->refclassid, true));
-								}
+								if (op == ENR_OP_ADD && (!IsENRRelationOid(tf1->classid, true) || !IsENRRelationOid(tf1->refclassid, true)))
+									elog(ERROR, "Unexpected catalog OID %d referenced in ENR.", tf1->classid);
 
 								break;
 							}

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -803,7 +803,7 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 					 * This helps ensure that we don't have any dependencies pointing to
 					 * non-ENR catalogs.
 					 */
-					if ((op == ENR_OP_ADD || op == ENR_OP_DROP) && HeapTupleIsValid(tup))
+					if ((op == ENR_OP_ADD || op == ENR_OP_UPDATE) && HeapTupleIsValid(tup))
 					{
 						Form_pg_class classForm = (Form_pg_class) GETSTRUCT(tup);
 
@@ -892,7 +892,7 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 					lc = list_head(enr->md.cattups[ENR_CATTUP_INDEX]);
 					ret = true;
 
-					if ((op == ENR_OP_ADD || op == ENR_OP_DROP) && HeapTupleIsValid(tup))
+					if ((op == ENR_OP_ADD || op == ENR_OP_UPDATE) && HeapTupleIsValid(tup))
 					{
 						Form_pg_index indexForm = (Form_pg_index) GETSTRUCT(tup);
 

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -52,6 +52,8 @@
 #include "utils/queryenvironment.h"
 #include "utils/rel.h"
 
+#define NUM_ENR_CATALOGS 11
+
 pltsql_get_tsql_enr_from_oid_hook_type pltsql_get_tsql_enr_from_oid_hook = NULL;
 
 /*
@@ -72,7 +74,7 @@ struct QueryEnvironment
  * These are the pg catalogs which we are placing in
  * ENR. We cannot mix any entries in non-ENR (ie on disk) catalogs.
  */
-static Oid ENRCatalogOids[11] =
+static Oid ENRCatalogOids[NUM_ENR_CATALOGS] =
 {
 	RelationRelationId,			/* pg_class */
 	TypeRelationId, 			/* pg_type */
@@ -98,7 +100,7 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 static void ENRAddUncommittedTupleData(EphemeralNamedRelation enr, Oid catoid, ENRTupleOperationType op, HeapTuple tup, bool in_enr_rollback);
 static void ENRDeleteUncommittedTupleData(SubTransactionId subid, EphemeralNamedRelation enr);
 static void ENRRollbackUncommittedTuple(QueryEnvironment *queryEnv, ENRUncommittedTuple uncommitted_tup);
-static bool IsENRRelationOid(Oid reloid, bool extended);
+static bool IsCatalogOidENR(Oid reloid, bool extended);
 static EphemeralNamedRelation find_enr(Form_pg_depend entry);
 
 QueryEnvironment *
@@ -352,13 +354,13 @@ ENRMetadataGetTupDesc(EphemeralNamedRelationMetadata enrmd)
 }
 
 /* Simple check to see if the provided OID is the OID of an ENR'd catalog. */
-static bool IsENRRelationOid(Oid reloid, bool extended)
+static bool IsCatalogOidENR(Oid reloid, bool extended)
 {
 	/* This should always be a catalog relation we're checking. */
 	if (!IsCatalogRelationOid(reloid))
 		return false;
 
-	for (int i = 0; i < 11; i++)
+	for (int i = 0; i < NUM_ENR_CATALOGS; i++)
 	{
 		if (reloid == ENRCatalogOids[i])
 			return true;
@@ -417,7 +419,7 @@ bool ENRGetSystableScan(Relation rel, Oid indexId, int nkeys, ScanKey key, List 
 			return false;
 	}
 
-	if (!IsENRRelationOid(reloid, false))
+	if (!IsCatalogOidENR(reloid, false))
 		return false;
 
 	switch (nkeys) {
@@ -835,9 +837,9 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 								 */
 								if (op == ENR_OP_ADD)
 								{
-									if (!IsENRRelationOid(tf1->classid, true))
+									if (!IsCatalogOidENR(tf1->classid, true))
 										elog(ERROR, "Unexpected catalog OID %d referenced in ENR.", tf1->classid);
-									else if (!IsENRRelationOid(tf1->refclassid, true))
+									else if (!IsCatalogOidENR(tf1->refclassid, true))
 										elog(ERROR, "Unexpected catalog OID %d referenced in ENR.", tf1->refclassid);
 								}
 
@@ -871,9 +873,9 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 								 */
 								if (op == ENR_OP_ADD)
 								{
-									if (!IsENRRelationOid(tf1->classid, true))
+									if (!IsCatalogOidENR(tf1->classid, true))
 										elog(ERROR, "Unexpected catalog OID %d referenced in ENR.", tf1->classid);
-									else if (!IsENRRelationOid(tf1->refclassid, true))
+									else if (!IsCatalogOidENR(tf1->refclassid, true))
 										elog(ERROR, "Unexpected catalog OID %d referenced in ENR.", tf1->refclassid);
 								}
 								break;

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -32,6 +32,9 @@
 #include "catalog/catalog.h"
 #include "catalog/dependency.h"
 #include "catalog/indexing.h"
+#include "catalog/pg_authid.h"
+#include "catalog/pg_collation.h"
+#include "catalog/pg_opclass.h"
 #include "catalog/pg_constraint.h"
 #include "catalog/pg_statistic.h"
 #include "catalog/pg_statistic_ext.h"
@@ -63,6 +66,27 @@ struct QueryEnvironment
 	MemoryContext	memctx;
 };
 
+/*
+ * This list must match ENRCatalogTupleType in queryenvironment.h.
+ *
+ * These are the pg catalogs which we are placing in
+ * ENR. We cannot mix any entries in non-ENR (ie on disk) catalogs.
+ */
+static Oid ENRCatalogOids[11] =
+{
+	RelationRelationId,			/* pg_class */
+	TypeRelationId, 			/* pg_type */
+	AttributeRelationId,		/* pg_attribute */
+	ConstraintRelationId,		/* pg_constraint */
+	StatisticRelationId,		/* pg_statistic */
+	StatisticExtRelationId,		/* pg_statistic_ext */
+	DependRelationId,			/* pg_depend */
+	SharedDependRelationId,		/* pg_shdepend */
+	IndexRelationId,			/* pg_index */
+	SequenceRelationId,			/* pg_sequence */
+	AttrDefaultRelationId		/* pg_attrdef */
+};
+
 struct QueryEnvironment topLevelQueryEnvData;
 struct QueryEnvironment *topLevelQueryEnv = &topLevelQueryEnvData;
 struct QueryEnvironment *currentQueryEnv = NULL;
@@ -74,6 +98,7 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 static void ENRAddUncommittedTupleData(EphemeralNamedRelation enr, Oid catoid, ENRTupleOperationType op, HeapTuple tup, bool in_enr_rollback);
 static void ENRDeleteUncommittedTupleData(SubTransactionId subid, EphemeralNamedRelation enr);
 static void ENRRollbackUncommittedTuple(QueryEnvironment *queryEnv, ENRUncommittedTuple uncommitted_tup);
+static bool IsENRRelationOid(Oid reloid, bool extended);
 static EphemeralNamedRelation find_enr(Form_pg_depend entry);
 
 QueryEnvironment *
@@ -326,6 +351,37 @@ ENRMetadataGetTupDesc(EphemeralNamedRelationMetadata enrmd)
 	return tupdesc;
 }
 
+/* Simple check to see if the provided OID is the OID of an ENR'd catalog. */
+static bool IsENRRelationOid(Oid reloid, bool extended)
+{
+	/* This should always be a catalog relation we're checking. */
+	if (!IsCatalogRelationOid(reloid))
+		return false;
+
+	for (int i = 0; i < 11; i++)
+	{
+		if (reloid == ENRCatalogOids[i])
+			return true;
+	}
+
+	/* 
+	 * These are catalogs that aren't in ENR but can be dependencies of 
+	 * temp tables.
+	 * 
+	 * There could be some potential for misuse here, involving creating
+	 * and dropping collations or roles in while having temp tables
+	 * that depend on them on a different session.
+	 */
+	if (extended)
+	{
+		if (reloid == CollationRelationId
+		 || reloid == AuthIdRelationId
+		 || reloid == OperatorClassRelationId)
+			return true;
+	}
+	return false;
+}
+
 /*
  * Get the starting tuple (or more precisely, a ListCell that contains the tuple)
  * for systable scan functions based on the given keys.
@@ -361,17 +417,7 @@ bool ENRGetSystableScan(Relation rel, Oid indexId, int nkeys, ScanKey key, List 
 			return false;
 	}
 
-	if (reloid != RelationRelationId &&
-		reloid != TypeRelationId &&
-		reloid != AttributeRelationId &&
-		reloid != ConstraintRelationId &&
-		reloid != StatisticRelationId &&
-		reloid != StatisticExtRelationId &&
-		reloid != DependRelationId &&
-		reloid != SharedDependRelationId &&
-		reloid != IndexRelationId &&
-		reloid != SequenceRelationId &&
-		reloid != AttrDefaultRelationId)
+	if (!IsENRRelationOid(reloid, false))
 		return false;
 
 	switch (nkeys) {
@@ -748,6 +794,23 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 					list_ptr = &enr->md.cattups[ENR_CATTUP_CLASS];
 					lc = list_head(enr->md.cattups[ENR_CATTUP_CLASS]);
 					ret = true;
+
+					/*
+					 * All of the below asserts should hold true for TSQL temp tables.
+					 *
+					 * This helps ensure that we don't have any dependencies pointing to
+					 * non-ENR catalogs.
+					 */
+					if ((op == ENR_OP_ADD || op == ENR_OP_DROP) && HeapTupleIsValid(tup))
+					{
+						Form_pg_class classForm = (Form_pg_class) GETSTRUCT(tup);
+
+						Assert(!classForm->relisshared);
+						Assert(classForm->relpersistence == RELPERSISTENCE_TEMP);
+						Assert(!classForm->relhastriggers);
+						Assert(!classForm->relrowsecurity);
+						Assert(!classForm->relispartition);
+					}
 				}
 				break;
 			case DependRelationId:
@@ -764,6 +827,17 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 								tf1->objid == tf2->objid &&
 								tf1->objsubid == tf2->objsubid) {
 								lc = curlc;
+
+								/*
+								 * When adding entries to pg_depend, do an additional sanity check
+								 * to verify we aren't creating links to non-ENR catalogs.
+								 */
+								if (op == ENR_OP_ADD)
+								{
+									Assert(IsENRRelationOid(tf1->classid, true));
+									Assert(IsENRRelationOid(tf1->refclassid, true));
+								}
+
 								break;
 							}
 						}
@@ -787,6 +861,17 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 								tf1->objid == tf2->objid &&
 								tf1->objsubid == tf2->objsubid) {
 								lc = curlc;
+
+								/*
+								 * When adding entries to pg_shdepend, do an additional check
+								 * to verify we aren't creating links to non-ENR catalogs.
+								 */
+								if (op == ENR_OP_ADD)
+								{
+									Assert(IsENRRelationOid(tf1->classid, true));
+									Assert(IsENRRelationOid(tf1->refclassid, true));
+								}
+
 								break;
 							}
 						}
@@ -800,6 +885,13 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 					list_ptr = &enr->md.cattups[ENR_CATTUP_INDEX];
 					lc = list_head(enr->md.cattups[ENR_CATTUP_INDEX]);
 					ret = true;
+
+					if ((op == ENR_OP_ADD || op == ENR_OP_DROP) && HeapTupleIsValid(tup))
+					{
+						Form_pg_index indexForm = (Form_pg_index) GETSTRUCT(tup);
+
+						Assert(!indexForm->indisreplident);
+					}
 				}
 				break;
 			case TypeRelationId:
@@ -962,14 +1054,14 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 					break;
 				case ENR_OP_UPDATE:
 					/*
-					* Invalidate the tuple before updating / removing it from the List.
-					* Consider the case when we remove the tuple and cache invalidation
-					* failed, then error handling would try to remove it again but would
-					* crash because entry is gone from the List but we could still find it in the syscache.
-					* If we failed to drop because we failed to invalidate, then subsequent
-					* creation of the same table would fail saying the tuple exists already
-					* which is much better than crashing.
-					*/
+					 * Invalidate the tuple before updating / removing it from the List.
+					 * Consider the case when we remove the tuple and cache invalidation
+					 * failed, then error handling would try to remove it again but would
+					 * crash because entry is gone from the List but we could still find it in the syscache.
+					 * If we failed to drop because we failed to invalidate, then subsequent
+					 * creation of the same table would fail saying the tuple exists already
+					 * which is much better than crashing.
+					 */
 					oldtup = lfirst(lc);
 					if (enr->md.is_bbf_temp_table && temp_table_xact_support)
 						ENRAddUncommittedTupleData(enr, catalog_oid, op, oldtup, in_enr_rollback);


### PR DESCRIPTION
### Description

Tests are running in https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3245

This change adds a number of sanity checks when ENR entries are added. Previously, there were no checks here which meant that we could run into cases we had not considered where an ENR entry could depend on a non-ENR entry, and vice-versa. When adding these tests, I discovered that there are still 3 on-disk catalogs that can be referenced by ENR entries:

- pg_collation
- pg_authid
- pg_opclass

These catalogs can't be trivially added to ENR, so I will create some followup tasks on properly handling these cases if possible.

Note that there are still some potential limitations. For example, the issue fixed in BABEL-4868 (see https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3122) would not have been caught by this change due to the way that dependency entries are created for functions as column defaults.

A way to truly guarantee that all corner cases could be caught is to implement a sort of check in Postgres' dependency code. This would be a pretty sizable change and have potential performance impact, since we would need to a) add infrastructure to allow lookups to all tuples in ENR by OID, and b) search through this structure every time we try to add a dependency. I've opted to not include that for now due to the reasons mentioned, but if there is interest in that we can have a separate discussion on it.
 
### Issues Resolved

BABEL-4776
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
