### PR TITLE
Added createoralter flag to ViewStmt node to recognize the ALTER VIEW statement

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -11245,7 +11245,7 @@ ViewStmt: CREATE OptTemp VIEW qualified_name opt_column_list opt_reloptions
 					n->replace = false;
 					n->options = $6;
 					n->withCheckOption = $9;
-					n->createoralter = false;
+					n->createOrAlter = false;
 					$$ = (Node *) n;
 				}
 		| CREATE OR REPLACE OptTemp VIEW qualified_name opt_column_list opt_reloptions
@@ -11260,7 +11260,7 @@ ViewStmt: CREATE OptTemp VIEW qualified_name opt_column_list opt_reloptions
 					n->replace = true;
 					n->options = $8;
 					n->withCheckOption = $11;
-					n->createoralter = false;
+					n->createOrAlter = false;
 					$$ = (Node *) n;
 				}
 		| CREATE OptTemp RECURSIVE VIEW qualified_name '(' columnList ')' opt_reloptions
@@ -11280,7 +11280,7 @@ ViewStmt: CREATE OptTemp VIEW qualified_name opt_column_list opt_reloptions
 								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 								 errmsg("WITH CHECK OPTION not supported on recursive views"),
 								 parser_errposition(@12)));
-					n->createoralter = false;
+					n->createOrAlter = false;
 					$$ = (Node *) n;
 				}
 		| CREATE OR REPLACE OptTemp RECURSIVE VIEW qualified_name '(' columnList ')' opt_reloptions
@@ -11300,7 +11300,7 @@ ViewStmt: CREATE OptTemp VIEW qualified_name opt_column_list opt_reloptions
 								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 								 errmsg("WITH CHECK OPTION not supported on recursive views"),
 								 parser_errposition(@14)));
-					n->createoralter = false;
+					n->createOrAlter = false;
 					$$ = (Node *) n;
 				}
 		;

--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -11245,6 +11245,7 @@ ViewStmt: CREATE OptTemp VIEW qualified_name opt_column_list opt_reloptions
 					n->replace = false;
 					n->options = $6;
 					n->withCheckOption = $9;
+					n->createoralter = false;
 					$$ = (Node *) n;
 				}
 		| CREATE OR REPLACE OptTemp VIEW qualified_name opt_column_list opt_reloptions
@@ -11259,6 +11260,7 @@ ViewStmt: CREATE OptTemp VIEW qualified_name opt_column_list opt_reloptions
 					n->replace = true;
 					n->options = $8;
 					n->withCheckOption = $11;
+					n->createoralter = false;
 					$$ = (Node *) n;
 				}
 		| CREATE OptTemp RECURSIVE VIEW qualified_name '(' columnList ')' opt_reloptions
@@ -11278,6 +11280,7 @@ ViewStmt: CREATE OptTemp VIEW qualified_name opt_column_list opt_reloptions
 								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 								 errmsg("WITH CHECK OPTION not supported on recursive views"),
 								 parser_errposition(@12)));
+					n->createoralter = false;
 					$$ = (Node *) n;
 				}
 		| CREATE OR REPLACE OptTemp RECURSIVE VIEW qualified_name '(' columnList ')' opt_reloptions
@@ -11297,6 +11300,7 @@ ViewStmt: CREATE OptTemp VIEW qualified_name opt_column_list opt_reloptions
 								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 								 errmsg("WITH CHECK OPTION not supported on recursive views"),
 								 parser_errposition(@14)));
+					n->createoralter = false;
 					$$ = (Node *) n;
 				}
 		;

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -3782,6 +3782,7 @@ typedef struct ViewStmt
 	bool		replace;		/* replace an existing view? */
 	List	   *options;		/* options from WITH clause */
 	ViewCheckOption withCheckOption;	/* WITH CHECK OPTION */
+	bool        createoralter;   /* CREATE OR ALTER/ ALTER VIEW stmt?*/
 } ViewStmt;
 
 /* ----------------------

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -3782,7 +3782,9 @@ typedef struct ViewStmt
 	bool		replace;		/* replace an existing view? */
 	List	   *options;		/* options from WITH clause */
 	ViewCheckOption withCheckOption;	/* WITH CHECK OPTION */
-	bool        createoralter;   /* CREATE OR ALTER/ ALTER VIEW stmt?*/
+	bool        createOrAlter;  /* is query 'create view' or 'create or alter view' or 'alter view' */
+                                /* flag is set in gram-tsql-rule.y and gram.y */
+
 } ViewStmt;
 
 /* ----------------------


### PR DESCRIPTION
### Description

Added the `createOrAlter` flag in the ViewStmt structure to recognize view operations (`Alter / Create or Alter View`) in T-SQL.

We are using PostgreSQL's existing ViewStmt node, which is shared between PostgreSQL's `CREATE VIEW` and T-SQL's `ALTER VIEW/CREATE OR ALTER VIEW` operations. To properly distinguish between these operations and prevent `CREATE VIEW` from being processed during `ALTER VIEW`, we use the `createOrAlter` flag.
 
Since both `CREATE VIEW` and `CREATE OR ALTER VIEW` initially set replace to false, we use the 'createOrAlter' flag to differentiate between them and implement the correct behavior when a view already exists.

Extension PR - https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3570

Signed off by: Rahul Parande rparande@amazon.com

### Issues Resolved

JIRA - BABEL-2017
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
