### PR TITLE
[DO NOT MERGE]Added BBF hook to truncate numeric result to correct scale

### DIFF
--- a/src/backend/executor/execExprInterp.c
+++ b/src/backend/executor/execExprInterp.c
@@ -66,6 +66,7 @@
 #include "nodes/nodeFuncs.h"
 #include "parser/parsetree.h"
 #include "pgstat.h"
+#include "parser/parser.h"
 #include "utils/array.h"
 #include "utils/builtins.h"
 #include "utils/date.h"
@@ -100,6 +101,9 @@
  * EEO_JUMP - jump to the specified step number within the current expression.
  */
 #if defined(EEO_USE_COMPUTED_GOTO)
+
+/* BBF Hook to truncate result to correct scale, when resulttype is numeric */
+bbf_trunc_numeric_result_hook_type bbf_trunc_numeric_result_hook = NULL;
 
 /* struct for jump target -> opcode lookup table */
 typedef struct ExprEvalOpLookup
@@ -732,6 +736,10 @@ ExecInterpExpr(ExprState *state, ExprContext *econtext, bool *isnull)
 
 			fcinfo->isnull = false;
 			d = op->d.func.fn_addr(fcinfo);
+
+			if (sql_dialect == SQL_DIALECT_TSQL && bbf_trunc_numeric_result_hook)
+				d = bbf_trunc_numeric_result_hook(fcinfo->flinfo->fn_expr, d, get_func_rettype(fcinfo->flinfo->fn_oid));
+
 			*op->resvalue = d;
 			*op->resnull = fcinfo->isnull;
 
@@ -756,6 +764,10 @@ ExecInterpExpr(ExprState *state, ExprContext *econtext, bool *isnull)
 			}
 			fcinfo->isnull = false;
 			d = op->d.func.fn_addr(fcinfo);
+
+			if (sql_dialect == SQL_DIALECT_TSQL && bbf_trunc_numeric_result_hook)
+				d = bbf_trunc_numeric_result_hook(fcinfo->flinfo->fn_expr, d, get_func_rettype(fcinfo->flinfo->fn_oid));
+
 			*op->resvalue = d;
 			*op->resnull = fcinfo->isnull;
 

--- a/src/backend/executor/execExprInterp.c
+++ b/src/backend/executor/execExprInterp.c
@@ -736,10 +736,6 @@ ExecInterpExpr(ExprState *state, ExprContext *econtext, bool *isnull)
 
 			fcinfo->isnull = false;
 			d = op->d.func.fn_addr(fcinfo);
-
-			if (sql_dialect == SQL_DIALECT_TSQL && bbf_trunc_numeric_result_hook)
-				d = bbf_trunc_numeric_result_hook(fcinfo->flinfo->fn_expr, d, get_func_rettype(fcinfo->flinfo->fn_oid));
-
 			*op->resvalue = d;
 			*op->resnull = fcinfo->isnull;
 

--- a/src/backend/executor/execExprInterp.c
+++ b/src/backend/executor/execExprInterp.c
@@ -103,7 +103,7 @@
 #if defined(EEO_USE_COMPUTED_GOTO)
 
 /* BBF Hook to truncate result to correct scale, when resulttype is numeric */
-bbf_trunc_numeric_result_hook_type bbf_trunc_numeric_result_hook = NULL;
+pltsql_trunc_numeric_result_hook_type pltsql_trunc_numeric_result_hook = NULL;
 
 /* struct for jump target -> opcode lookup table */
 typedef struct ExprEvalOpLookup
@@ -761,8 +761,8 @@ ExecInterpExpr(ExprState *state, ExprContext *econtext, bool *isnull)
 			fcinfo->isnull = false;
 			d = op->d.func.fn_addr(fcinfo);
 
-			if (sql_dialect == SQL_DIALECT_TSQL && bbf_trunc_numeric_result_hook)
-				d = bbf_trunc_numeric_result_hook(fcinfo->flinfo->fn_expr, d, get_func_rettype(fcinfo->flinfo->fn_oid), -1);
+			if (sql_dialect == SQL_DIALECT_TSQL && pltsql_trunc_numeric_result_hook)
+				d = pltsql_trunc_numeric_result_hook(fcinfo->flinfo->fn_expr, d, get_func_rettype(fcinfo->flinfo->fn_oid), -1);
 
 			*op->resvalue = d;
 			*op->resnull = fcinfo->isnull;

--- a/src/backend/executor/execExprInterp.c
+++ b/src/backend/executor/execExprInterp.c
@@ -766,7 +766,7 @@ ExecInterpExpr(ExprState *state, ExprContext *econtext, bool *isnull)
 			{
 				func_result_type = get_func_rettype(fcinfo->flinfo->fn_oid);
 				if (getBaseType(func_result_type) == NUMERICOID)
-					d = pltsql_trunc_numeric_result_hook(fcinfo->flinfo->fn_expr, d, func_result_type, -1);
+					d = pltsql_trunc_numeric_result_hook(NULL, fcinfo->flinfo->fn_expr, d, func_result_type, -1);
 			}
 
 			*op->resvalue = d;

--- a/src/backend/executor/execExprInterp.c
+++ b/src/backend/executor/execExprInterp.c
@@ -762,7 +762,7 @@ ExecInterpExpr(ExprState *state, ExprContext *econtext, bool *isnull)
 			d = op->d.func.fn_addr(fcinfo);
 
 			if (sql_dialect == SQL_DIALECT_TSQL && bbf_trunc_numeric_result_hook)
