### PR TITLE
Added BBF hook to adjust numeric result to correct scale (#529)

### DIFF
--- a/src/backend/executor/execExprInterp.c
+++ b/src/backend/executor/execExprInterp.c
@@ -101,6 +101,9 @@
  */
 #if defined(EEO_USE_COMPUTED_GOTO)
 
+/* Hook to truncate result to correct scale, when resulttype is numeric */
+adjust_numeric_result_hook_type adjust_numeric_result_hook = NULL;
+
 /* struct for jump target -> opcode lookup table */
 typedef struct ExprEvalOpLookup
 {
@@ -735,6 +738,14 @@ ExecInterpExpr(ExprState *state, ExprContext *econtext, bool *isnull)
 			*op->resvalue = d;
 			*op->resnull = fcinfo->isnull;
 
+			if (adjust_numeric_result_hook && fcinfo->flinfo != NULL)
+			{
+				if (state->parent != NULL)
+					*op->resvalue = adjust_numeric_result_hook(state->parent->plan, fcinfo->flinfo->fn_expr, d, *op->resnull, InvalidOid, -1);
+				else
+					*op->resvalue = adjust_numeric_result_hook(NULL, fcinfo->flinfo->fn_expr, d, *op->resnull, InvalidOid, -1);
+			}
+
 			EEO_NEXT();
 		}
 
@@ -758,6 +769,15 @@ ExecInterpExpr(ExprState *state, ExprContext *econtext, bool *isnull)
 			d = op->d.func.fn_addr(fcinfo);
 			*op->resvalue = d;
 			*op->resnull = fcinfo->isnull;
+
+			if (adjust_numeric_result_hook && fcinfo->flinfo != NULL)
+			{
+				if (state->parent != NULL)
+					*op->resvalue = adjust_numeric_result_hook(state->parent->plan, fcinfo->flinfo->fn_expr, d, *op->resnull, InvalidOid, -1);
+				else
+					*op->resvalue = adjust_numeric_result_hook(NULL, fcinfo->flinfo->fn_expr, d, *op->resnull, InvalidOid, -1);
+			}
+				
 
 	strictfail:
 			EEO_NEXT();

--- a/src/backend/executor/execTuples.c
+++ b/src/backend/executor/execTuples.c
@@ -85,6 +85,8 @@ const TupleTableSlotOps TTSOpsHeapTuple;
 const TupleTableSlotOps TTSOpsMinimalTuple;
 const TupleTableSlotOps TTSOpsBufferHeapTuple;
 
+/* Hook to update typmod of all the entries of a previously initialized tuple descriptor */
+ExecUpdateResultTypeTL_hook_type ExecUpdateResultTypeTL_hook = NULL;
 
 /*
  * TupleTableSlotOps implementations.
@@ -1756,6 +1758,9 @@ void
 ExecInitResultTypeTL(PlanState *planstate)
 {
 	TupleDesc	tupDesc = ExecTypeFromTL(planstate->plan->targetlist);
+
+	if (ExecUpdateResultTypeTL_hook)
+		ExecUpdateResultTypeTL_hook(planstate, tupDesc);
 
 	planstate->ps_ResultTupleDesc = tupDesc;
 }

--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -1119,6 +1119,16 @@ finalize_aggregate(AggState *aggstate,
 
 			result = FunctionCallInvoke(fcinfo);
 			*resultIsNull = fcinfo->isnull;
+			if (adjust_numeric_result_hook)
+			{
+				if (peragg->aggref != NULL)
+					result = adjust_numeric_result_hook(aggstate->ss.ps.plan, 
+														(Node *) peragg->aggref, 
+														result, 
+														*resultIsNull, 
+														peragg->aggref->aggtype, 
+														-1);
+			}
 			*resultVal = MakeExpandedObjectReadOnly(result,
 													fcinfo->isnull,
 													peragg->resulttypeLen);

--- a/src/backend/nodes/nodeFuncs.c
+++ b/src/backend/nodes/nodeFuncs.c
@@ -36,6 +36,7 @@ static bool planstate_walk_members(PlanState **planstates, int nplans,
 								   void *context);
 
 coalesce_typmod_hook_type coalesce_typmod_hook = NULL;
+exprTypmod_hook_type exprTypmod_hook = NULL;
 
 /*
  *	exprType -
@@ -509,6 +510,10 @@ exprTypmod(const Node *expr)
 		default:
 			break;
 	}
+
+	if (exprTypmod_hook)
+		return exprTypmod_hook(NULL, (Node *) expr);
+
 	return -1;
 }
 

--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -2613,6 +2613,7 @@ eval_const_expressions_mutator(Node *node,
 				List	   *args = expr->args;
 				Expr	   *simple;
 				OpExpr	   *newexpr;
+				int32       result_typmod = -1;
 
 				/*
 				 * Need to get OID of underlying function.  Okay to scribble
@@ -2620,12 +2621,15 @@ eval_const_expressions_mutator(Node *node,
 				 */
 				set_opfuncid(expr);
 
+				if (exprTypmod_hook)
+					result_typmod = exprTypmod_hook(NULL, node);
+
 				/*
 				 * Code for op/func reduction is pretty bulky, so split it out
 				 * as a separate function.
 				 */
 				simple = simplify_function(expr->opfuncid,
-										   expr->opresulttype, -1,
+										   expr->opresulttype, result_typmod,
 										   expr->opcollid,
 										   expr->inputcollid,
 										   &args,
@@ -2676,6 +2680,7 @@ eval_const_expressions_mutator(Node *node,
 				bool		has_nonconst_input = false;
 				Expr	   *simple;
 				DistinctExpr *newexpr;
+				int32       result_typmod = -1;
 
 				/*
 				 * Reduce constants in the DistinctExpr's arguments.  We know
@@ -2724,12 +2729,15 @@ eval_const_expressions_mutator(Node *node,
 					set_opfuncid((OpExpr *) expr);	/* rely on struct
 													 * equivalence */
 
+					if (exprTypmod_hook)
+						result_typmod = exprTypmod_hook(NULL, node);
+
 					/*
 					 * Code for op/func reduction is pretty bulky, so split it
 					 * out as a separate function.
 					 */
 					simple = simplify_function(expr->opfuncid,
-											   expr->opresulttype, -1,
+											   expr->opresulttype, result_typmod,
 											   expr->opcollid,
 											   expr->inputcollid,
 											   &args,
@@ -2961,6 +2969,7 @@ eval_const_expressions_mutator(Node *node,
 				Oid			intypioparam;
 				Expr	   *simple;
 				CoerceViaIO *newexpr;
+				int32       result_typmod = -1;
 
 				/* Make a List so we can use simplify_function */
 				args = list_make1(expr->arg);
@@ -3011,8 +3020,11 @@ eval_const_expressions_mutator(Node *node,
 												false,
 												true));
 
+					if (exprTypmod_hook)
+						result_typmod = exprTypmod_hook(NULL, node);
+
 					simple = simplify_function(infunc,
-											   expr->resulttype, -1,
+											   expr->resulttype, result_typmod,
 											   expr->resultcollid,
 											   InvalidOid,
 											   &args,
@@ -5109,6 +5121,9 @@ evaluate_expr(Expr *expr, Oid result_type, int32 result_typmod,
 
 	/* Release all the junk we just created */
 	FreeExecutorState(estate);
+
+	if (adjust_numeric_result_hook)
+		const_val = adjust_numeric_result_hook(NULL, (Node *) expr, const_val, const_is_null, result_type, result_typmod);
 
 	/*
 	 * Make the constant result node.

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -102,6 +102,12 @@ extern PGDLLEXPORT TriggerRecuresiveCheck_hook_type TriggerRecuresiveCheck_hook;
 typedef bool (*bbfViewHasInsteadofTrigger_hook_type) (Relation view, CmdType event);
 extern PGDLLIMPORT bbfViewHasInsteadofTrigger_hook_type bbfViewHasInsteadofTrigger_hook;
 
+typedef Datum (*adjust_numeric_result_hook_type) (Plan *plan, Node *expr, Datum result, bool result_isnull, Oid result_type, int32 result_typmod);
+extern PGDLLIMPORT adjust_numeric_result_hook_type adjust_numeric_result_hook;
+
+typedef void (*ExecUpdateResultTypeTL_hook_type) (PlanState *planstate, TupleDesc desc);
+extern PGDLLIMPORT ExecUpdateResultTypeTL_hook_type ExecUpdateResultTypeTL_hook;
+
 typedef bool (*check_rowcount_hook_type) (int es_processed);
 extern PGDLLEXPORT check_rowcount_hook_type check_rowcount_hook;
 

--- a/src/include/nodes/nodeFuncs.h
+++ b/src/include/nodes/nodeFuncs.h
@@ -14,6 +14,7 @@
 #define NODEFUNCS_H
 
 #include "nodes/parsenodes.h"
+#include "nodes/plannodes.h"
 
 struct PlanState;				/* avoid including execnodes.h too */
 
@@ -221,5 +222,8 @@ extern bool planstate_tree_walker_impl(struct PlanState *planstate,
 
 typedef int32 (*coalesce_typmod_hook_type) (const CoalesceExpr *cexpr);
 extern PGDLLEXPORT coalesce_typmod_hook_type coalesce_typmod_hook;
+
+typedef int32 (*exprTypmod_hook_type)(Plan *plan, Node *expr);
+extern PGDLLIMPORT exprTypmod_hook_type exprTypmod_hook;
 
 #endif							/* NODEFUNCS_H */


### PR DESCRIPTION
### Description

For Babelfish, the expected behaviour should be for every arithmetic computation which results in numeric datatype, the result should be adjusted(truncated/rounded) to the correct scale. To get this behaviour added hooks at following places to adjust the result value.

evaluate_expr() - All the arithmetic computations that result in constant value, happens here. So added a hook to adjust the result after every such arithmetic computation. ExecInterpExpr() - All the arithmetic computations other than mentioned above, happens here. So added a hook to adjust the result after every such arithmetic computation. finalize_aggregate() - For aggregate functions, the final result is computed here, so added a hook to adjust the result for aggregate functions. Also,

for some nodes such as T_OpExpr, T_DistinctExpr, T_CoerceViaIO the result_typmod was directly hardcoded as -1 in PostgreSQL, Added hook pltsql_exprTypmod_hook to compute the typmod of the expression and passed those instead of -1 to avoid losing typmod information. added pltsql_exprTypmod_hook to compute expression typmod for expressions whose typmod is not computed by exprTypmod. During initialisation of resulttype in function ExecInitResultTypeTL added hook ExecUpdateResultTypeTL_hook to set correct typmod of all attributes of result tuple. 

cherry-pick from https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/529

Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3611

Issues Resolved
BABEL-5467

Authored-by: rohit bhagat [rohitbgt@amazon.com](mailto:rohitbgt@amazon.com)
Signed-off-by: yashneet vinayak [yashneet@amazon.com](mailto:yashneet@amazon.com)

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
