### PR TITLE
Performance Improvement of create login in BBF

### DIFF
--- a/src/backend/utils/adt/acl.c
+++ b/src/backend/utils/adt/acl.c
@@ -5076,7 +5076,18 @@ roles_is_member_of(Oid roleid, enum RoleRecurseType type,
 			 */
 			if (otherid == admin_of && form->admin_option &&
 				OidIsValid(admin_of) && !OidIsValid(*admin_role))
-				*admin_role = memberid;
+				{
+					*admin_role = memberid;
+
+					/* 
+					 * Need not to iterate through all the members 
+					 * if admin_role is found.
+					 */
+					if (sql_dialect == SQL_DIALECT_TSQL)
+					{
+						return NULL;
+					}
+				}
 
 			/* If we're supposed to ignore non-heritable grants, do so. */
 			if (type == ROLERECURSE_PRIVS && !form->inherit_option)

--- a/src/backend/utils/adt/acl.c
+++ b/src/backend/utils/adt/acl.c
@@ -134,7 +134,7 @@ bbf_get_sysadmin_oid_hook_type bbf_get_sysadmin_oid_hook = NULL;
 get_bbf_admin_oid_hook_type get_bbf_admin_oid_hook = NULL;
 pltsql_get_object_owner_hook_type pltsql_get_object_owner_hook = NULL;
 is_bbf_db_ddladmin_operation_hook_type is_bbf_db_ddladmin_operation_hook = NULL;
-has_bbf_role_direct_membership_with_admin_true_hook_type has_bbf_role_direct_membership_with_admin_true_hook = NULL;
+bbf_check_member_has_direct_priv_to_grant_role_hook_type bbf_check_member_has_direct_priv_to_grant_role_hook = NULL;
 
 
 /*
@@ -5279,17 +5279,10 @@ is_admin_of_role(Oid member, Oid role)
 	if (member == role)
 		return false;
 
-	/*
-	 * Check if the given member is bbf_role_admin.
-         * If the member has the privilege to grant a given role through direct membership,
-         * returns the member with admin option set to true.
-	 */
-	if (sql_dialect == SQL_DIALECT_TSQL 
-		&& get_bbf_admin_oid_hook && member == (*get_bbf_admin_oid_hook)()
-			&& (has_bbf_role_direct_membership_with_admin_true_hook) 
-				&& (*has_bbf_role_direct_membership_with_admin_true_hook)(role))
+	if ((bbf_check_member_has_direct_priv_to_grant_role_hook) 
+		&& (*bbf_check_member_has_direct_priv_to_grant_role_hook)(member, role))
 	{
-		return member;
+		return true;
 	}
 
 	(void) roles_is_member_of(member, ROLERECURSE_MEMBERS, role, &admin_role);

--- a/src/backend/utils/adt/acl.c
+++ b/src/backend/utils/adt/acl.c
@@ -134,6 +134,7 @@ bbf_get_sysadmin_oid_hook_type bbf_get_sysadmin_oid_hook = NULL;
 get_bbf_admin_oid_hook_type get_bbf_admin_oid_hook = NULL;
 pltsql_get_object_owner_hook_type pltsql_get_object_owner_hook = NULL;
 is_bbf_db_ddladmin_operation_hook_type is_bbf_db_ddladmin_operation_hook = NULL;
+has_bbf_role_direct_membership_with_admin_true_hook_type has_bbf_role_direct_membership_with_admin_true_hook = NULL;
 
 
 /*
@@ -5076,19 +5077,7 @@ roles_is_member_of(Oid roleid, enum RoleRecurseType type,
 			 */
 			if (otherid == admin_of && form->admin_option &&
 				OidIsValid(admin_of) && !OidIsValid(*admin_role))
-				{
-					*admin_role = memberid;
-
-					/* 
-					 * Need not to iterate through all the members 
-					 * if roleid is bbf_role_admin and admin_role is found.
-					 */
-					if (sql_dialect == SQL_DIALECT_TSQL &&
-						get_bbf_admin_oid_hook  && roleid == (*get_bbf_admin_oid_hook)())
-					{
-						return NULL;
-					}
-				}
+				*admin_role = memberid;
 
 			/* If we're supposed to ignore non-heritable grants, do so. */
 			if (type == ROLERECURSE_PRIVS && !form->inherit_option)
@@ -5289,6 +5278,19 @@ is_admin_of_role(Oid member, Oid role)
 	/* By policy, a role cannot have WITH ADMIN OPTION on itself. */
 	if (member == role)
 		return false;
+
+	/*
+	 * Check if the given member is bbf_role_admin.
+         * If the member has the privilege to grant a given role through direct membership,
+         * returns the member with admin option set to true.
+	 */
+	if (sql_dialect == SQL_DIALECT_TSQL 
+		&& get_bbf_admin_oid_hook && member == (*get_bbf_admin_oid_hook)()
+			&& (has_bbf_role_direct_membership_with_admin_true_hook) 
+				&& (*has_bbf_role_direct_membership_with_admin_true_hook)(role))
+	{
+		return member;
+	}
 
 	(void) roles_is_member_of(member, ROLERECURSE_MEMBERS, role, &admin_role);
 	return OidIsValid(admin_role);

--- a/src/backend/utils/adt/acl.c
+++ b/src/backend/utils/adt/acl.c
@@ -5081,9 +5081,10 @@ roles_is_member_of(Oid roleid, enum RoleRecurseType type,
 
 					/* 
 					 * Need not to iterate through all the members 
-					 * if admin_role is found.
+					 * if roleid is bbf_role_admin and admin_role is found.
 					 */
-					if (sql_dialect == SQL_DIALECT_TSQL)
+					if (sql_dialect == SQL_DIALECT_TSQL &&
+						get_bbf_admin_oid_hook  && roleid == (*get_bbf_admin_oid_hook)())
 					{
 						return NULL;
 					}

--- a/src/include/utils/acl.h
+++ b/src/include/utils/acl.h
@@ -309,6 +309,9 @@ extern PGDLLEXPORT is_bbf_db_ddladmin_operation_hook_type is_bbf_db_ddladmin_ope
 typedef bool (*pltsql_allow_storing_init_privs_hook_type) (Oid objoid, Oid classoid, int objsubid);
 extern PGDLLEXPORT pltsql_allow_storing_init_privs_hook_type pltsql_allow_storing_init_privs_hook;
 
+typedef bool (*has_bbf_role_direct_membership_with_admin_true_hook_type) (Oid);
+extern PGDLLEXPORT has_bbf_role_direct_membership_with_admin_true_hook_type has_bbf_role_direct_membership_with_admin_true_hook;
+
 #define IS_BBF_DB_DDLADMIN(namespaceId) \
 	(is_bbf_db_ddladmin_operation_hook &&       \
 	 is_bbf_db_ddladmin_operation_hook(namespaceId))

--- a/src/include/utils/acl.h
+++ b/src/include/utils/acl.h
@@ -309,8 +309,8 @@ extern PGDLLEXPORT is_bbf_db_ddladmin_operation_hook_type is_bbf_db_ddladmin_ope
 typedef bool (*pltsql_allow_storing_init_privs_hook_type) (Oid objoid, Oid classoid, int objsubid);
 extern PGDLLEXPORT pltsql_allow_storing_init_privs_hook_type pltsql_allow_storing_init_privs_hook;
 
-typedef bool (*has_bbf_role_direct_membership_with_admin_true_hook_type) (Oid);
-extern PGDLLEXPORT has_bbf_role_direct_membership_with_admin_true_hook_type has_bbf_role_direct_membership_with_admin_true_hook;
+typedef bool (*bbf_check_member_has_direct_priv_to_grant_role_hook_type) (Oid, Oid);
+extern PGDLLEXPORT bbf_check_member_has_direct_priv_to_grant_role_hook_type bbf_check_member_has_direct_priv_to_grant_role_hook;
 
 #define IS_BBF_DB_DDLADMIN(namespaceId) \
 	(is_bbf_db_ddladmin_operation_hook &&       \


### PR DESCRIPTION
### Description

Extension PR : https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3291

In Major version 16 Babelfish introduced a new role bbf_admin_role which is a member of all the roles which created implicitly from TSQL. This increases the Load on any Grant/Revoke operations that happen since in BBF to "select the role through which it gets permission to current user to grant", is inefficient and loops over members of members to find the all members of the role even though the required role is find.
This commit optimizes the selection of role with is_admin_option true for babelfish by escaping the search for any TSQL roles conditionally.
Without the changes the time taken to create a login increases drastically and linearly:

Flame graph : 
![kernel](https://github.com/user-attachments/assets/12f6e7f7-2f5f-48de-b7f2-2d3449239311)



The average time consumed by create login stmt(with 125 dbs and 125 logins present) : 12836 ms
with these changes we see the time taken to create login increasing linearly but not as drastically as it was before the changes:

Flame graph : 
![perf-kernel-new-hook](https://github.com/user-attachments/assets/dc1e3663-4d6f-4fb5-a7c3-cc5b976c97d0)


The average time consumed by create login stmt(with 125 dbs and 125 logins present) : 49 ms

### Issues Resolved

BABEL-5349
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).