-				d = bbf_trunc_numeric_result_hook(fcinfo->flinfo->fn_expr, d, get_func_rettype(fcinfo->flinfo->fn_oid));
+				d = bbf_trunc_numeric_result_hook(fcinfo->flinfo->fn_expr, d, get_func_rettype(fcinfo->flinfo->fn_oid), -1);
 
 			*op->resvalue = d;
 			*op->resnull = fcinfo->isnull;

--- a/src/backend/executor/execExprInterp.c
+++ b/src/backend/executor/execExprInterp.c
@@ -102,7 +102,7 @@
  */
 #if defined(EEO_USE_COMPUTED_GOTO)
 
-/* BBF Hook to truncate result to correct scale, when resulttype is numeric */
+/* pltsql Hook to truncate result to correct scale, when resulttype is numeric */
 pltsql_trunc_numeric_result_hook_type pltsql_trunc_numeric_result_hook = NULL;
 
 /* struct for jump target -> opcode lookup table */
@@ -748,6 +748,7 @@ ExecInterpExpr(ExprState *state, ExprContext *econtext, bool *isnull)
 			NullableDatum *args = fcinfo->args;
 			int			nargs = op->d.func.nargs;
 			Datum		d;
+			Oid         func_result_type = InvalidOid;
 
 			/* strict function, so check for NULL args */
 			for (int argno = 0; argno < nargs; argno++)
@@ -762,7 +763,11 @@ ExecInterpExpr(ExprState *state, ExprContext *econtext, bool *isnull)
 			d = op->d.func.fn_addr(fcinfo);
 
 			if (sql_dialect == SQL_DIALECT_TSQL && pltsql_trunc_numeric_result_hook)
-				d = pltsql_trunc_numeric_result_hook(fcinfo->flinfo->fn_expr, d, get_func_rettype(fcinfo->flinfo->fn_oid), -1);
+			{
+				func_result_type = get_func_rettype(fcinfo->flinfo->fn_oid);
+				if (getBaseType(func_result_type) == NUMERICOID)
+					d = pltsql_trunc_numeric_result_hook(fcinfo->flinfo->fn_expr, d, func_result_type, -1);
+			}
 
 			*op->resvalue = d;
 			*op->resnull = fcinfo->isnull;

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -68,6 +68,7 @@
 #include "utils/expandeddatum.h"
 #include "utils/lsyscache.h"
 #include "utils/typcache.h"
+#include "parser/parser.h"
 
 static TupleDesc ExecTypeFromTLInternal(List *targetList,
 										bool skipjunk);
@@ -1800,7 +1801,10 @@ void
 ExecInitResultTupleSlotTL(PlanState *planstate,
 						  const TupleTableSlotOps *tts_ops)
 {
-	ExecInitResultTypeTL(planstate);
+	if (sql_dialect == SQL_DIALECT_TSQL && pltsql_ExecInitResultTypeTL_hook)
+		pltsql_ExecInitResultTypeTL_hook(planstate);
+	else
+		ExecInitResultTypeTL(planstate);
 	ExecInitResultSlot(planstate, tts_ops);
 }
 

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -86,7 +86,7 @@ const TupleTableSlotOps TTSOpsHeapTuple;
 const TupleTableSlotOps TTSOpsMinimalTuple;
 const TupleTableSlotOps TTSOpsBufferHeapTuple;
 
