### PR TITLE
[OSS-ONLY][BABEL] Fix invalid write valgrind warning inside NextCopyFrom

### DIFF
--- a/src/backend/commands/copyfromparse.c
+++ b/src/backend/commands/copyfromparse.c
@@ -1090,8 +1090,6 @@ NextCopyFrom(CopyFromState cstate, ExprContext *econtext,
 	if (fill_missing_values_in_copyfrom_hook)
 		fill_missing_values_in_copyfrom_hook(cstate->rel, values, nulls);
 
-	pfree(cstate->defaults);
-
 	return true;
 }
 


### PR DESCRIPTION
### Description

We missed removing a pfree during cherry pick from community
which resulted in invalid write since we ended up writing on freed
data inside NextCopyFrom() here
```
MemSet(cstate->defaults, false, num_phys_attrs * sizeof(bool));
```

[babelfish cherry pick commit](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/commit/16f3f16b99bfb93d8532e3b0830c97e4de01fb80#diff-5974661d4ffb034fd936898b834cfd5c28e5ada5ea84b8863a32355af35c4f5bR1612) vs [community commit](https://github.com/postgres/postgres/commit/b635ac03e80237838bec8b224eb4dea97985fda3#diff-98d8bfd706468f77f8b0d5d0797e3dba3ffaaa88438143ef4cf7fedecaa56827L1043)

With this fix, problematic test file runs clean with valgrind

 
### Issues Resolved

[BABEL-5501]
 
### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
