### PR TITLE
Performance Improvement of create login in BBF (#507)

### DIFF
--- a/src/backend/utils/adt/acl.c
+++ b/src/backend/utils/adt/acl.c
@@ -134,6 +134,7 @@ bbf_get_sysadmin_oid_hook_type bbf_get_sysadmin_oid_hook = NULL;
 get_bbf_admin_oid_hook_type get_bbf_admin_oid_hook = NULL;
 pltsql_get_object_owner_hook_type pltsql_get_object_owner_hook = NULL;
 is_bbf_db_ddladmin_operation_hook_type is_bbf_db_ddladmin_operation_hook = NULL;
+bbf_check_member_has_direct_priv_to_grant_role_hook_type bbf_check_member_has_direct_priv_to_grant_role_hook = NULL;
 
 
 /*
@@ -5277,6 +5278,12 @@ is_admin_of_role(Oid member, Oid role)
 	/* By policy, a role cannot have WITH ADMIN OPTION on itself. */
 	if (member == role)
 		return false;
+
+	if ((bbf_check_member_has_direct_priv_to_grant_role_hook) 
+		&& (*bbf_check_member_has_direct_priv_to_grant_role_hook)(member, role))
+	{
+		return true;
+	}
 
 	(void) roles_is_member_of(member, ROLERECURSE_MEMBERS, role, &admin_role);
 	return OidIsValid(admin_role);

--- a/src/include/utils/acl.h
+++ b/src/include/utils/acl.h
@@ -309,6 +309,9 @@ extern PGDLLEXPORT is_bbf_db_ddladmin_operation_hook_type is_bbf_db_ddladmin_ope
 typedef bool (*pltsql_allow_storing_init_privs_hook_type) (Oid objoid, Oid classoid, int objsubid);
 extern PGDLLEXPORT pltsql_allow_storing_init_privs_hook_type pltsql_allow_storing_init_privs_hook;
 
+typedef bool (*bbf_check_member_has_direct_priv_to_grant_role_hook_type) (Oid, Oid);
+extern PGDLLEXPORT bbf_check_member_has_direct_priv_to_grant_role_hook_type bbf_check_member_has_direct_priv_to_grant_role_hook;
+
 #define IS_BBF_DB_DDLADMIN(namespaceId) \
 	(is_bbf_db_ddladmin_operation_hook &&       \
 	 is_bbf_db_ddladmin_operation_hook(namespaceId))


### PR DESCRIPTION
### Description
Extension PR : https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3366

In Major version 16 Babelfish introduced a new role bbf_admin_role which is a member of all the roles which created implicitly from TSQL. This increases the Load on any Grant/Revoke operations that happen since in BBF to "select the role through which it gets permission to current user to grant", is inefficient and loops over members of members to find the all members of the role even though the required role is find. This commit optimizes the selection of role with is_admin_option true for babelfish by escaping the search for any TSQL roles conditionally.

### Issues Resolved
BABEL-5349