-/* pltsql Hook to truncate result to correct scale, when resulttype is numeric */
+/* pltsql hook to initialize result type */
 pltsql_ExecInitResultTypeTL_hook_type pltsql_ExecInitResultTypeTL_hook = NULL;
 
 /*

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -1756,9 +1756,14 @@ ExecFetchSlotHeapTupleDatum(TupleTableSlot *slot)
 void
 ExecInitResultTypeTL(PlanState *planstate)
 {
-	TupleDesc	tupDesc = ExecTypeFromTL(planstate->plan->targetlist);
+	if (sql_dialect == SQL_DIALECT_TSQL && pltsql_ExecInitResultTypeTL_hook)
+		pltsql_ExecInitResultTypeTL_hook(planstate);
+	else
+	{
+		TupleDesc	tupDesc = ExecTypeFromTL(planstate->plan->targetlist);
 
-	planstate->ps_ResultTupleDesc = tupDesc;
+		planstate->ps_ResultTupleDesc = tupDesc;
+	}
 }
 
 /* --------------------------------
@@ -1801,10 +1806,7 @@ void
 ExecInitResultTupleSlotTL(PlanState *planstate,
 						  const TupleTableSlotOps *tts_ops)
 {
-	if (sql_dialect == SQL_DIALECT_TSQL && pltsql_ExecInitResultTypeTL_hook)
-		pltsql_ExecInitResultTypeTL_hook(planstate);
-	else
-		ExecInitResultTypeTL(planstate);
+	ExecInitResultTypeTL(planstate);
 	ExecInitResultSlot(planstate, tts_ops);
 }
 

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -86,6 +86,8 @@ const TupleTableSlotOps TTSOpsHeapTuple;
 const TupleTableSlotOps TTSOpsMinimalTuple;
 const TupleTableSlotOps TTSOpsBufferHeapTuple;
 
+/* pltsql Hook to truncate result to correct scale, when resulttype is numeric */
+pltsql_ExecInitResultTypeTL_hook_type pltsql_ExecInitResultTypeTL_hook = NULL;
 
 /*
  * TupleTableSlotOps implementations.

--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -1119,8 +1119,8 @@ finalize_aggregate(AggState *aggstate,
 			Datum		result;
 
 			result = FunctionCallInvoke(fcinfo);
-            if (sql_dialect == SQL_DIALECT_TSQL && bbf_trunc_numeric_result_hook)
-                result = bbf_trunc_numeric_result_hook((Node *) peragg->aggref, result, peragg->aggref->aggtype, -1);
+            if (sql_dialect == SQL_DIALECT_TSQL && pltsql_trunc_numeric_result_hook)
+                result = pltsql_trunc_numeric_result_hook((Node *) peragg->aggref, result, peragg->aggref->aggtype, -1);
 			*resultIsNull = fcinfo->isnull;
 			*resultVal = MakeExpandedObjectReadOnly(result,
 													fcinfo->isnull,

--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -1119,7 +1119,7 @@ finalize_aggregate(AggState *aggstate,
 			Datum		result;
 
 			result = FunctionCallInvoke(fcinfo);
-            if (sql_dialect == SQL_DIALECT_TSQL && pltsql_trunc_numeric_result_hook)
+            if (sql_dialect == SQL_DIALECT_TSQL && pltsql_trunc_numeric_result_hook && getBaseType(peragg->aggref->aggtype) == NUMERICOID)
                 result = pltsql_trunc_numeric_result_hook((Node *) peragg->aggref, result, peragg->aggref->aggtype, -1);
 			*resultIsNull = fcinfo->isnull;
 			*resultVal = MakeExpandedObjectReadOnly(result,

--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -1120,7 +1120,7 @@ finalize_aggregate(AggState *aggstate,
 
 			result = FunctionCallInvoke(fcinfo);
             if (sql_dialect == SQL_DIALECT_TSQL && pltsql_trunc_numeric_result_hook && getBaseType(peragg->aggref->aggtype) == NUMERICOID)
-                result = pltsql_trunc_numeric_result_hook((Node *) peragg->aggref, result, peragg->aggref->aggtype, -1);
+                result = pltsql_trunc_numeric_result_hook(aggstate->ss.ps.plan, (Node *) peragg->aggref, result, peragg->aggref->aggtype, -1);
 			*resultIsNull = fcinfo->isnull;
 			*resultVal = MakeExpandedObjectReadOnly(result,
 													fcinfo->isnull,

--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -263,6 +263,7 @@
 #include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
 #include "optimizer/optimizer.h"
+#include "parser/parser.h"
 #include "parser/parse_agg.h"
 #include "parser/parse_coerce.h"
 #include "utils/acl.h"
@@ -1118,6 +1119,8 @@ finalize_aggregate(AggState *aggstate,
 			Datum		result;
 
 			result = FunctionCallInvoke(fcinfo);
+            if (sql_dialect == SQL_DIALECT_TSQL && bbf_trunc_numeric_result_hook)
+                result = bbf_trunc_numeric_result_hook((Node *) peragg->aggref, result, peragg->aggref->aggtype, -1);
 			*resultIsNull = fcinfo->isnull;
 			*resultVal = MakeExpandedObjectReadOnly(result,
 													fcinfo->isnull,

--- a/src/backend/executor/nodeSeqscan.c
+++ b/src/backend/executor/nodeSeqscan.c
@@ -32,13 +32,8 @@
 #include "executor/execdebug.h"
 #include "executor/nodeSeqscan.h"
 #include "utils/rel.h"
-#include "parser/parser.h"
 
 static TupleTableSlot *SeqNext(SeqScanState *node);
-
-/* pltsql Hook to truncate result to correct scale, when resulttype is numeric */
-pltsql_ExecInitResultTypeTL_hook_type pltsql_ExecInitResultTypeTL_hook = NULL;
-
 
 /* ----------------------------------------------------------------
  *						Scan Support

--- a/src/backend/executor/nodeSeqscan.c
+++ b/src/backend/executor/nodeSeqscan.c
@@ -167,10 +167,7 @@ ExecInitSeqScan(SeqScan *node, EState *estate, int eflags)
 	/*
 	 * Initialize result type and projection.
 	 */
-	if (sql_dialect == SQL_DIALECT_TSQL && pltsql_ExecInitResultTypeTL_hook)
-		pltsql_ExecInitResultTypeTL_hook(&scanstate->ss.ps);
-	else
-		ExecInitResultTypeTL(&scanstate->ss.ps);
+	ExecInitResultTypeTL(&scanstate->ss.ps);
 	ExecAssignScanProjectionInfo(&scanstate->ss);
 
 	/*

--- a/src/backend/executor/nodeSeqscan.c
+++ b/src/backend/executor/nodeSeqscan.c
@@ -32,8 +32,13 @@
 #include "executor/execdebug.h"
 #include "executor/nodeSeqscan.h"
 #include "utils/rel.h"
+#include "parser/parser.h"
 
 static TupleTableSlot *SeqNext(SeqScanState *node);
+
+/* pltsql Hook to truncate result to correct scale, when resulttype is numeric */
+pltsql_ExecInitResultTypeTL_hook_type pltsql_ExecInitResultTypeTL_hook = NULL;
+
 
 /* ----------------------------------------------------------------
  *						Scan Support
@@ -162,7 +167,10 @@ ExecInitSeqScan(SeqScan *node, EState *estate, int eflags)
 	/*
 	 * Initialize result type and projection.
 	 */
