### PR TITLE
Support for TSQL UNPIVOT Operator

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -92,6 +92,9 @@ pre_transform_setop_sort_clause_hook_type pre_transform_setop_sort_clause_hook =
 /* Hook to transform TSQL pivot clause in select stmt */
 transform_pivot_clause_hook_type transform_pivot_clause_hook = NULL;
 
+/* Hook to transform TSQL unpivot clauses in select stmt */
+transform_unpivot_clause_hook_type transform_unpivot_clause_hook = NULL;
+
 static Query *transformOptionalSelectInto(ParseState *pstate, Node *parseTree);
 static Query *transformDeleteStmt(ParseState *pstate, DeleteStmt *stmt);
 static Query *transformInsertStmt(ParseState *pstate, InsertStmt *stmt);
@@ -1438,6 +1441,12 @@ transformSelectStmt(ParseState *pstate, SelectStmt *stmt)
 	ListCell   *l;
 
 	qry->commandType = CMD_SELECT;
+
+	/* Unpack and process TSQL UNPIVOT nodes in stmt->fromClause, if present */
+	if(transform_unpivot_clause_hook)
+	{
+		(*transform_unpivot_clause_hook)(pstate, stmt);
+	}
 
 	/* process the WITH clause independently of all else */
 	if (stmt->withClause && ( sql_dialect == SQL_DIALECT_PG || transform_pivot_clause_hook == NULL || !stmt->isPivot))

--- a/src/include/parser/analyze.h
+++ b/src/include/parser/analyze.h
@@ -68,6 +68,10 @@ extern PGDLLEXPORT pre_transform_setop_sort_clause_hook_type pre_transform_setop
 typedef void (*transform_pivot_clause_hook_type)(ParseState *pstate, SelectStmt *stmt);
 extern PGDLLEXPORT transform_pivot_clause_hook_type transform_pivot_clause_hook;
 
+/* Hook for transform unpivot clause in tsql select stmt */
+typedef void (*transform_unpivot_clause_hook_type)(ParseState *pstate, SelectStmt *stmt);
+extern PGDLLEXPORT transform_unpivot_clause_hook_type transform_unpivot_clause_hook;
+
 extern Query *parse_analyze_fixedparams(RawStmt *parseTree, const char *sourceText,
 										const Oid *paramTypes, int numParams, QueryEnvironment *queryEnv);
 extern Query *parse_analyze(RawStmt *parseTree, const char *sourceText,


### PR DESCRIPTION
### Description

*Cherry-picked from 5_X_DEV__PG_17_X*

This PR implements TSQL UNPIVOT operator support in Babelfish by transforming it into equivalent PostgreSQL CROSS JOIN LATERAL operations. Currently, Babelfish does not support UNPIVOT operations. With this change, users can now use TSQL UNPIVOT syntax to transform wide-format data into long format.

Changes:
On the engine side, in the parse analyze stage, a hook `transform_unpivot_clause_hook` is introduced, which points to the analyze hook `transform_unpivot_clause` implemented in babelfish extensions.
 
### Issues Resolved

BABEL-4307
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
