### PR TITLE
Add Dialect check for ALTER TABLE ENABLE/DISABLE TRIG ALL

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -2789,8 +2789,14 @@ alter_table_cmd:
 			| ENABLE_P TRIGGER ALL
 				{
 					AlterTableCmd *n = makeNode(AlterTableCmd);
-
-					n->subtype = AT_EnableTrigAll;
+					if(sql_dialect == SQL_DIALECT_TSQL)
+					{
+						n->subtype = AT_EnableTrigUser;
+					}
+					else
+					{
+						n->subtype = AT_EnableTrigAll;
+					}
 					$$ = (Node *) n;
 				}
 			/* ALTER TABLE <name> ENABLE TRIGGER USER */
@@ -2815,7 +2821,14 @@ alter_table_cmd:
 				{
 					AlterTableCmd *n = makeNode(AlterTableCmd);
 
-					n->subtype = AT_DisableTrigAll;
+					if(sql_dialect == SQL_DIALECT_TSQL)
+					{
+						n->subtype = AT_DisableTrigUser;
+					}
+					else
+					{
+						n->subtype = AT_DisableTrigAll;
+					}
 					$$ = (Node *) n;
 				}
 			/* ALTER TABLE <name> DISABLE TRIGGER USER */


### PR DESCRIPTION
### Description

To Disable FKEY Action Triggers we need superuser privileges [code reference](https://github.com/postgres/postgres/blob/master/src/backend/commands/trigger.c#L1773-L1777) , But for tsql we only need to disable user defined triggers , You can see the difference between ALL vs USER Enable/Disable  [here](https://github.com/postgres/postgres/blob/master/src/backend/commands/tablecmds.c#L5542-L5564) . We should specify the  `AT_[Disable/Enable]TrigUser` command for  `ENABLE/DISABLE TRIGGER ALL` Syntax instead of `AT_[Disable/Enable]TrigAll` 
Extension PR https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3547

### Issues Resolved
BABEL-5645
Signed-off-by: Nirmit Shah <nirmisha@amazon.com>
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