-	ExecInitResultTypeTL(&scanstate->ss.ps);
+	if (sql_dialect == SQL_DIALECT_TSQL && pltsql_ExecInitResultTypeTL_hook)
+		pltsql_ExecInitResultTypeTL_hook(&scanstate->ss.ps);
+	else
+		ExecInitResultTypeTL(&scanstate->ss.ps);
 	ExecAssignScanProjectionInfo(&scanstate->ss);
 
 	/*

--- a/src/backend/nodes/nodeFuncs.c
+++ b/src/backend/nodes/nodeFuncs.c
@@ -511,7 +511,7 @@ exprTypmod(const Node *expr)
 			break;
 	}
 
-	if (sql_dialect == SQL_DIALECT_TSQL && resolve_numeric_typmod_from_exp_hook){
+	if (sql_dialect == SQL_DIALECT_TSQL && resolve_numeric_typmod_from_exp_hook && getBaseType(exprType(expr)) == NUMERICOID){
 		return resolve_numeric_typmod_from_exp_hook(NULL, (Node *) expr);
 	}
 

--- a/src/backend/nodes/nodeFuncs.c
+++ b/src/backend/nodes/nodeFuncs.c
@@ -511,9 +511,8 @@ exprTypmod(const Node *expr)
 			break;
 	}
 
-	if (sql_dialect == SQL_DIALECT_TSQL && resolve_numeric_typmod_from_exp_hook && getBaseType(exprType(expr)) == NUMERICOID){
+	if (sql_dialect == SQL_DIALECT_TSQL && resolve_numeric_typmod_from_exp_hook && getBaseType(exprType(expr)) == NUMERICOID)
 		return resolve_numeric_typmod_from_exp_hook(NULL, (Node *) expr);
-	}
 
 	return -1;
 }

--- a/src/backend/nodes/nodeFuncs.c
+++ b/src/backend/nodes/nodeFuncs.c
@@ -36,6 +36,7 @@ static bool planstate_walk_members(PlanState **planstates, int nplans,
 								   void *context);
 
 coalesce_typmod_hook_type coalesce_typmod_hook = NULL;
+resolve_numeric_typmod_from_exp_hook_type resolve_numeric_typmod_from_exp_hook = NULL;
 
 /*
  *	exprType -
@@ -509,6 +510,11 @@ exprTypmod(const Node *expr)
 		default:
 			break;
 	}
+
+	if (sql_dialect == SQL_DIALECT_TSQL && resolve_numeric_typmod_from_exp_hook){
+		return resolve_numeric_typmod_from_exp_hook(NULL, expr);
+	}
+
 	return -1;
 }
 

--- a/src/backend/nodes/nodeFuncs.c
+++ b/src/backend/nodes/nodeFuncs.c
@@ -36,7 +36,7 @@ static bool planstate_walk_members(PlanState **planstates, int nplans,
 								   void *context);
 
 coalesce_typmod_hook_type coalesce_typmod_hook = NULL;
-resolve_numeric_typmod_from_exp_hook_type resolve_numeric_typmod_from_exp_hook = NULL;
+pltsql_exprTypmod_hook_type pltsql_exprTypmod_hook = NULL;
 
 /*
  *	exprType -
@@ -511,8 +511,8 @@ exprTypmod(const Node *expr)
 			break;
 	}
 
-	if (sql_dialect == SQL_DIALECT_TSQL && resolve_numeric_typmod_from_exp_hook && getBaseType(exprType(expr)) == NUMERICOID)
-		return resolve_numeric_typmod_from_exp_hook(NULL, (Node *) expr);
+	if (sql_dialect == SQL_DIALECT_TSQL && pltsql_exprTypmod_hook)
+		return pltsql_exprTypmod_hook(NULL, (Node *) expr);
 
 	return -1;
 }

--- a/src/backend/nodes/nodeFuncs.c
+++ b/src/backend/nodes/nodeFuncs.c
@@ -512,7 +512,7 @@ exprTypmod(const Node *expr)
 	}
 
 	if (sql_dialect == SQL_DIALECT_TSQL && resolve_numeric_typmod_from_exp_hook){
-		return resolve_numeric_typmod_from_exp_hook(NULL, expr);
+		return resolve_numeric_typmod_from_exp_hook(NULL, (Node *) expr);
 	}
 
 	return -1;

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -2429,16 +2429,11 @@ static Node *
 eval_const_expressions_mutator(Node *node,
 							   eval_const_expressions_context *context)
 {
-	int32 result_typmod = -1;
-
 	/* since this function recurses, it could be driven to stack overflow */
 	check_stack_depth();
 
 	if (node == NULL)
 		return NULL;
