### PR TITLE
[BABEL] Fix warnings in IsTsqlTableVariable & ExecModifyTable 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
           sudo apt install -y libipc-run-perl
       - name: build-postgres
         run: |
-          ./configure --with-icu --enable-cassert --enable-tap-tests
+          ./configure --with-icu --enable-cassert --enable-tap-tests --without-readline
           make world-bin -j8 COPT='-Werror -Wno-error=maybe-uninitialized'
       - name: run-tests
         run: |

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -3955,7 +3955,7 @@ ExecModifyTable(PlanState *pstate)
 	/* for INSERT ... EXECUTE */
 	bool 		tsql_insert_exec = node->callStmt != NULL;
 	Tuplestorestate *tss = NULL;
-	TupleDesc 	tupdesc;
+	TupleDesc 	tupdesc = NULL;
 	DestReceiver *dest = NULL;
 
 	CHECK_FOR_INTERRUPTS();

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -3954,7 +3954,7 @@ ExecModifyTable(PlanState *pstate)
 	bool		tuplock;
 	/* for INSERT ... EXECUTE */
 	bool 		tsql_insert_exec = node->callStmt != NULL;
-	Tuplestorestate *tss;
+	Tuplestorestate *tss = NULL;
 	TupleDesc 	tupdesc;
 	DestReceiver *dest = NULL;
 

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -1784,7 +1784,6 @@ bool IsTsqlTableVariable(Relation relation)
 	return sql_dialect == SQL_DIALECT_TSQL 
 		&& relation
 		&& relation->rd_rel->relpersistence == RELPERSISTENCE_TEMP 
-		&& relation->rd_rel->relname.data 
 		&& strlen(relation->rd_rel->relname.data) >= 1 
 		&& relation->rd_rel->relname.data[0] == '@';
 }


### PR DESCRIPTION
### Description

1. Fix warning in IsTsqlTableVariable
```
queryenvironment.c: In function ‘IsTsqlTableVariable’:
queryenvironment.c:1787:17: error: the comparison will always evaluate as ‘true’ for the address of ‘data’ will never be NULL [-Werror=address]
 1787 |                 && relation->rd_rel->relname.data
      |                 ^~
In file included from ../../../../src/include/postgres.h:45,
                 from queryenvironment.c:23:
../../../../src/include/c.h:742:25: note: ‘data’ declared here
  742 |         char            data[NAMEDATALEN];
      |                         ^~~~
```
removed this line since it will always evaluate to true

2. Supress warning for uninitialized variable `tss`
```
nodeModifyTable.c: In function ‘ExecModifyTable’:
nodeModifyTable.c:4064:25: warning: ‘tss’ may be used uninitialized [-Wmaybe-uninitialized]
 4064 |                         tuplestore_gettupleslot(tss, true, false, context.planSlot);
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
nodeModifyTable.c:3957:26: note: ‘tss’ was declared here
 3957 |         Tuplestorestate *tss;
      |                          ^~~
nodeModifyTable.c:4063:44: warning: ‘tupdesc’ may be used uninitialized [-Wmaybe-uninitialized]
 4063 |                         context.planSlot = MakeSingleTupleTableSlot(tupdesc, &TTSOpsMinimalTuple);
      |                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
nodeModifyTable.c:3958:25: note: ‘tupdesc’ was declared here
 3958 |         TupleDesc       tupdesc;
      |                         ^~~~~~~
```
This warning is a non issue since tss will always be initialized as per our code. So as a fix initialize the variable with NULL to silence the warnings.

3. Configure engine without readline in github actions

#### Engine Change https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/520
#### Extensios Change https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3430
 
### Issues Resolved

[No JIRA]
 
### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>

### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
