### PR TITLE
Display unmapped schema names in error messages BABEL5

### DIFF
--- a/src/backend/catalog/namespace.c
+++ b/src/backend/catalog/namespace.c
@@ -216,6 +216,7 @@ char *SYS_NAMESPACE_NAME = "sys";
 
 relname_lookup_hook_type relname_lookup_hook = NULL;
 match_pltsql_func_call_hook_type match_pltsql_func_call_hook = NULL;
+remove_db_name_in_schema_hook_type remove_db_name_in_schema_hook = NULL;
 
 
 /* Local functions */
@@ -3633,10 +3634,16 @@ get_namespace_oid(const char *nspname, bool missing_ok)
 	oid = GetSysCacheOid1(NAMESPACENAME, Anum_pg_namespace_oid,
 						  CStringGetDatum(nspname));
 	if (!OidIsValid(oid) && !missing_ok)
+	{
+		if (sql_dialect == SQL_DIALECT_TSQL && remove_db_name_in_schema_hook)
+		{
+			nspname = (*remove_db_name_in_schema_hook)(nspname);
+		} 
 		ereport(ERROR,
 				(errcode(ERRCODE_UNDEFINED_SCHEMA),
 				 errmsg("schema \"%s\" does not exist", nspname)));
 
+	} 
 	return oid;
 }
 

--- a/src/backend/parser/parse_func.c
+++ b/src/backend/parser/parse_func.c
@@ -2063,6 +2063,10 @@ funcname_signature_string(const char *funcname, int nargs,
 
 	initStringInfo(&argbuf);
 
+	if (sql_dialect == SQL_DIALECT_TSQL && remove_db_name_in_schema_hook) {
+		funcname = (*remove_db_name_in_schema_hook)(funcname);
+	}
+
 	appendStringInfo(&argbuf, "%s(", funcname);
 
 	numposargs = nargs - list_length(argnames);

--- a/src/backend/parser/parse_relation.c
+++ b/src/backend/parser/parse_relation.c
@@ -1453,10 +1453,19 @@ parserOpenTable(ParseState *pstate, const RangeVar *relation, int lockmode)
 	if (rel == NULL)
 	{
 		if (relation->schemaname)
+		{
+			if (sql_dialect == SQL_DIALECT_TSQL && remove_db_name_in_schema_hook){
+				const char *schema_name = (*remove_db_name_in_schema_hook)(relation->schemaname);
+				ereport(ERROR,
+					(errcode(ERRCODE_UNDEFINED_TABLE),
+					 errmsg("relation \"%s.%s\" does not exist",
+							schema_name, relation->relname)));
+			} else
 			ereport(ERROR,
 					(errcode(ERRCODE_UNDEFINED_TABLE),
 					 errmsg("relation \"%s.%s\" does not exist",
 							relation->schemaname, relation->relname)));
+		}
 		else
 		{
 			/*

--- a/src/include/catalog/namespace.h
+++ b/src/include/catalog/namespace.h
@@ -90,6 +90,8 @@ typedef bool (*match_pltsql_func_call_hook_type) (HeapTuple proctup, int nargs, 
 												  bool *use_defaults, bool *any_special,
 												  bool *variadic, Oid *va_elem_type);
 extern PGDLLEXPORT match_pltsql_func_call_hook_type match_pltsql_func_call_hook;
+typedef const char * (*remove_db_name_in_schema_hook_type) (const char *schema_name);
+extern PGDLLEXPORT remove_db_name_in_schema_hook_type remove_db_name_in_schema_hook;
 
 #define RangeVarGetRelid(relation, lockmode, missing_ok) \
 	RangeVarGetRelidExtended(relation, lockmode, \

--- a/src/include/parser/parse_func.h
+++ b/src/include/parser/parse_func.h
@@ -80,5 +80,7 @@ typedef void (*make_fn_arguments_from_stored_proc_probin_hook_type)(ParseState *
 extern PGDLLEXPORT make_fn_arguments_from_stored_proc_probin_hook_type make_fn_arguments_from_stored_proc_probin_hook;
 typedef void (*report_proc_not_found_error_hook_type) (List *names, List *fargs, List *argnames, Oid *input_typeids, int nargs, ParseState *pstate, int location, bool proc_call);
 extern PGDLLEXPORT report_proc_not_found_error_hook_type report_proc_not_found_error_hook;
+typedef const char * (*remove_db_name_in_schema_hook_type) (const char *schema_name);
+extern PGDLLEXPORT remove_db_name_in_schema_hook_type remove_db_name_in_schema_hook;
 
 #endif							/* PARSE_FUNC_H */


### PR DESCRIPTION
### Description

Previously, Babelfish displays the mapped schema names in error messages. This commit imports a hook function remove_db_name_in_schema and uses it to restore thr unmapped name. Original unmapped name will be displayed with this commit.
 
### Issues Resolved

[BABEL-2961](https://jira.rds.a2z.com/browse/BABEL-2961)
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
