### PR TITLE
[BABEL] Fix object resolution inside pltsql routines

### DIFF
--- a/src/backend/catalog/namespace.c
+++ b/src/backend/catalog/namespace.c
@@ -206,6 +206,7 @@ char *SYS_NAMESPACE_NAME = "sys";
 relname_lookup_hook_type relname_lookup_hook = NULL;
 match_pltsql_func_call_hook_type match_pltsql_func_call_hook = NULL;
 remove_db_name_in_schema_hook_type remove_db_name_in_schema_hook = NULL;
+is_bbf_tds_connection_hook_type is_bbf_tds_connection_hook = NULL;
 
 
 /* Local functions */
@@ -3519,8 +3520,7 @@ GetOverrideSearchPath(MemoryContext context)
 			result->addTemp = true;
 		else
 		{
-			/* sys comes before pg_catalog when sql_dialect is tsql */
-			if (sql_dialect != SQL_DIALECT_TSQL)
+			if (!(is_bbf_tds_connection_hook && !is_bbf_tds_connection_hook() && sql_dialect == SQL_DIALECT_TSQL))
 				Assert(linitial_oid(schemas) == PG_CATALOG_NAMESPACE);
 			result->addCatalog = true;
 		}
@@ -3587,8 +3587,7 @@ OverrideSearchPathMatchesCurrent(OverrideSearchPath *path)
 	/* If path->addCatalog, next item should be pg_catalog. */
 	if (path->addCatalog)
 	{
-		/* If tsql dialect, next item should be sys */
-		if (sql_dialect == SQL_DIALECT_TSQL)
+		if (is_bbf_tds_connection_hook && !is_bbf_tds_connection_hook() && sql_dialect == SQL_DIALECT_TSQL)
 		{
 			if (lc && lfirst_oid(lc) == get_namespace_oid(SYS_NAMESPACE_NAME, true))
 				lc = lnext(activeSearchPath, lc);
@@ -4006,11 +4005,7 @@ recomputeNamespacePath(void)
 	if (!list_member_oid(oidlist, PG_CATALOG_NAMESPACE))
 		oidlist = lcons_oid(PG_CATALOG_NAMESPACE, oidlist);
 
-	/*
-	 * When sql_dialect is tsql, schema sys is used for catalog instead of
-	 * pg_catalog. So, add it to search_path ahead of pg_catalog.
-	 */
-	if (sql_dialect == SQL_DIALECT_TSQL)
+	if (is_bbf_tds_connection_hook && !is_bbf_tds_connection_hook() && sql_dialect == SQL_DIALECT_TSQL)
 	{
 		Oid sys_oid = get_namespace_oid(SYS_NAMESPACE_NAME, true);
 		if (!list_member_oid(oidlist, sys_oid))
@@ -4455,8 +4450,8 @@ check_search_path(char **newval, void **extra, GucSource source)
 	List	   *namelist;
 
 	/* quick exit for babelfish when setting search path in fmgr_security_definer */
-	if (sql_dialect == SQL_DIALECT_TSQL && set_local_schema_for_func_hook
-		&& pltsql_check_search_path == false)
+	if (sql_dialect == SQL_DIALECT_TSQL && pltsql_check_search_path == false &&
+		is_bbf_tds_connection_hook && is_bbf_tds_connection_hook())
 	{
 		pltsql_check_search_path = true;
 		return true;
@@ -4508,6 +4503,14 @@ assign_search_path(const char *newval, void *extra)
 void
 assign_sql_dialect(int newval, void *extra)
 {
+	/*
+	 * We only append sys to search path implictly for non tds connection
+	 * to babelfish database so no need to invalidate search path or its
+	 * cache for tds connections
+	 */
+	if (is_bbf_tds_connection_hook && is_bbf_tds_connection_hook())
+		return;
+
 	baseSearchPathValid = false;
 }
 

--- a/src/backend/utils/fmgr/fmgr.c
+++ b/src/backend/utils/fmgr/fmgr.c
@@ -47,7 +47,6 @@ PGDLLIMPORT fmgr_hook_type fmgr_hook = NULL;
 PGDLLIMPORT non_tsql_proc_entry_hook_type non_tsql_proc_entry_hook = NULL;
 PGDLLIMPORT get_func_language_oids_hook_type get_func_language_oids_hook = NULL;
 PGDLLIMPORT pgstat_function_wrapper_hook_type pgstat_function_wrapper_hook = NULL;
-set_local_schema_for_func_hook_type set_local_schema_for_func_hook = NULL;
 bool pltsql_check_search_path = true;
 
 /*
@@ -662,7 +661,6 @@ struct fmgr_security_definer_cache
 	Datum		arg;			/* passthrough argument for plugin modules */
 	Oid         pronamespace;
 	char 		prokind;
-	char 		*prosearchpath;
 	Oid			prolang;
 	Oid         sys_nspoid;
 };
@@ -697,7 +695,6 @@ fmgr_security_definer(PG_FUNCTION_ARGS)
 	int			non_tsql_proc_count = 0;
 	void	   *newextra = NULL;
 	char 	   *cacheTupleProcname = NULL;
-	int 	    pltsql_save_nestlevel;
 
 	if (get_func_language_oids_hook)
 		get_func_language_oids_hook(&pltsql_lang_oid, &pltsql_validator_oid);
@@ -740,19 +737,6 @@ fmgr_security_definer(PG_FUNCTION_ARGS)
 		fcache->prolang = procedureStruct->prolang;
 		fcache->pronamespace = procedureStruct->pronamespace;
 		fcache->sys_nspoid = InvalidOid;
-		if((set_sql_dialect && (fcache->prolang == pltsql_lang_oid || fcache->prolang == pltsql_validator_oid))
-			&& strcmp(format_type_be(procedureStruct->prorettype), "trigger") != 0
-			&& fcache->prokind == PROKIND_FUNCTION)
-		{
-			char *new_search_path = NULL;
-			new_search_path = (*set_local_schema_for_func_hook)(fcache->pronamespace);
-			if(new_search_path)
-			{
-				oldcxt = MemoryContextSwitchTo(fcinfo->flinfo->fn_mcxt);
-				fcache->prosearchpath = pstrdup(new_search_path);
-				MemoryContextSwitchTo(oldcxt);
-			}
-		}
 
 		datum = SysCacheGetAttr(PROCOID, tuple, Anum_pg_proc_proconfig,
 								&isnull);
@@ -857,16 +841,6 @@ fmgr_security_definer(PG_FUNCTION_ARGS)
 			pfree(cacheTupleProcname);
 		}
 
-		if (fcache->prosearchpath)
-		{
-			pltsql_save_nestlevel = NewGUCNestLevel();
-			pltsql_check_search_path = false;
-			(void) set_config_option("search_path", fcache->prosearchpath,
-									PGC_USERSET, PGC_S_SESSION,
-									GUC_ACTION_SAVE, true, 0, false);
-			pltsql_check_search_path = true;
-		}
-
 		result = FunctionCallInvoke(fcinfo);
 
 		/*
@@ -906,19 +880,12 @@ fmgr_security_definer(PG_FUNCTION_ARGS)
 			assign_sql_dialect(sql_dialect_value_old, newextra);
 		}
 
-		if (fcache->prosearchpath)
-			pltsql_check_search_path = true;
-		
 		PG_RE_THROW();
 	}
 	PG_END_TRY();
 
 	fcinfo->flinfo = save_flinfo;
 
-	if (fcache->prosearchpath)
-	{
-		AtEOXact_GUC(true, pltsql_save_nestlevel);
-	}
 	if (fcache->proconfig)
 		AtEOXact_GUC(true, save_nestlevel);
 	if (set_sql_dialect)

--- a/src/include/catalog/namespace.h
+++ b/src/include/catalog/namespace.h
@@ -92,6 +92,9 @@ extern PGDLLEXPORT match_pltsql_func_call_hook_type match_pltsql_func_call_hook;
 typedef const char * (*remove_db_name_in_schema_hook_type) (const char *schema_name, const char *object_type);
 extern PGDLLEXPORT remove_db_name_in_schema_hook_type remove_db_name_in_schema_hook;
 
+typedef bool (*is_bbf_tds_connection_hook_type) ();
+extern PGDLLEXPORT is_bbf_tds_connection_hook_type is_bbf_tds_connection_hook;
+
 #define RangeVarGetRelid(relation, lockmode, missing_ok) \
 	RangeVarGetRelidExtended(relation, lockmode, \
 							 (missing_ok) ? RVR_MISSING_OK : 0, NULL, NULL)

--- a/src/include/fmgr.h
+++ b/src/include/fmgr.h
@@ -797,13 +797,10 @@ typedef void (*non_tsql_proc_entry_hook_type) (int, int);
 
 typedef void (*get_func_language_oids_hook_type)(Oid *, Oid *);
 
-typedef char *(*set_local_schema_for_func_hook_type) (Oid proc_nsp_oid);
-
 extern PGDLLIMPORT needs_fmgr_hook_type needs_fmgr_hook;
 extern PGDLLIMPORT fmgr_hook_type fmgr_hook;
 extern PGDLLEXPORT non_tsql_proc_entry_hook_type non_tsql_proc_entry_hook;
 extern PGDLLEXPORT get_func_language_oids_hook_type get_func_language_oids_hook;
-extern PGDLLEXPORT set_local_schema_for_func_hook_type set_local_schema_for_func_hook;
 extern bool pltsql_check_search_path;
 
 #define FmgrHookIsNeeded(fn_oid)							\


### PR DESCRIPTION
### Description

Remove search path handling for pltsql functions in fmgr.c.
This will now be handled in extension code.

Also we were implicitly appending sys schema to search path
when dialect was TSQL but now we ensure search path will 
always contain sys for TDS connections.
So to help performance, make implicit appending of sys to
search path logic work only for non TDS connections to 
babelfish_db.

#### Cherry Picked From https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/517

#### Engine PR https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/540
#### Extensions PR https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3535

### Issues Resolved

[BABEL-5448]

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
