### PR TITLE
Fix Improper Plan Invalidation for Fkey Integrity check queries

### DIFF
--- a/src/backend/utils/adt/ri_triggers.c
+++ b/src/backend/utils/adt/ri_triggers.c
@@ -263,6 +263,10 @@ static void ri_ReportViolation(const RI_ConstraintInfo *riinfo,
 							   int queryno, bool partgone) pg_attribute_noreturn();
 
 
+
+/* pltsql Hook to truncate result to correct scale, when resulttype is numeric */
+ri_FetchPreparedPlan_hook_type ri_FetchPreparedPlan_hook = NULL;
+
 /*
  * RI_FKey_check -
  *
@@ -2776,7 +2780,7 @@ ri_FetchPreparedPlan(RI_QueryKey *key)
 	 * locked both FK and PK rels.
 	 */
 	plan = entry->plan;
-	if (plan && SPI_plan_is_valid(plan))
+	if (plan && SPI_plan_is_valid(plan) && ri_FetchPreparedPlan_hook && (*ri_FetchPreparedPlan_hook)(plan))
 		return plan;
 
 	/*

--- a/src/backend/utils/adt/ri_triggers.c
+++ b/src/backend/utils/adt/ri_triggers.c
@@ -2780,7 +2780,7 @@ ri_FetchPreparedPlan(RI_QueryKey *key)
 	 * locked both FK and PK rels.
 	 */
 	plan = entry->plan;
-	if (plan && SPI_plan_is_valid(plan) && ri_FetchPreparedPlan_hook && (*ri_FetchPreparedPlan_hook)(plan))
+	if (plan && SPI_plan_is_valid(plan) && (!ri_FetchPreparedPlan_hook || (*ri_FetchPreparedPlan_hook)(plan)))
 		return plan;
 
 	/*

--- a/src/backend/utils/adt/ri_triggers.c
+++ b/src/backend/utils/adt/ri_triggers.c
@@ -265,7 +265,7 @@ static void ri_ReportViolation(const RI_ConstraintInfo *riinfo,
 
 
 /* pltsql Hook to truncate result to correct scale, when resulttype is numeric */
-ri_FetchPreparedPlan_hook_type ri_FetchPreparedPlan_hook = NULL;
+validateCachedPlanSearchPath_hook_type validateCachedPlanSearchPath_hook = NULL;
 
 /*
  * RI_FKey_check -
@@ -2780,7 +2780,7 @@ ri_FetchPreparedPlan(RI_QueryKey *key)
 	 * locked both FK and PK rels.
 	 */
 	plan = entry->plan;
-	if (plan && SPI_plan_is_valid(plan) && (!ri_FetchPreparedPlan_hook || (*ri_FetchPreparedPlan_hook)(plan)))
+	if (plan && SPI_plan_is_valid(plan) && (!validateCachedPlanSearchPath_hook || (*validateCachedPlanSearchPath_hook)(plan)))
 		return plan;
 
 	/*

--- a/src/backend/utils/adt/ri_triggers.c
+++ b/src/backend/utils/adt/ri_triggers.c
@@ -54,7 +54,6 @@
 #include "utils/ruleutils.h"
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
-#include "utils/guc_hooks.h"
 
 /*
  * Local definitions
@@ -99,27 +98,29 @@
 #define RUN_AS_PSQL(qplan)  																				\
 do																											\
 {																											\
-	if (sql_dialect == SQL_DIALECT_TSQL)																	\
-	{																										\
-		int sql_dialect_old = sql_dialect;																	\
-		void *newextra = NULL;																				\
-		sql_dialect = SQL_DIALECT_PG;																		\
-		assign_sql_dialect(sql_dialect, newextra);															\
-		PG_TRY();																							\
-		{																									\
-			qplan;																							\
-		}																									\
-		PG_FINALLY();																						\
-		{																									\
-			sql_dialect = sql_dialect_old;																	\
-			assign_sql_dialect(sql_dialect, newextra);														\
-		}																									\
-		PG_END_TRY();																						\
-	}																										\
-	else																									\
+	bool reset_dialect = (sql_dialect == SQL_DIALECT_TSQL);                                         \
+	if (reset_dialect)																						\
+		set_config_option("babelfishpg_tsql.sql_dialect", "postgres",										\
+			GUC_CONTEXT_CONFIG,						\
+			PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);												\
+																											\
+	PG_TRY();																								\
 	{																										\
 		qplan;																								\
 	}																										\
+	PG_CATCH();																								\
+	{																										\
+		if (reset_dialect)																					\
+			set_config_option("babelfishpg_tsql.sql_dialect", "tsql",										\
+							GUC_CONTEXT_CONFIG,		\
+							PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);								\
+		PG_RE_THROW();																						\
+	}																										\
+	PG_END_TRY();																							\
+	if (reset_dialect)																						\
+		set_config_option("babelfishpg_tsql.sql_dialect", "tsql",											\
+						GUC_CONTEXT_CONFIG,			\
+						PGC_S_SESSION, GUC_ACTION_SAVE, true, 0, false);									\
 } while (0)
 
 
@@ -432,11 +433,11 @@ RI_FKey_check(TriggerData *trigdata)
 	 * referenced side.  The reason is that our snapshot must be fresh in
 	 * order for the hack in find_inheritance_children() to work.
 	 */
