### PR TITLE
Refactor direct SSL handshake logic

### DIFF
--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -247,7 +247,8 @@ ProtocolExtensionConfig default_protocol_config = {
 	libpq_end_command,
 	NULL, NULL, NULL, NULL,		/* use libpq defaults for printtup*() */
 	NULL,
-	libpq_report_param_status
+	libpq_report_param_status,
+	libpq_ssl_handshake
 };
 
 /* still more option variables */
@@ -1511,6 +1512,11 @@ libpq_end_command(QueryCompletion *qc, CommandDest dest)
 	EndCommand(qc, dest, false);
 }
 
+int
+libpq_ssl_handshake(struct Port *port)
+{
+	return WrapperProcessSSLStartup(port);
+}
 
 /*
  * on_proc_exit callback to close server's listen sockets

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -248,7 +248,7 @@ ProtocolExtensionConfig default_protocol_config = {
 	NULL, NULL, NULL, NULL,		/* use libpq defaults for printtup*() */
 	NULL,
 	libpq_report_param_status,
-	libpq_ssl_handshake
+	libpq_direct_ssl_handshake
 };
 
 /* still more option variables */
@@ -1513,9 +1513,9 @@ libpq_end_command(QueryCompletion *qc, CommandDest dest)
 }
 
 int
-libpq_ssl_handshake(struct Port *port)
+libpq_direct_ssl_handshake(struct Port *port)
 {
-	return WrapperProcessSSLStartup(port);
+	return ProcessSSLStartup(port);
 }
 
 /*

--- a/src/backend/tcop/backend_startup.c
+++ b/src/backend/tcop/backend_startup.c
@@ -253,15 +253,14 @@ BackendInitialize(ClientSocket *client_sock, CAC_state cac, ProtocolExtensionCon
 	RegisterTimeout(STARTUP_PACKET_TIMEOUT, StartupPacketTimeoutHandler);
 	enable_timeout_after(STARTUP_PACKET_TIMEOUT, AuthenticationTimeout * 1000);
 
-	/* Handle direct SSL handshake for non-TDS connections */
-	if (!port->is_tds_conn)
-	status = ProcessSSLStartup(port);
+	/* Handle protocol-specific SSL handshake */
+	status = port->protocol_config->fn_ssl_handshake(port);
 
 	/*
 	 * Receive the startup packet (which might turn out to be a cancel request
 	 * packet).
 	 */
-	if (port->is_tds_conn || status == STATUS_OK)
+	if (status == STATUS_OK)
 		status = (port->protocol_config->fn_start)(port);
 
 	/*
@@ -888,4 +887,13 @@ static void
 StartupPacketTimeoutHandler(void)
 {
 	_exit(1);
+}
+
+/*
+ * Wrapper for ProcessSSLStartup to handle direct SSL handshake
+ */
+int
+WrapperProcessSSLStartup(Port *port)
+{
+    return ProcessSSLStartup(port);
 }

