### PR TITLE
Some fixes for db_owner role (#514)

### DIFF
--- a/src/bin/pg_dump/dumpall_babel_utils.c
+++ b/src/bin/pg_dump/dumpall_babel_utils.c
@@ -271,7 +271,7 @@ getBabelfishRolesQuery(PGconn *conn, PQExpBuffer buf, char *role_catalog,
 
 	appendPQExpBuffer(buf,
 					  ") AS db_owner_members "
-					  "JOIN pg_roles pr ON pr.rolname = sys.babelfish_truncate_identifier(db_owner_members.member_role || '_obj') ");
+					  "JOIN pg_roles pr ON pr.rolname = sys.babelfish_truncate_identifier(db_owner_members.member_role || '_bbfobj') ");
 
 	appendPQExpBuffer(buf, "), "
 					  "bbf_roles AS (SELECT rc.* FROM %s rc INNER JOIN bbf_catalog bcat "
@@ -389,7 +389,7 @@ getBabelfishRoleMembershipQuery(PGconn *conn, PQExpBuffer buf,
 
 	appendPQExpBuffer(buf,
 					  ") AS db_owner_members "
-					  "JOIN pg_roles pr ON pr.rolname = sys.babelfish_truncate_identifier(db_owner_members.member_role || '_obj') ");
+					  "JOIN pg_roles pr ON pr.rolname = sys.babelfish_truncate_identifier(db_owner_members.member_role || '_bbfobj') ");
 
 	appendPQExpBuffer(buf, "), "
 					  "bbf_roles AS (SELECT rc.* FROM %s rc INNER JOIN bbf_catalog bcat "


### PR DESCRIPTION
### Description

This commit changes the suffix for internally associated role from "_obj" to "_bbfobj" for users that are member of db_owner role. This is done to reduce the chance of an internal name clash.

Task: BABEL-4899, BABEL-5491, BABEL-5502
Signed-off-by: Sharu Goel <goelshar@amazon.com>
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