-	RUN_AS_PSQL(ri_PerformCheck(riinfo, &qkey, qplan,
+	ri_PerformCheck(riinfo, &qkey, qplan,
 					fk_rel, pk_rel,
 					NULL, newslot,
 					pk_rel->rd_rel->relkind == RELKIND_PARTITIONED_TABLE,
-					SPI_OK_SELECT));
+					SPI_OK_SELECT);
 
 	if (SPI_finish() != SPI_OK_FINISH)
 		elog(ERROR, "SPI_finish failed");
@@ -559,11 +560,11 @@ ri_Check_Pk_Match(Relation pk_rel, Relation fk_rel,
 	/*
 	 * We have a plan now. Run it.
 	 */
-	RUN_AS_PSQL(result = ri_PerformCheck(riinfo, &qkey, qplan,
+	result = ri_PerformCheck(riinfo, &qkey, qplan,
 							 fk_rel, pk_rel,
 							 oldslot, NULL,
 							 true,	/* treat like update */
-							 SPI_OK_SELECT));
+							 SPI_OK_SELECT);
 
 	if (SPI_finish() != SPI_OK_FINISH)
 		elog(ERROR, "SPI_finish failed");
@@ -751,11 +752,11 @@ ri_restrict(TriggerData *trigdata, bool is_no_action)
 	/*
 	 * We have a plan now. Run it to check for existing references.
 	 */
-	RUN_AS_PSQL(ri_PerformCheck(riinfo, &qkey, qplan,
+	ri_PerformCheck(riinfo, &qkey, qplan,
 					fk_rel, pk_rel,
 					oldslot, NULL,
 					true,		/* must detect new rows */
-					SPI_OK_SELECT));
+					SPI_OK_SELECT);
 
 	if (SPI_finish() != SPI_OK_FINISH)
 		elog(ERROR, "SPI_finish failed");
@@ -857,11 +858,11 @@ RI_FKey_cascade_del(PG_FUNCTION_ARGS)
 	 * We have a plan now. Build up the arguments from the key values in the
 	 * deleted PK tuple and delete the referencing rows
 	 */
-	RUN_AS_PSQL(ri_PerformCheck(riinfo, &qkey, qplan,
+	ri_PerformCheck(riinfo, &qkey, qplan,
 					fk_rel, pk_rel,
 					oldslot, NULL,
 					true,		/* must detect new rows */
-					SPI_OK_DELETE));
+					SPI_OK_DELETE);
 
 	if (SPI_finish() != SPI_OK_FINISH)
 		elog(ERROR, "SPI_finish failed");
@@ -978,11 +979,11 @@ RI_FKey_cascade_upd(PG_FUNCTION_ARGS)
 	/*
 	 * We have a plan now. Run it to update the existing references.
 	 */
-	RUN_AS_PSQL(ri_PerformCheck(riinfo, &qkey, qplan,
+	ri_PerformCheck(riinfo, &qkey, qplan,
 					fk_rel, pk_rel,
 					oldslot, newslot,
 					true,		/* must detect new rows */
-					SPI_OK_UPDATE));
+					SPI_OK_UPDATE);
 
 	if (SPI_finish() != SPI_OK_FINISH)
 		elog(ERROR, "SPI_finish failed");
@@ -1210,11 +1211,11 @@ ri_set(TriggerData *trigdata, bool is_set_null, int tgkind)
 	/*
 	 * We have a plan now. Run it to update the existing references.
 	 */
-	RUN_AS_PSQL(ri_PerformCheck(riinfo, &qkey, qplan,
+	ri_PerformCheck(riinfo, &qkey, qplan,
 					fk_rel, pk_rel,
 					oldslot, NULL,
 					true,		/* must detect new rows */
-					SPI_OK_UPDATE));
+					SPI_OK_UPDATE);
 
 	if (SPI_finish() != SPI_OK_FINISH)
 		elog(ERROR, "SPI_finish failed");
@@ -1605,11 +1606,11 @@ RI_Initial_Check(Trigger *trigger, Relation fk_rel, Relation pk_rel)
 	 * register the snapshot, because SPI_execute_snapshot will see to it. We
 	 * need at most one tuple returned, so pass limit = 1.
 	 */
-	RUN_AS_PSQL(spi_result = SPI_execute_snapshot(qplan,
+	spi_result = SPI_execute_snapshot(qplan,
 									  NULL, NULL,
 									  GetLatestSnapshot(),
 									  InvalidSnapshot,
-									  true, false, 1));
+									  true, false, 1);
 
 	/* Check result */
 	if (spi_result != SPI_OK_SELECT)
@@ -1832,7 +1833,7 @@ RI_PartitionRemove_Check(Trigger *trigger, Relation fk_rel, Relation pk_rel)
 	 * Generate the plan.  We don't need to cache it, and there are no
 	 * arguments to the plan.
 	 */
-	RUN_AS_PSQL(qplan = SPI_prepare(querybuf.data, 0, NULL));
+	qplan = SPI_prepare(querybuf.data, 0, NULL);
 
 	if (qplan == NULL)
 		elog(ERROR, "SPI_prepare returned %s for %s",
@@ -1845,11 +1846,11 @@ RI_PartitionRemove_Check(Trigger *trigger, Relation fk_rel, Relation pk_rel)
 	 * register the snapshot, because SPI_execute_snapshot will see to it. We
 	 * need at most one tuple returned, so pass limit = 1.
 	 */
-	RUN_AS_PSQL(spi_result = SPI_execute_snapshot(qplan,
+	spi_result = SPI_execute_snapshot(qplan,
 									  NULL, NULL,
 									  GetLatestSnapshot(),
 									  InvalidSnapshot,
-									  true, false, 1));
+									  true, false, 1);
 
 	/* Check result */
 	if (spi_result != SPI_OK_SELECT)

--- a/src/include/executor/spi.h
+++ b/src/include/executor/spi.h
@@ -214,4 +214,7 @@ extern bool SPI_inside_nonatomic_context(void);
 
 extern PGDLLEXPORT void SPI_setCurrentInternalTxnMode(bool mode);
 extern int  SPI_get_depth(void);
+
+typedef bool (*ri_FetchPreparedPlan_hook_type) (SPIPlanPtr plan);
+extern PGDLLIMPORT ri_FetchPreparedPlan_hook_type ri_FetchPreparedPlan_hook;
 #endif							/* SPI_H */

--- a/src/include/executor/spi.h
+++ b/src/include/executor/spi.h
@@ -215,6 +215,6 @@ extern bool SPI_inside_nonatomic_context(void);
 extern PGDLLEXPORT void SPI_setCurrentInternalTxnMode(bool mode);
 extern int  SPI_get_depth(void);
 
-typedef bool (*ri_FetchPreparedPlan_hook_type) (SPIPlanPtr plan);
-extern PGDLLIMPORT ri_FetchPreparedPlan_hook_type ri_FetchPreparedPlan_hook;
+typedef bool (*validateCachedPlanSearchPath_hook_type) (SPIPlanPtr plan);
+extern PGDLLIMPORT validateCachedPlanSearchPath_hook_type validateCachedPlanSearchPath_hook;
 #endif							/* SPI_H */


### PR DESCRIPTION
### Description
Introduce a hook , that checks whether the hashed plan for Referential integrity queries is valid or not , as in case for babelfish there can be change in search path due to for example table variables etc , if the search path doesn't match we discard the plan . And replan this query.
 
### Issues Resolved
BABEL-5270

Extension PR https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3536
Signed-off-by: Nirmit Shah <nirmisha@amazon.com>

### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