--- a/src/backend/tcop/backend_startup.c
+++ b/src/backend/tcop/backend_startup.c
@@ -253,8 +253,8 @@ BackendInitialize(ClientSocket *client_sock, CAC_state cac, ProtocolExtensionCon
 	RegisterTimeout(STARTUP_PACKET_TIMEOUT, StartupPacketTimeoutHandler);
 	enable_timeout_after(STARTUP_PACKET_TIMEOUT, AuthenticationTimeout * 1000);
 
-	/* Handle protocol-specific SSL handshake */
-	status = port->protocol_config->fn_ssl_handshake(port);
+	/* Handle protocol-specific direct SSL handshake */
+	status = port->protocol_config->fn_direct_ssl_handshake(port);
 
 	/*
 	 * Receive the startup packet (which might turn out to be a cancel request

--- a/src/backend/tcop/backend_startup.c
+++ b/src/backend/tcop/backend_startup.c
@@ -42,7 +42,7 @@
 bool		Trace_connection_negotiation = false;
 static void BackendInitialize(ClientSocket *client_sock, CAC_state cac, ProtocolExtensionConfig *protocol_config);
 int	ProcessStartupPacket(Port *port, bool ssl_done, bool gss_done);
-static int	ProcessSSLStartup(Port *port);
+int	ProcessSSLStartup(Port *port);
 static void SendNegotiateProtocolVersion(List *unrecognized_protocol_options);
 static void process_startup_packet_die(SIGNAL_ARGS);
 static void StartupPacketTimeoutHandler(void);
@@ -359,7 +359,7 @@ BackendInitialize(ClientSocket *client_sock, CAC_state cac, ProtocolExtensionCon
  * This happens before the startup packet so we are careful not to actually
  * read any bytes from the stream if it's not a direct SSL connection.
  */
-static int
+int
 ProcessSSLStartup(Port *port)
 {
 	int			firstbyte;
@@ -887,13 +887,4 @@ static void
 StartupPacketTimeoutHandler(void)
 {
 	_exit(1);
-}
-
-/*
- * Wrapper for ProcessSSLStartup to handle direct SSL handshake
- */
-int
-WrapperProcessSSLStartup(Port *port)
-{
-    return ProcessSSLStartup(port);
 }

--- a/src/include/libpq/libpq-be.h
+++ b/src/include/libpq/libpq-be.h
@@ -117,6 +117,9 @@ typedef struct ProtocolExtensionConfig {
 	void	(*fn_printtup_destroy)(DestReceiver *self);
 	int		(*fn_process_command)(void);
 	void	(*fn_report_param_status)(const char *name, char *val);
+
+	/* function pointer for handling direct SSL handshake */
+	int		(*fn_ssl_handshake)(struct Port *port);
 } ProtocolExtensionConfig;
 
 /*

--- a/src/include/libpq/libpq-be.h
+++ b/src/include/libpq/libpq-be.h
@@ -119,7 +119,7 @@ typedef struct ProtocolExtensionConfig {
 	void	(*fn_report_param_status)(const char *name, char *val);
 
 	/* function pointer for handling direct SSL handshake */
-	int		(*fn_ssl_handshake)(struct Port *port);
+	int		(*fn_direct_ssl_handshake)(struct Port *port);
 } ProtocolExtensionConfig;
 
 /*

--- a/src/include/postmaster/protocol_extension.h
+++ b/src/include/postmaster/protocol_extension.h
@@ -42,6 +42,6 @@ extern void	libpq_send_ready_for_query(CommandDest dest);
 extern int	libpq_read_command(StringInfo inBuf);
 extern void	libpq_end_command(QueryCompletion *qc, CommandDest dest);
 extern void	libpq_report_param_status(const char *name, char *val);
-extern int	libpq_ssl_handshake(struct Port *port);
+extern int	libpq_direct_ssl_handshake(struct Port *port);
 
 #endif							/* _PROTOCOL_EXTENSION_H */

--- a/src/include/postmaster/protocol_extension.h
+++ b/src/include/postmaster/protocol_extension.h
@@ -42,5 +42,6 @@ extern void	libpq_send_ready_for_query(CommandDest dest);
 extern int	libpq_read_command(StringInfo inBuf);
 extern void	libpq_end_command(QueryCompletion *qc, CommandDest dest);
 extern void	libpq_report_param_status(const char *name, char *val);
+extern int	libpq_ssl_handshake(struct Port *port);
 
 #endif							/* _PROTOCOL_EXTENSION_H */

--- a/src/include/tcop/backend_startup.h
+++ b/src/include/tcop/backend_startup.h
@@ -39,6 +39,6 @@ typedef struct BackendStartupData
 
 extern void BackendMain(char *startup_data, size_t startup_data_len) pg_attribute_noreturn();
 extern int	ProcessStartupPacket(Port *port, bool ssl_done, bool gss_done);
-extern int	WrapperProcessSSLStartup(Port *port);
+extern int	ProcessSSLStartup(Port *port);
 
 #endif							/* BACKEND_STARTUP_H */

--- a/src/include/tcop/backend_startup.h
+++ b/src/include/tcop/backend_startup.h
@@ -39,5 +39,6 @@ typedef struct BackendStartupData
 
 extern void BackendMain(char *startup_data, size_t startup_data_len) pg_attribute_noreturn();
 extern int	ProcessStartupPacket(Port *port, bool ssl_done, bool gss_done);
+extern int	WrapperProcessSSLStartup(Port *port);
 
 #endif							/* BACKEND_STARTUP_H */


### PR DESCRIPTION
### Description

This commit refactors the direct SSL handshake logic in the engine to support protocol-specific handling through the `fn_direct_ssl_handshake` function pointer. Changed the definition of `ProcessSSLStartup` function to non-static for handling non-TDS connections directly from `postmaster.c`. The connection startup process now delegates SSL handshake handling to the protocol-defined function.

Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3261
 
### Issues Resolved

BABEL-5342
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
