### PR TITLE
[OSS-ONLY] Update BabelfishDump RPM version to 16.7 and Include changelog

### DIFF
--- a/BabelfishDump.spec
+++ b/BabelfishDump.spec
@@ -26,7 +26,7 @@
 
 Name: BabelfishDump
 Summary: Postgresql dump utilities modified for Babelfish
-Version: 16.4
+Version: 16.6
 Release: 1%{?dist}%{?_trivial}%{?_buildid}
 License: PostgreSQL
 Url: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish
@@ -151,6 +151,33 @@ LD_LIBRARY_PATH=%{_builddir}/%{name}/src/interfaces/libpq $RPM_BUILD_ROOT/usr/bi
 %{_bindir}/bbf_dumpall
 
 %changelog
+* Wed Dec 11 2024 Sharu Goel <goelshar@amazon.com> - 16.6-1
+- Add support to dump linked roles associated with members of db_owner role
+
+* Wed Dec 11 2024 ANJU BHARTI <abanju@amazon.com> - 16.6-1
+- Handle dump logic for babelfish db_ddladmin fixed database role
+
+* Wed Dec 11 2024 Harsh Lunagariya <lunharsh@amazon.com> - 16.6-1
+- Handle dump logic for babelfish db_securityadmin fixed database role
+
+* Wed Dec 11 2024 ANJU BHARTI <abanju@amazon.com> - 16.6-1
+- Handle dump logic for babelfish db_creator fixed server role
+
+* Wed Dec 11 2024 Shalini Lohia <lshalini@amazon.com> - 16.6-1
+- Handle dump logic for babelfish db_datareader/db_datawriter fixed database roles
+
+* Wed Dec 11 2024 Tanzeel Khan <tzlkhan@amazon.com> - 16.6-1
+- Handle dump logic for babelfish db_accessadmin fixed database role
+
+* Wed Dec 11 2024 ANJU BHARTI <abanju@amazon.com> - 16.6-1
+- Handle dump logic for babelfish securityadmin fixed server role
+
+* Tue Nov 19 2024 Rishabh Tanwar <ritanwar@amazon.com> - 16.6-1
+- Enable babelfishpg_tsql.dump_restore GUC while restoring roles
+
+* Thu Oct 3 2024 Tanzeel Khan <tzlkhan@amazon.com> - 16.6-1
+- Dump physical database aclprivs for fixed database roles
+
 * Mon Aug 5 2024 Masahiko Sawada <msawada@postgresql.com> - 16.4-1
 - [CVE-2024-7348] Restrict accesses to non-system views and foreign tables during pg_dump.
 

--- a/BabelfishDump.spec
+++ b/BabelfishDump.spec
@@ -26,7 +26,7 @@
 
 Name: BabelfishDump
 Summary: Postgresql dump utilities modified for Babelfish
-Version: 16.6
+Version: 16.7
 Release: 1%{?dist}%{?_trivial}%{?_buildid}
 License: PostgreSQL
 Url: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish
@@ -151,31 +151,31 @@ LD_LIBRARY_PATH=%{_builddir}/%{name}/src/interfaces/libpq $RPM_BUILD_ROOT/usr/bi
 %{_bindir}/bbf_dumpall
 
 %changelog
-* Wed Dec 11 2024 Sharu Goel <goelshar@amazon.com> - 16.6-1
+* Wed Dec 11 2024 Sharu Goel <goelshar@amazon.com> - 16.7-1
 - Add support to dump linked roles associated with members of db_owner role
 
-* Wed Dec 11 2024 ANJU BHARTI <abanju@amazon.com> - 16.6-1
+* Wed Dec 11 2024 ANJU BHARTI <abanju@amazon.com> - 16.7-1
 - Handle dump logic for babelfish db_ddladmin fixed database role
 
-* Wed Dec 11 2024 Harsh Lunagariya <lunharsh@amazon.com> - 16.6-1
+* Wed Dec 11 2024 Harsh Lunagariya <lunharsh@amazon.com> - 16.7-1
 - Handle dump logic for babelfish db_securityadmin fixed database role
 
-* Wed Dec 11 2024 ANJU BHARTI <abanju@amazon.com> - 16.6-1
+* Wed Dec 11 2024 ANJU BHARTI <abanju@amazon.com> - 16.7-1
 - Handle dump logic for babelfish db_creator fixed server role
 
-* Wed Dec 11 2024 Shalini Lohia <lshalini@amazon.com> - 16.6-1
+* Wed Dec 11 2024 Shalini Lohia <lshalini@amazon.com> - 16.7-1
 - Handle dump logic for babelfish db_datareader/db_datawriter fixed database roles
 
-* Wed Dec 11 2024 Tanzeel Khan <tzlkhan@amazon.com> - 16.6-1
+* Wed Dec 11 2024 Tanzeel Khan <tzlkhan@amazon.com> - 16.7-1
 - Handle dump logic for babelfish db_accessadmin fixed database role
 
-* Wed Dec 11 2024 ANJU BHARTI <abanju@amazon.com> - 16.6-1
+* Wed Dec 11 2024 ANJU BHARTI <abanju@amazon.com> - 16.7-1
 - Handle dump logic for babelfish securityadmin fixed server role
 
-* Tue Nov 19 2024 Rishabh Tanwar <ritanwar@amazon.com> - 16.6-1
+* Tue Nov 19 2024 Rishabh Tanwar <ritanwar@amazon.com> - 16.7-1
 - Enable babelfishpg_tsql.dump_restore GUC while restoring roles
 
-* Thu Oct 3 2024 Tanzeel Khan <tzlkhan@amazon.com> - 16.6-1
+* Thu Oct 3 2024 Tanzeel Khan <tzlkhan@amazon.com> - 16.7-1
 - Dump physical database aclprivs for fixed database roles
 
 * Mon Aug 5 2024 Masahiko Sawada <msawada@postgresql.com> - 16.4-1


### PR DESCRIPTION
### Description
Update BabelfishDump RPM version to 16.7 and Include changelog.

Task: OSS-ONLY
Signed-off-by: Rishabh Tanwar ritanwar@amazon.com

### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