-
-	if (sql_dialect == SQL_DIALECT_TSQL && resolve_numeric_typmod_from_exp_hook)
-		result_typmod = resolve_numeric_typmod_from_exp_hook(NULL, node);
 
 	switch (nodeTag(node))
 	{
@@ -2618,12 +2613,16 @@ eval_const_expressions_mutator(Node *node,
 				List	   *args = expr->args;
 				Expr	   *simple;
 				OpExpr	   *newexpr;
+				int32       result_typmod;
 
 				/*
 				 * Need to get OID of underlying function.  Okay to scribble
 				 * on input to this extent.
 				 */
 				set_opfuncid(expr);
+
+				if (sql_dialect == SQL_DIALECT_TSQL && resolve_numeric_typmod_from_exp_hook && expr->opresulttype == NUMERICOID)
+					result_typmod = resolve_numeric_typmod_from_exp_hook(NULL, node);
 
 				/*
 				 * Code for op/func reduction is pretty bulky, so split it out
@@ -2681,6 +2680,7 @@ eval_const_expressions_mutator(Node *node,
 				bool		has_nonconst_input = false;
 				Expr	   *simple;
 				DistinctExpr *newexpr;
+				int32       result_typmod;
 
 				/*
 				 * Reduce constants in the DistinctExpr's arguments.  We know
@@ -2728,6 +2728,9 @@ eval_const_expressions_mutator(Node *node,
 					 */
 					set_opfuncid((OpExpr *) expr);	/* rely on struct
 													 * equivalence */
+
+					if (sql_dialect == SQL_DIALECT_TSQL && resolve_numeric_typmod_from_exp_hook && expr->opresulttype == NUMERICOID)
+						result_typmod = resolve_numeric_typmod_from_exp_hook(NULL, node);
 
 					/*
 					 * Code for op/func reduction is pretty bulky, so split it
@@ -2966,6 +2969,7 @@ eval_const_expressions_mutator(Node *node,
 				Oid			intypioparam;
 				Expr	   *simple;
 				CoerceViaIO *newexpr;
+				int32       result_typmod;
 
 				/* Make a List so we can use simplify_function */
 				args = list_make1(expr->arg);
@@ -2985,7 +2989,7 @@ eval_const_expressions_mutator(Node *node,
 								 &infunc, &intypioparam);
 
 				simple = simplify_function(outfunc,
-										   CSTRINGOID, result_typmod,
+										   CSTRINGOID, -1,
 										   InvalidOid,
 										   InvalidOid,
 										   &args,
@@ -3015,6 +3019,9 @@ eval_const_expressions_mutator(Node *node,
 												Int32GetDatum(-1),
 												false,
 												true));
+
+					if (sql_dialect == SQL_DIALECT_TSQL && resolve_numeric_typmod_from_exp_hook && expr->resulttype == NUMERICOID)
+						result_typmod = resolve_numeric_typmod_from_exp_hook(NULL, node);
 
 					simple = simplify_function(infunc,
 											   expr->resulttype, result_typmod,

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -2429,12 +2429,17 @@ static Node *
 eval_const_expressions_mutator(Node *node,
 							   eval_const_expressions_context *context)
 {
+	int32 result_typmod = -1;
 
 	/* since this function recurses, it could be driven to stack overflow */
 	check_stack_depth();
 
 	if (node == NULL)
 		return NULL;
+
+	if (sql_dialect == SQL_DIALECT_TSQL && resolve_numeric_typmod_from_exp_hook)
+		result_typmod = resolve_numeric_typmod_from_exp_hook(NULL, node);
+
 	switch (nodeTag(node))
 	{
 		case T_Param:
@@ -2625,7 +2630,7 @@ eval_const_expressions_mutator(Node *node,
 				 * as a separate function.
 				 */
 				simple = simplify_function(expr->opfuncid,
-										   expr->opresulttype, -1,
+										   expr->opresulttype, result_typmod,
 										   expr->opcollid,
 										   expr->inputcollid,
 										   &args,
@@ -2729,7 +2734,7 @@ eval_const_expressions_mutator(Node *node,
 					 * out as a separate function.
 					 */
 					simple = simplify_function(expr->opfuncid,
-											   expr->opresulttype, -1,
+											   expr->opresulttype, result_typmod,
 											   expr->opcollid,
 											   expr->inputcollid,
 											   &args,
@@ -2980,7 +2985,7 @@ eval_const_expressions_mutator(Node *node,
 								 &infunc, &intypioparam);
 
 				simple = simplify_function(outfunc,
-										   CSTRINGOID, -1,
+										   CSTRINGOID, result_typmod,
 										   InvalidOid,
 										   InvalidOid,
 										   &args,
@@ -3012,7 +3017,7 @@ eval_const_expressions_mutator(Node *node,
 												true));
 
 					simple = simplify_function(infunc,
-											   expr->resulttype, -1,
+											   expr->resulttype, result_typmod,
 											   expr->resultcollid,
 											   InvalidOid,
 											   &args,
@@ -5055,6 +5060,7 @@ evaluate_expr(Expr *expr, Oid result_type, int32 result_typmod,
 	bool		const_is_null;
 	int16		resultTypLen;
 	bool		resultTypByVal;
+	int32		scale;
 
 	/*
 	 * To use the executor, we need an EState.
@@ -5113,6 +5119,11 @@ evaluate_expr(Expr *expr, Oid result_type, int32 result_typmod,
 	/*
 	 * Make the constant result node.
 	 */
+	if (sql_dialect == SQL_DIALECT_TSQL && result_type == NUMERICOID && result_typmod != -1){
+		scale = (result_typmod - VARHDRSZ) & 0xffff; 
+		const_val = DirectFunctionCall2(numeric_trunc, const_val, Int32GetDatum(scale));
+	}
+
 	return (Expr *) makeConst(result_type, result_typmod, result_collation,
 							  resultTypLen,
 							  const_val, const_is_null,

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -2429,12 +2429,12 @@ static Node *
 eval_const_expressions_mutator(Node *node,
 							   eval_const_expressions_context *context)
 {
+
 	/* since this function recurses, it could be driven to stack overflow */
 	check_stack_depth();
 
 	if (node == NULL)
 		return NULL;
-
 	switch (nodeTag(node))
 	{
 		case T_Param:
@@ -2613,7 +2613,7 @@ eval_const_expressions_mutator(Node *node,
 				List	   *args = expr->args;
 				Expr	   *simple;
 				OpExpr	   *newexpr;
-				int32       result_typmod;
+				int32       result_typmod = -1;
 
 				/*
 				 * Need to get OID of underlying function.  Okay to scribble
@@ -2680,7 +2680,7 @@ eval_const_expressions_mutator(Node *node,
 				bool		has_nonconst_input = false;
 				Expr	   *simple;
 				DistinctExpr *newexpr;
-				int32       result_typmod;
+				int32       result_typmod = -1;
 
 				/*
 				 * Reduce constants in the DistinctExpr's arguments.  We know
@@ -2969,7 +2969,7 @@ eval_const_expressions_mutator(Node *node,
 				Oid			intypioparam;
 				Expr	   *simple;
 				CoerceViaIO *newexpr;
-				int32       result_typmod;
+				int32       result_typmod = -1;
 
 				/* Make a List so we can use simplify_function */
 				args = list_make1(expr->arg);
@@ -5067,7 +5067,6 @@ evaluate_expr(Expr *expr, Oid result_type, int32 result_typmod,
 	bool		const_is_null;
 	int16		resultTypLen;
 	bool		resultTypByVal;
-	int32		scale;
 
 	/*
 	 * To use the executor, we need an EState.
@@ -5126,10 +5125,8 @@ evaluate_expr(Expr *expr, Oid result_type, int32 result_typmod,
 	/*
 	 * Make the constant result node.
 	 */
-	if (sql_dialect == SQL_DIALECT_TSQL && result_type == NUMERICOID && result_typmod != -1){
-		scale = (result_typmod - VARHDRSZ) & 0xffff; 
-		const_val = DirectFunctionCall2(numeric_trunc, const_val, Int32GetDatum(scale));
-	}
+	if (sql_dialect == SQL_DIALECT_TSQL && bbf_trunc_numeric_result_hook)
+		const_val = bbf_trunc_numeric_result_hook(NULL, const_val, result_type, result_typmod);
 
 	return (Expr *) makeConst(result_type, result_typmod, result_collation,
 							  resultTypLen,

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -5123,7 +5123,7 @@ evaluate_expr(Expr *expr, Oid result_type, int32 result_typmod,
 	FreeExecutorState(estate);
 
 	if (sql_dialect == SQL_DIALECT_TSQL && pltsql_trunc_numeric_result_hook && getBaseType(result_type) == NUMERICOID)
-		const_val = pltsql_trunc_numeric_result_hook(NULL, const_val, result_type, result_typmod);
+		const_val = pltsql_trunc_numeric_result_hook(NULL, NULL, const_val, result_type, result_typmod);
 
 	/*
 	 * Make the constant result node.

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -2621,7 +2621,7 @@ eval_const_expressions_mutator(Node *node,
 				 */
 				set_opfuncid(expr);
 
-				if (sql_dialect == SQL_DIALECT_TSQL && resolve_numeric_typmod_from_exp_hook && expr->opresulttype == NUMERICOID)
+				if (sql_dialect == SQL_DIALECT_TSQL && resolve_numeric_typmod_from_exp_hook && getBaseType(expr->opresulttype) == NUMERICOID)
 					result_typmod = resolve_numeric_typmod_from_exp_hook(NULL, node);
 
 				/*
@@ -2729,7 +2729,7 @@ eval_const_expressions_mutator(Node *node,
 					set_opfuncid((OpExpr *) expr);	/* rely on struct
 													 * equivalence */
 
-					if (sql_dialect == SQL_DIALECT_TSQL && resolve_numeric_typmod_from_exp_hook && expr->opresulttype == NUMERICOID)
+					if (sql_dialect == SQL_DIALECT_TSQL && resolve_numeric_typmod_from_exp_hook && getBaseType(expr->opresulttype) == NUMERICOID)
 						result_typmod = resolve_numeric_typmod_from_exp_hook(NULL, node);
 
 					/*
@@ -3020,7 +3020,7 @@ eval_const_expressions_mutator(Node *node,
 												false,
 												true));
 
-					if (sql_dialect == SQL_DIALECT_TSQL && resolve_numeric_typmod_from_exp_hook && expr->resulttype == NUMERICOID)
+					if (sql_dialect == SQL_DIALECT_TSQL && resolve_numeric_typmod_from_exp_hook && getBaseType(expr->resulttype) == NUMERICOID)
 						result_typmod = resolve_numeric_typmod_from_exp_hook(NULL, node);
 
 					simple = simplify_function(infunc,

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -2621,8 +2621,8 @@ eval_const_expressions_mutator(Node *node,
 				 */
 				set_opfuncid(expr);
 
-				if (sql_dialect == SQL_DIALECT_TSQL && resolve_numeric_typmod_from_exp_hook && getBaseType(expr->opresulttype) == NUMERICOID)
-					result_typmod = resolve_numeric_typmod_from_exp_hook(NULL, node);
+				if (sql_dialect == SQL_DIALECT_TSQL && pltsql_exprTypmod_hook)
+					result_typmod = pltsql_exprTypmod_hook(NULL, node);
 
 				/*
 				 * Code for op/func reduction is pretty bulky, so split it out
@@ -2729,8 +2729,8 @@ eval_const_expressions_mutator(Node *node,
 					set_opfuncid((OpExpr *) expr);	/* rely on struct
 													 * equivalence */
 
-					if (sql_dialect == SQL_DIALECT_TSQL && resolve_numeric_typmod_from_exp_hook && getBaseType(expr->opresulttype) == NUMERICOID)
-						result_typmod = resolve_numeric_typmod_from_exp_hook(NULL, node);
+					if (sql_dialect == SQL_DIALECT_TSQL && pltsql_exprTypmod_hook)
+						result_typmod = pltsql_exprTypmod_hook(NULL, node);
 
 					/*
 					 * Code for op/func reduction is pretty bulky, so split it
@@ -3020,8 +3020,8 @@ eval_const_expressions_mutator(Node *node,
 												false,
 												true));
 
-					if (sql_dialect == SQL_DIALECT_TSQL && resolve_numeric_typmod_from_exp_hook && getBaseType(expr->resulttype) == NUMERICOID)
-						result_typmod = resolve_numeric_typmod_from_exp_hook(NULL, node);
+					if (sql_dialect == SQL_DIALECT_TSQL && pltsql_exprTypmod_hook)
+						result_typmod = pltsql_exprTypmod_hook(NULL, node);
 
 					simple = simplify_function(infunc,
 											   expr->resulttype, result_typmod,
@@ -5122,12 +5122,12 @@ evaluate_expr(Expr *expr, Oid result_type, int32 result_typmod,
 	/* Release all the junk we just created */
 	FreeExecutorState(estate);
 
+	if (sql_dialect == SQL_DIALECT_TSQL && pltsql_trunc_numeric_result_hook)
+		const_val = pltsql_trunc_numeric_result_hook(NULL, const_val, result_type, result_typmod);
+
 	/*
 	 * Make the constant result node.
 	 */
-	if (sql_dialect == SQL_DIALECT_TSQL && bbf_trunc_numeric_result_hook)
-		const_val = bbf_trunc_numeric_result_hook(NULL, const_val, result_type, result_typmod);
-
 	return (Expr *) makeConst(result_type, result_typmod, result_collation,
 							  resultTypLen,
 							  const_val, const_is_null,

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -5122,7 +5122,7 @@ evaluate_expr(Expr *expr, Oid result_type, int32 result_typmod,
 	/* Release all the junk we just created */
 	FreeExecutorState(estate);
 
-	if (sql_dialect == SQL_DIALECT_TSQL && pltsql_trunc_numeric_result_hook)
+	if (sql_dialect == SQL_DIALECT_TSQL && pltsql_trunc_numeric_result_hook && getBaseType(result_type) == NUMERICOID)
 		const_val = pltsql_trunc_numeric_result_hook(NULL, const_val, result_type, result_typmod);
 
 	/*

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -102,7 +102,7 @@ extern PGDLLEXPORT TriggerRecuresiveCheck_hook_type TriggerRecuresiveCheck_hook;
 typedef bool (*bbfViewHasInsteadofTrigger_hook_type) (Relation view, CmdType event);
 extern PGDLLIMPORT bbfViewHasInsteadofTrigger_hook_type bbfViewHasInsteadofTrigger_hook;
 
-typedef Datum (*pltsql_trunc_numeric_result_hook_type) (Node *fn_expr, Datum result, Oid result_type, int32 result_typmod);
+typedef Datum (*pltsql_trunc_numeric_result_hook_type) (Plan *plan, Node *fn_expr, Datum result, Oid result_type, int32 result_typmod);
 extern PGDLLIMPORT pltsql_trunc_numeric_result_hook_type pltsql_trunc_numeric_result_hook;
 
 typedef bool (*check_rowcount_hook_type) (int es_processed);

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -105,6 +105,9 @@ extern PGDLLIMPORT bbfViewHasInsteadofTrigger_hook_type bbfViewHasInsteadofTrigg
 typedef Datum (*pltsql_trunc_numeric_result_hook_type) (Plan *plan, Node *fn_expr, Datum result, Oid result_type, int32 result_typmod);
 extern PGDLLIMPORT pltsql_trunc_numeric_result_hook_type pltsql_trunc_numeric_result_hook;
 
+typedef void (*pltsql_ExecInitResultTypeTL_hook_type) (PlanState *planstate);
+extern PGDLLIMPORT pltsql_ExecInitResultTypeTL_hook_type pltsql_ExecInitResultTypeTL_hook;
+
 typedef bool (*check_rowcount_hook_type) (int es_processed);
 extern PGDLLEXPORT check_rowcount_hook_type check_rowcount_hook;
 

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -102,8 +102,8 @@ extern PGDLLEXPORT TriggerRecuresiveCheck_hook_type TriggerRecuresiveCheck_hook;
 typedef bool (*bbfViewHasInsteadofTrigger_hook_type) (Relation view, CmdType event);
 extern PGDLLIMPORT bbfViewHasInsteadofTrigger_hook_type bbfViewHasInsteadofTrigger_hook;
 
-typedef Datum (*bbf_trunc_numeric_result_hook_type) (Node *fn_expr, Datum result, Oid result_type, int32 result_typmod);
-extern PGDLLIMPORT bbf_trunc_numeric_result_hook_type bbf_trunc_numeric_result_hook;
+typedef Datum (*pltsql_trunc_numeric_result_hook_type) (Node *fn_expr, Datum result, Oid result_type, int32 result_typmod);
+extern PGDLLIMPORT pltsql_trunc_numeric_result_hook_type pltsql_trunc_numeric_result_hook;
 
 typedef bool (*check_rowcount_hook_type) (int es_processed);
 extern PGDLLEXPORT check_rowcount_hook_type check_rowcount_hook;

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -102,7 +102,7 @@ extern PGDLLEXPORT TriggerRecuresiveCheck_hook_type TriggerRecuresiveCheck_hook;
 typedef bool (*bbfViewHasInsteadofTrigger_hook_type) (Relation view, CmdType event);
 extern PGDLLIMPORT bbfViewHasInsteadofTrigger_hook_type bbfViewHasInsteadofTrigger_hook;
 
-typedef Datum (*bbf_trunc_numeric_result_hook_type) (Node *fn_expr, Datum result, Oid result_type);
+typedef Datum (*bbf_trunc_numeric_result_hook_type) (Node *fn_expr, Datum result, Oid result_type, int32 result_typmod);
 extern PGDLLIMPORT bbf_trunc_numeric_result_hook_type bbf_trunc_numeric_result_hook;
 
 typedef bool (*check_rowcount_hook_type) (int es_processed);

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -102,6 +102,9 @@ extern PGDLLEXPORT TriggerRecuresiveCheck_hook_type TriggerRecuresiveCheck_hook;
 typedef bool (*bbfViewHasInsteadofTrigger_hook_type) (Relation view, CmdType event);
 extern PGDLLIMPORT bbfViewHasInsteadofTrigger_hook_type bbfViewHasInsteadofTrigger_hook;
 
+typedef Datum (*bbf_trunc_numeric_result_hook_type) (Node *fn_expr, Datum result, Oid result_type);
+extern PGDLLIMPORT bbf_trunc_numeric_result_hook_type bbf_trunc_numeric_result_hook;
+
 typedef bool (*check_rowcount_hook_type) (int es_processed);
 extern PGDLLEXPORT check_rowcount_hook_type check_rowcount_hook;
 

--- a/src/include/nodes/nodeFuncs.h
+++ b/src/include/nodes/nodeFuncs.h
@@ -223,7 +223,7 @@ extern bool planstate_tree_walker_impl(struct PlanState *planstate,
 typedef int32 (*coalesce_typmod_hook_type) (const CoalesceExpr *cexpr);
 extern PGDLLEXPORT coalesce_typmod_hook_type coalesce_typmod_hook;
 
-typedef int32 (*resolve_numeric_typmod_from_exp_hook_type)(Plan *plan, Node *expr);
-extern PGDLLIMPORT resolve_numeric_typmod_from_exp_hook_type resolve_numeric_typmod_from_exp_hook;
+typedef int32 (*pltsql_exprTypmod_hook_type)(Plan *plan, Node *expr);
+extern PGDLLIMPORT pltsql_exprTypmod_hook_type pltsql_exprTypmod_hook;
 
 #endif							/* NODEFUNCS_H */

--- a/src/include/nodes/nodeFuncs.h
+++ b/src/include/nodes/nodeFuncs.h
@@ -14,6 +14,7 @@
 #define NODEFUNCS_H
 
 #include "nodes/parsenodes.h"
+#include "nodes/plannodes.h"
 
 struct PlanState;				/* avoid including execnodes.h too */
 
@@ -221,5 +222,8 @@ extern bool planstate_tree_walker_impl(struct PlanState *planstate,
 
 typedef int32 (*coalesce_typmod_hook_type) (const CoalesceExpr *cexpr);
 extern PGDLLEXPORT coalesce_typmod_hook_type coalesce_typmod_hook;
+
+typedef int32 (*resolve_numeric_typmod_from_exp_hook_type)(Plan *plan, Node *expr);
+extern PGDLLEXPORT resolve_numeric_typmod_from_exp_hook_type resolve_numeric_typmod_from_exp_hook;
 
 #endif							/* NODEFUNCS_H */

--- a/src/include/nodes/nodeFuncs.h
+++ b/src/include/nodes/nodeFuncs.h
@@ -224,6 +224,6 @@ typedef int32 (*coalesce_typmod_hook_type) (const CoalesceExpr *cexpr);
 extern PGDLLEXPORT coalesce_typmod_hook_type coalesce_typmod_hook;
 
 typedef int32 (*resolve_numeric_typmod_from_exp_hook_type)(Plan *plan, Node *expr);
-extern PGDLLEXPORT resolve_numeric_typmod_from_exp_hook_type resolve_numeric_typmod_from_exp_hook;
+extern PGDLLIMPORT resolve_numeric_typmod_from_exp_hook_type resolve_numeric_typmod_from_exp_hook;
 
 #endif							/* NODEFUNCS_H */


### PR DESCRIPTION
### Description
For Babelfish, the expected behaviour should be for every arithmetic computation which results in numeric datatype, the result should be truncated to the correct scale. To get this behaviour added hooks at following places to truncate the result value.
- evaluate_expr() - All the arithmetic computations that result in constant value, happens here. So added a hook to truncate the result after every such arithmetic computation.
- ExecInterpExpr() - All the arithmetic computations other than mentioned above, happens here. So added a hook to truncate the result after every such arithmetic computation.
- finalize_aggregate() - For aggregate functions, the final result is computed here, so added a hook to truncate the result for aggregate functions.

Also, for some nodes such as `T_OpExpr, T_DistinctExpr, T_CoerceViaIO` the result_typmod was directly hardcoded as `-1` in PostgreSQL, Added hook `pltsql_exprTypmod_hook` to compute the typmod of the expression and passed those instead of `-1` to avoid losing typmod information. Also, added `pltsql_exprTypmod_hook` to compute expression typmod for expressions whose typmod is not computed by `exprTypmod`.

Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3521
Cherry-picked from: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/529

### Issues Resolved
BABEL-5467
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
