### PR TITLE
Move logic to handle numberTuples to ExecutePlan

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -65,6 +65,7 @@
 /* Hooks for plugins to get control in ExecutorStart/Run/Finish/End */
 ExecutorStart_hook_type ExecutorStart_hook = NULL;
 ExecutorRun_hook_type ExecutorRun_hook = NULL;
+ExecutePlan_hook_type ExecutePlan_hook = NULL;
 ExecutorFinish_hook_type ExecutorFinish_hook = NULL;
 ExecutorEnd_hook_type ExecutorEnd_hook = NULL;
 
@@ -1638,6 +1639,17 @@ ExecutePlan(QueryDesc *queryDesc,
 	else
 		use_parallel_mode = queryDesc->plannedstmt->parallelModeNeeded;
 	queryDesc->already_executed = true;
+
+	/*
+	 * we also want to adjust numberTuples with babelfishpg_tsql.rowcount
+	 * if we are inside TSQL dialect.
+	 */
+	if (sql_dialect == SQL_DIALECT_TSQL &&
+		queryDesc->operation == CMD_SELECT &&
+		ExecutePlan_hook)
+	{
+		(*ExecutePlan_hook) (queryDesc, use_parallel_mode, &numberTuples);
+	}
 
 	estate->es_use_parallel_mode = use_parallel_mode;
 	if (use_parallel_mode)

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -82,6 +82,12 @@ typedef void (*ExecutorRun_hook_type) (QueryDesc *queryDesc,
 									   bool execute_once);
 extern PGDLLEXPORT ExecutorRun_hook_type ExecutorRun_hook;
 
+/* Hook for plugins to get control in ExecutePlan() */
+typedef void (*ExecutePlan_hook_type) (QueryDesc *queryDesc,
+									   bool use_parallel_mode,
+									   uint64 *numberTuples);
+extern PGDLLEXPORT ExecutePlan_hook_type ExecutePlan_hook;
+
 /* Hook for plugins to get control in ExecutorFinish() */
 typedef void (*ExecutorFinish_hook_type) (QueryDesc *queryDesc);
 extern PGDLLEXPORT ExecutorFinish_hook_type ExecutorFinish_hook;


### PR DESCRIPTION
### Description

Community [commit](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/commit/7f07ff583ea8d55bb32853de40c3a9b69644c80f) simplified executor code to decide whether to use parallel query. Based on the new condition executor will never pick parallel operation if numberTuples != 0 is non zero, which happens when we put a limit on number of tuples that can be returned by executor.

In Babelfish we were always initializing the `ROWCOUNT` as `INT_MAX` and the setting `numberTuples = ROWCOUNT`(inside `pltsql_ExecutorRun(...)`), which means Babelfish select query will never be able to use parallelism even though it could. This determination of whether to use parallelism is being done inside `ExecutePlan(...)` so we have postponed the logic of handling numberTuples til we make decision on parallelism (ie, inside `ExecutePlan(...)`). This commit introduces a hook which will be initialised by extension to handle this logic inside `ExecutePlan(...)`. 

 
### Issues Resolved

Task: BABEL-5606
Signed-off-by: Dipesh Dhameliya <dddhamel@amazon.com>

### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
