### PR TITLE
Set PG dialect While Running FKEY checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ jobs:
         run: |
           sudo apt update --fix-missing -y
           sudo apt install -y libipc-run-perl
+          sudo apt-get install -y libreadline-dev
       - name: build-postgres
         run: |
           ./configure --with-icu --enable-cassert --enable-tap-tests

--- a/src/backend/utils/adt/ri_triggers.c
+++ b/src/backend/utils/adt/ri_triggers.c
@@ -430,11 +430,11 @@ RI_FKey_check(TriggerData *trigdata)
 	 * referenced side.  The reason is that our snapshot must be fresh in
 	 * order for the hack in find_inheritance_children() to work.
 	 */
-	ri_PerformCheck(riinfo, &qkey, qplan,
+	RUN_AS_PSQL(ri_PerformCheck(riinfo, &qkey, qplan,
 					fk_rel, pk_rel,
 					NULL, newslot,
 					pk_rel->rd_rel->relkind == RELKIND_PARTITIONED_TABLE,
-					SPI_OK_SELECT);
+					SPI_OK_SELECT));
 
 	if (SPI_finish() != SPI_OK_FINISH)
 		elog(ERROR, "SPI_finish failed");
@@ -557,11 +557,11 @@ ri_Check_Pk_Match(Relation pk_rel, Relation fk_rel,
 	/*
 	 * We have a plan now. Run it.
 	 */
-	result = ri_PerformCheck(riinfo, &qkey, qplan,
+	RUN_AS_PSQL(result = ri_PerformCheck(riinfo, &qkey, qplan,
 							 fk_rel, pk_rel,
 							 oldslot, NULL,
 							 true,	/* treat like update */
-							 SPI_OK_SELECT);
+							 SPI_OK_SELECT));
 
 	if (SPI_finish() != SPI_OK_FINISH)
 		elog(ERROR, "SPI_finish failed");
@@ -749,11 +749,11 @@ ri_restrict(TriggerData *trigdata, bool is_no_action)
 	/*
 	 * We have a plan now. Run it to check for existing references.
 	 */
-	ri_PerformCheck(riinfo, &qkey, qplan,
+	RUN_AS_PSQL(ri_PerformCheck(riinfo, &qkey, qplan,
 					fk_rel, pk_rel,
 					oldslot, NULL,
 					true,		/* must detect new rows */
-					SPI_OK_SELECT);
+					SPI_OK_SELECT));
 
 	if (SPI_finish() != SPI_OK_FINISH)
 		elog(ERROR, "SPI_finish failed");
@@ -855,11 +855,11 @@ RI_FKey_cascade_del(PG_FUNCTION_ARGS)
 	 * We have a plan now. Build up the arguments from the key values in the
 	 * deleted PK tuple and delete the referencing rows
 	 */
-	ri_PerformCheck(riinfo, &qkey, qplan,
+	RUN_AS_PSQL(ri_PerformCheck(riinfo, &qkey, qplan,
 					fk_rel, pk_rel,
 					oldslot, NULL,
 					true,		/* must detect new rows */
-					SPI_OK_DELETE);
+					SPI_OK_DELETE));
 
 	if (SPI_finish() != SPI_OK_FINISH)
 		elog(ERROR, "SPI_finish failed");
@@ -976,11 +976,11 @@ RI_FKey_cascade_upd(PG_FUNCTION_ARGS)
 	/*
 	 * We have a plan now. Run it to update the existing references.
 	 */
-	ri_PerformCheck(riinfo, &qkey, qplan,
+	RUN_AS_PSQL(ri_PerformCheck(riinfo, &qkey, qplan,
 					fk_rel, pk_rel,
 					oldslot, newslot,
 					true,		/* must detect new rows */
-					SPI_OK_UPDATE);
+					SPI_OK_UPDATE));
 
 	if (SPI_finish() != SPI_OK_FINISH)
 		elog(ERROR, "SPI_finish failed");
@@ -1208,11 +1208,11 @@ ri_set(TriggerData *trigdata, bool is_set_null, int tgkind)
 	/*
 	 * We have a plan now. Run it to update the existing references.
 	 */
-	ri_PerformCheck(riinfo, &qkey, qplan,
+	RUN_AS_PSQL(ri_PerformCheck(riinfo, &qkey, qplan,
 					fk_rel, pk_rel,
 					oldslot, NULL,
 					true,		/* must detect new rows */
-					SPI_OK_UPDATE);
+					SPI_OK_UPDATE));
 
 	if (SPI_finish() != SPI_OK_FINISH)
 		elog(ERROR, "SPI_finish failed");

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -1783,8 +1783,7 @@ bool IsTsqlTableVariable(Relation relation)
 {
 	return sql_dialect == SQL_DIALECT_TSQL 
 		&& relation
-		&& relation->rd_rel->relpersistence == RELPERSISTENCE_TEMP 
-		&& relation->rd_rel->relname.data 
+		&& relation->rd_rel->relpersistence == RELPERSISTENCE_TEMP  
 		&& strlen(relation->rd_rel->relname.data) >= 1 
 		&& relation->rd_rel->relname.data[0] == '@';
 }


### PR DESCRIPTION
### Description

On TSQL Endpoint, When Using Temp Table Inside Trigger, we plan the Referential Integrity(RI) check queries in `PG_DIALECT` but were not executing them using the same dialect they were planned in , which led to improper plan invalidation and incorrect namespace search path resolution.

Fixes https://github.com/babelfish-for-postgresql/babelfish_extensions/issues/3058
 
### Issues Resolved

BABEL-5270
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
