### PR TITLE
Avoid checking permission of Babelfish temp tables on parallel worker

### DIFF
--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -62,8 +62,6 @@
 #include "utils/snapmgr.h"
 
 
-Bitmapset *tempRelids = NULL;
-
 /* Hooks for plugins to get control in ExecutorStart/Run/Finish/End */
 ExecutorStart_hook_type ExecutorStart_hook = NULL;
 ExecutorRun_hook_type ExecutorRun_hook = NULL;

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -656,6 +656,7 @@ ExecCheckOneRelPerms(RTEPermissionInfo *perminfo)
 	 * operations are not allowed for temp table in Postgres. Babelfish
 	 * can skip permission check for such use cases under parallel worker
 	 * using this hook.
+	 * Note - This hook must not be used outside of Babelfish parallel worker
 	 */
 	if (IsBabelfishParallelWorker() &&
 		ExecCheckOneRelPerms_hook &&

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -657,7 +657,8 @@ ExecCheckOneRelPerms(RTEPermissionInfo *perminfo)
 	 * are not allowed for temp table in Postgres. So give extension a
 	 * chance to skip permission check for such use cases.
 	 */
-	if (ExecCheckOneRelPerms_hook &&
+	if (IsBabelfishParallelWorker() &&
+		ExecCheckOneRelPerms_hook &&
 		(*ExecCheckOneRelPerms_hook)(perminfo))
 		return true;
 

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -658,8 +658,8 @@ ExecCheckOneRelPerms(RTEPermissionInfo *perminfo)
 	 * using this hook.
 	 * Note - This hook must not be used outside of Babelfish parallel worker
 	 */
-	if (IsBabelfishParallelWorker() &&
-		ExecCheckOneRelPerms_hook &&
+	if (ExecCheckOneRelPerms_hook &&
+		IsBabelfishParallelWorker() &&
 		(*ExecCheckOneRelPerms_hook)(perminfo))
 		return true;
 

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -72,6 +72,8 @@ ExecutorEnd_hook_type ExecutorEnd_hook = NULL;
 
 TriggerRecuresiveCheck_hook_type TriggerRecuresiveCheck_hook = NULL;
 check_rowcount_hook_type check_rowcount_hook = NULL;
+skip_ExecutorCheckPerms_hook_type skip_ExecutorCheckPerms_hook = NULL;
+
 /* Hook for plugin to get control in ExecCheckPermissions() */
 ExecutorCheckPerms_hook_type ExecutorCheckPerms_hook = NULL;
 
@@ -618,7 +620,13 @@ ExecCheckPermissions(List *rangeTable, List *rteperminfos,
 
 		Assert(OidIsValid(perminfo->relid));
 
-		if (IsBabelfishParallelWorker() && bms_is_member(perminfo->relid, tempRelids))
+		/* 
+		 * Babelfish specific logic - skip permission check for temp table
+		 * under parallel worker
+		 */
+		if (IsBabelfishParallelWorker() &&
+			skip_ExecutorCheckPerms_hook &&
+			(*skip_ExecutorCheckPerms_hook)(perminfo->relid))
 			continue;
 
 		result = ExecCheckOneRelPerms(perminfo);

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -70,7 +70,7 @@ ExecutorEnd_hook_type ExecutorEnd_hook = NULL;
 
 TriggerRecuresiveCheck_hook_type TriggerRecuresiveCheck_hook = NULL;
 check_rowcount_hook_type check_rowcount_hook = NULL;
-skip_ExecutorCheckPerms_hook_type skip_ExecutorCheckPerms_hook = NULL;
+ExecCheckOneRelPerms_hook_type ExecCheckOneRelPerms_hook = NULL;
 
 /* Hook for plugin to get control in ExecCheckPermissions() */
 ExecutorCheckPerms_hook_type ExecutorCheckPerms_hook = NULL;
@@ -86,6 +86,7 @@ static void ExecutePlan(QueryDesc *queryDesc,
 						uint64 numberTuples,
 						ScanDirection direction,
 						DestReceiver *dest);
+static bool ExecCheckOneRelPerms(RTEPermissionInfo *perminfo);
 static bool ExecCheckPermissionsModified(Oid relOid, Oid userid,
 										 Bitmapset *modifiedCols,
 										 AclMode requiredPerms);
@@ -616,16 +617,6 @@ ExecCheckPermissions(List *rangeTable, List *rteperminfos,
 		RTEPermissionInfo *perminfo = lfirst_node(RTEPermissionInfo, l);
 
 		Assert(OidIsValid(perminfo->relid));
-
-		/* 
-		 * Babelfish specific logic - skip permission check for temp table
-		 * under parallel worker
-		 */
-		if (IsBabelfishParallelWorker() &&
-			skip_ExecutorCheckPerms_hook &&
-			(*skip_ExecutorCheckPerms_hook)(perminfo->relid))
-			continue;
-
 		result = ExecCheckOneRelPerms(perminfo);
 		if (!result)
 		{
@@ -647,7 +638,7 @@ ExecCheckPermissions(List *rangeTable, List *rteperminfos,
  * ExecCheckOneRelPerms
  *		Check access permissions for a single relation.
  */
-bool
+static bool
 ExecCheckOneRelPerms(RTEPermissionInfo *perminfo)
 {
 	AclMode		requiredPerms;
@@ -658,6 +649,17 @@ ExecCheckOneRelPerms(RTEPermissionInfo *perminfo)
 
 	requiredPerms = perminfo->requiredPerms;
 	Assert(requiredPerms != 0);
+
+	/* 
+	 * Some extension may want to avoid permission check for some special
+	 * cases. For example, Babelfish temp table is implemented using ENR
+	 * which is not shared with parallel worker and parallel operations
+	 * are not allowed for temp table in Postgres. So give extension a
+	 * chance to skip permission check for such use cases.
+	 */
+	if (ExecCheckOneRelPerms_hook &&
+		(*ExecCheckOneRelPerms_hook)(perminfo))
+		return true;
 
 	/*
 	 * userid to check as: current user unless we have a setuid indication.
@@ -3055,4 +3057,13 @@ EvalPlanQualEnd(EPQState *epqstate)
 	epqstate->relsubs_rowmark = NULL;
 	epqstate->relsubs_done = NULL;
 	epqstate->relsubs_blocked = NULL;
+}
+
+/*
+ * ExecCheckOneRelPerms_wrapper - wrapper around ExecCheckOneRelPerms
+ */
+bool
+ExecCheckOneRelPerms_wrapper(RTEPermissionInfo *perminfo)
+{
+	return ExecCheckOneRelPerms(perminfo);
 }

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -651,11 +651,11 @@ ExecCheckOneRelPerms(RTEPermissionInfo *perminfo)
 	Assert(requiredPerms != 0);
 
 	/* 
-	 * Some extension may want to avoid permission check for some special
-	 * cases. For example, Babelfish temp table is implemented using ENR
-	 * which is not shared with parallel worker and parallel operations
-	 * are not allowed for temp table in Postgres. So give extension a
-	 * chance to skip permission check for such use cases.
+	 * Babelfish specific logic - Babelfish temp table is implemented
+	 * using ENR which is not shared with parallel worker and parallel
+	 * operations are not allowed for temp table in Postgres. Babelfish
+	 * can skip permission check for such use cases under parallel worker
+	 * using this hook.
 	 */
 	if (IsBabelfishParallelWorker() &&
 		ExecCheckOneRelPerms_hook &&

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -86,7 +86,6 @@ static void ExecutePlan(QueryDesc *queryDesc,
 						uint64 numberTuples,
 						ScanDirection direction,
 						DestReceiver *dest);
-static bool ExecCheckOneRelPerms(RTEPermissionInfo *perminfo);
 static bool ExecCheckPermissionsModified(Oid relOid, Oid userid,
 										 Bitmapset *modifiedCols,
 										 AclMode requiredPerms);
@@ -648,7 +647,7 @@ ExecCheckPermissions(List *rangeTable, List *rteperminfos,
  * ExecCheckOneRelPerms
  *		Check access permissions for a single relation.
  */
-static bool
+bool
 ExecCheckOneRelPerms(RTEPermissionInfo *perminfo)
 {
 	AclMode		requiredPerms;

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -62,6 +62,8 @@
 #include "utils/snapmgr.h"
 
 
+Bitmapset *tempRelids = NULL;
+
 /* Hooks for plugins to get control in ExecutorStart/Run/Finish/End */
 ExecutorStart_hook_type ExecutorStart_hook = NULL;
 ExecutorRun_hook_type ExecutorRun_hook = NULL;
@@ -615,6 +617,10 @@ ExecCheckPermissions(List *rangeTable, List *rteperminfos,
 		RTEPermissionInfo *perminfo = lfirst_node(RTEPermissionInfo, l);
 
 		Assert(OidIsValid(perminfo->relid));
+
+		if (IsBabelfishParallelWorker() && bms_is_member(perminfo->relid, tempRelids))
+			continue;
+
 		result = ExecCheckOneRelPerms(perminfo);
 		if (!result)
 		{
@@ -840,10 +846,9 @@ InitPlan(QueryDesc *queryDesc, int eflags)
 	int			i;
 
 	/*
-	 * Do permissions checks if not Babelfish parallel worker
+	 * Do permissions checks
 	 */
-	if (!IsBabelfishParallelWorker())
-		ExecCheckPermissions(rangeTable, plannedstmt->permInfos, true);
+	ExecCheckPermissions(rangeTable, plannedstmt->permInfos, true);
 
 	/*
 	 * initialize the node's execution state

--- a/src/backend/executor/execParallel.c
+++ b/src/backend/executor/execParallel.c
@@ -65,6 +65,8 @@
 #define PARALLEL_KEY_JIT_INSTRUMENTATION UINT64CONST(0xE000000000000009)
 #define PARALLEL_KEY_WAL_USAGE			UINT64CONST(0xE00000000000000A)
 
+#define PARALLEL_KEY_TEMP_RELIDS		UINT64CONST(0xE00000000000000B)
+
 #define PARALLEL_TUPLE_QUEUE_SIZE		65536
 
 /*
@@ -608,6 +610,23 @@ ExecInitParallelPlan(PlanState *planstate, EState *estate,
 	Size		dsa_minsize = dsa_minimum_size();
 	char	   *query_string;
 	int			query_len;
+	ListCell	*lc;
+	char	   *temp_relids_str = NULL;
+	char	   *temp_relids_space;
+	Bitmapset	*temp_relids = NULL;
+
+	/* Put this under BBF extension and have dialect check */
+	foreach(lc, estate->es_range_table)
+	{
+		RangeTblEntry *rte = (RangeTblEntry *) lfirst(lc);
+		if (rte->rtekind == RTE_RELATION &&
+			OidIsValid(rte->relid) && 
+			 get_rel_persistence(rte->relid) == 't')
+		{
+			temp_relids = bms_add_member(temp_relids, rte->relid);
+		}
+	}
+	temp_relids_str = bmsToString(temp_relids);
 
 	/*
 	 * Force any initplan outputs that we're going to pass to workers to be
@@ -676,6 +695,12 @@ ExecInitParallelPlan(PlanState *planstate, EState *estate,
 	 */
 	shm_toc_estimate_chunk(&pcxt->estimator,
 						   mul_size(sizeof(WalUsage), pcxt->nworkers));
+	shm_toc_estimate_keys(&pcxt->estimator, 1);
+
+	/*
+	 * Babelfish extra context
+	 */
+	shm_toc_estimate_chunk(&pcxt->estimator, strlen(temp_relids_str) + 1);
 	shm_toc_estimate_keys(&pcxt->estimator, 1);
 
 	/* Estimate space for tuple queues. */
@@ -772,6 +797,11 @@ ExecInitParallelPlan(PlanState *planstate, EState *estate,
 									  mul_size(sizeof(WalUsage), pcxt->nworkers));
 	shm_toc_insert(pcxt->toc, PARALLEL_KEY_WAL_USAGE, walusage_space);
 	pei->wal_usage = walusage_space;
+
+	/* TODO: Move all this to extension. */
+	temp_relids_space = shm_toc_allocate(pcxt->toc, strlen(temp_relids_str) + 1);
+	memcpy(temp_relids_space, temp_relids_str, strlen(temp_relids_str) + 1);
+	shm_toc_insert(pcxt->toc, PARALLEL_KEY_TEMP_RELIDS, temp_relids_space);
 
 	/* Set up the tuple queues that the workers will write into. */
 	pei->tqueue = ExecParallelSetupTupleQueues(pcxt, false);
@@ -1410,6 +1440,7 @@ ParallelQueryMain(dsm_segment *seg, shm_toc *toc)
 	void	   *area_space;
 	dsa_area   *area;
 	ParallelWorkerContext pwcxt;
+	char	   *temp_relids_str;
 
 	/* Get fixed-size state. */
 	fpes = shm_toc_lookup(toc, PARALLEL_KEY_EXECUTOR_FIXED, false);
@@ -1431,6 +1462,8 @@ ParallelQueryMain(dsm_segment *seg, shm_toc *toc)
 
 	/* Attach to the dynamic shared memory area. */
 	area_space = shm_toc_lookup(toc, PARALLEL_KEY_DSA, false);
+	temp_relids_str = shm_toc_lookup(toc, PARALLEL_KEY_TEMP_RELIDS, false);
+	tempRelids = (Bitmapset *) stringToNode(temp_relids_str);
 	area = dsa_attach_in_place(area_space, seg);
 
 	/* Start up the executor */

--- a/src/backend/executor/execParallel.c
+++ b/src/backend/executor/execParallel.c
@@ -688,9 +688,7 @@ ExecInitParallelPlan(PlanState *planstate, EState *estate,
 
 	/* Let extension estimate a dynamic shared memory needed to communicate additional context */
 	if (ExecInitParallelPlan_hook)
-	{
 		(*ExecInitParallelPlan_hook)(estate, pcxt, true);
-	}
 
 	/*
 	 * Give parallel-aware nodes a chance to add to the estimates, and get a

--- a/src/backend/executor/execParallel.c
+++ b/src/backend/executor/execParallel.c
@@ -686,7 +686,7 @@ ExecInitParallelPlan(PlanState *planstate, EState *estate,
 						   mul_size(PARALLEL_TUPLE_QUEUE_SIZE, pcxt->nworkers));
 	shm_toc_estimate_keys(&pcxt->estimator, 1);
 
-	/* Give extension a chance to share additional details */
+	/* Let extension estimate a dynamic shared memory needed to communicate additional context */
 	if (ExecInitParallelPlan_hook)
 	{
 		(*ExecInitParallelPlan_hook)(estate, pcxt, true);
@@ -782,7 +782,7 @@ ExecInitParallelPlan(PlanState *planstate, EState *estate,
 	shm_toc_insert(pcxt->toc, PARALLEL_KEY_WAL_USAGE, walusage_space);
 	pei->wal_usage = walusage_space;
 
-	/* Give extension a chance to share additional details */
+	/* Give extension a chance to share additional context */
 	if (ExecInitParallelPlan_hook)
 	{
 		(*ExecInitParallelPlan_hook)(estate, pcxt,false);
@@ -1448,7 +1448,8 @@ ParallelQueryMain(dsm_segment *seg, shm_toc *toc)
 	area_space = shm_toc_lookup(toc, PARALLEL_KEY_DSA, false);
 	area = dsa_attach_in_place(area_space, seg);
 
-	if (IsBabelfishParallelWorker() && ParallelQueryMain_hook)
+	/* Give extension chance to retrieve additional context shared by leader node */
+	if (ParallelQueryMain_hook)
 	{
 		(*ParallelQueryMain_hook)(toc);
 	}

--- a/src/backend/executor/execParallel.c
+++ b/src/backend/executor/execParallel.c
@@ -65,8 +65,6 @@
 #define PARALLEL_KEY_JIT_INSTRUMENTATION UINT64CONST(0xE000000000000009)
 #define PARALLEL_KEY_WAL_USAGE			UINT64CONST(0xE00000000000000A)
 
-#define PARALLEL_KEY_TEMP_RELIDS		UINT64CONST(0xE00000000000000B)
-
 #define PARALLEL_TUPLE_QUEUE_SIZE		65536
 
 /*
@@ -123,6 +121,9 @@ typedef struct ExecParallelInitializeDSMContext
 	SharedExecutorInstrumentation *instrumentation;
 	int			nnodes;
 } ExecParallelInitializeDSMContext;
+
+ExecInitParallelPlan_hook_type ExecInitParallelPlan_hook = NULL;
+ParallelQueryMain_hook_type ParallelQueryMain_hook = NULL;
 
 /* Helper functions that run in the parallel leader. */
 static char *ExecSerializePlan(Plan *plan, EState *estate);
@@ -610,23 +611,6 @@ ExecInitParallelPlan(PlanState *planstate, EState *estate,
 	Size		dsa_minsize = dsa_minimum_size();
 	char	   *query_string;
 	int			query_len;
-	ListCell	*lc;
-	char	   *temp_relids_str = NULL;
-	char	   *temp_relids_space;
-	Bitmapset	*temp_relids = NULL;
-
-	/* Put this under BBF extension and have dialect check */
-	foreach(lc, estate->es_range_table)
-	{
-		RangeTblEntry *rte = (RangeTblEntry *) lfirst(lc);
-		if (rte->rtekind == RTE_RELATION &&
-			OidIsValid(rte->relid) && 
-			 get_rel_persistence(rte->relid) == 't')
-		{
-			temp_relids = bms_add_member(temp_relids, rte->relid);
-		}
-	}
-	temp_relids_str = bmsToString(temp_relids);
 
 	/*
 	 * Force any initplan outputs that we're going to pass to workers to be
@@ -695,12 +679,6 @@ ExecInitParallelPlan(PlanState *planstate, EState *estate,
 	 */
 	shm_toc_estimate_chunk(&pcxt->estimator,
 						   mul_size(sizeof(WalUsage), pcxt->nworkers));
-	shm_toc_estimate_keys(&pcxt->estimator, 1);
-
-	/*
-	 * Babelfish extra context
-	 */
-	shm_toc_estimate_chunk(&pcxt->estimator, strlen(temp_relids_str) + 1);
 	shm_toc_estimate_keys(&pcxt->estimator, 1);
 
 	/* Estimate space for tuple queues. */
@@ -798,10 +776,11 @@ ExecInitParallelPlan(PlanState *planstate, EState *estate,
 	shm_toc_insert(pcxt->toc, PARALLEL_KEY_WAL_USAGE, walusage_space);
 	pei->wal_usage = walusage_space;
 
-	/* TODO: Move all this to extension. */
-	temp_relids_space = shm_toc_allocate(pcxt->toc, strlen(temp_relids_str) + 1);
-	memcpy(temp_relids_space, temp_relids_str, strlen(temp_relids_str) + 1);
-	shm_toc_insert(pcxt->toc, PARALLEL_KEY_TEMP_RELIDS, temp_relids_space);
+	/* Give extension a chance to share additional details */
+	if (ExecInitParallelPlan_hook)
+	{
+		(*ExecInitParallelPlan_hook)(estate, pcxt,false);
+	}
 
 	/* Set up the tuple queues that the workers will write into. */
 	pei->tqueue = ExecParallelSetupTupleQueues(pcxt, false);
@@ -1440,7 +1419,6 @@ ParallelQueryMain(dsm_segment *seg, shm_toc *toc)
 	void	   *area_space;
 	dsa_area   *area;
 	ParallelWorkerContext pwcxt;
-	char	   *temp_relids_str;
 
 	/* Get fixed-size state. */
 	fpes = shm_toc_lookup(toc, PARALLEL_KEY_EXECUTOR_FIXED, false);
@@ -1462,9 +1440,12 @@ ParallelQueryMain(dsm_segment *seg, shm_toc *toc)
 
 	/* Attach to the dynamic shared memory area. */
 	area_space = shm_toc_lookup(toc, PARALLEL_KEY_DSA, false);
-	temp_relids_str = shm_toc_lookup(toc, PARALLEL_KEY_TEMP_RELIDS, false);
-	tempRelids = (Bitmapset *) stringToNode(temp_relids_str);
 	area = dsa_attach_in_place(area_space, seg);
+
+	if (ParallelQueryMain_hook)
+	{
+		(*ParallelQueryMain_hook)(toc);
+	}
 
 	/* Start up the executor */
 	queryDesc->plannedstmt->jitFlags = fpes->jit_flags;

--- a/src/backend/executor/execParallel.c
+++ b/src/backend/executor/execParallel.c
@@ -686,6 +686,12 @@ ExecInitParallelPlan(PlanState *planstate, EState *estate,
 						   mul_size(PARALLEL_TUPLE_QUEUE_SIZE, pcxt->nworkers));
 	shm_toc_estimate_keys(&pcxt->estimator, 1);
 
+	/* Give extension a chance to share additional details */
+	if (ExecInitParallelPlan_hook)
+	{
+		(*ExecInitParallelPlan_hook)(estate, pcxt, true);
+	}
+
 	/*
 	 * Give parallel-aware nodes a chance to add to the estimates, and get a
 	 * count of how many PlanState nodes there are.
@@ -1442,7 +1448,7 @@ ParallelQueryMain(dsm_segment *seg, shm_toc *toc)
 	area_space = shm_toc_lookup(toc, PARALLEL_KEY_DSA, false);
 	area = dsa_attach_in_place(area_space, seg);
 
-	if (ParallelQueryMain_hook)
+	if (IsBabelfishParallelWorker() && ParallelQueryMain_hook)
 	{
 		(*ParallelQueryMain_hook)(toc);
 	}

--- a/src/include/access/parallel.h
+++ b/src/include/access/parallel.h
@@ -81,15 +81,11 @@ extern void ParallelWorkerMain(Datum main_arg);
 /* Below helpers are added to support parallel workers in Babelfish context */
 extern bool IsBabelfishParallelWorker(void);
 
-/* Key for BabelfishFixedParallelState */
-#define BABELFISH_PARALLEL_KEY_FIXED        UINT64CONST(0xBBF0000000000001)
-
 /* Hooks for communicating babelfish related information to parallel worker */
 typedef void (*bbf_InitializeParallelDSM_hook_type)(ParallelContext *pcxt, bool estimate);
 extern PGDLLIMPORT bbf_InitializeParallelDSM_hook_type bbf_InitializeParallelDSM_hook;
 
 typedef void (*bbf_ParallelWorkerMain_hook_type)(shm_toc *toc);
 extern PGDLLIMPORT bbf_ParallelWorkerMain_hook_type bbf_ParallelWorkerMain_hook;
-
 
 #endif							/* PARALLEL_H */

--- a/src/include/executor/execParallel.h
+++ b/src/include/executor/execParallel.h
@@ -48,4 +48,10 @@ extern void ExecParallelReinitialize(PlanState *planstate,
 
 extern void ParallelQueryMain(dsm_segment *seg, shm_toc *toc);
 
+typedef void (*ParallelQueryMain_hook_type)(shm_toc *toc);
+extern PGDLLIMPORT ParallelQueryMain_hook_type ParallelQueryMain_hook;
+
+typedef void (*ExecInitParallelPlan_hook_type)(EState *estate, ParallelContext *pcxt, bool estimate);
+extern PGDLLIMPORT ExecInitParallelPlan_hook_type ExecInitParallelPlan_hook;
+
 #endif							/* EXECPARALLEL_H */

--- a/src/include/executor/execParallel.h
+++ b/src/include/executor/execParallel.h
@@ -51,6 +51,11 @@ extern void ParallelQueryMain(dsm_segment *seg, shm_toc *toc);
 typedef void (*ParallelQueryMain_hook_type)(shm_toc *toc);
 extern PGDLLIMPORT ParallelQueryMain_hook_type ParallelQueryMain_hook;
 
+/*
+ * When estimate = true passed then caller wants extension to estimate a dynamic shared memory (DSM)
+ * needed by that extension to communicate additional context with Parallel worker.
+ * When estimate = false then caller wants to insert additional context to DSM.
+ */
 typedef void (*ExecInitParallelPlan_hook_type)(EState *estate, ParallelContext *pcxt, bool estimate);
 extern PGDLLIMPORT ExecInitParallelPlan_hook_type ExecInitParallelPlan_hook;
 

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -691,4 +691,6 @@ extern ResultRelInfo *ExecLookupResultRelByOid(ModifyTableState *node,
 											   bool missing_ok,
 											   bool update_cache);
 
+extern Bitmapset *tempRelids;
+
 #endif							/* EXECUTOR_H  */

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -111,6 +111,9 @@ extern PGDLLIMPORT ExecUpdateResultTypeTL_hook_type ExecUpdateResultTypeTL_hook;
 typedef bool (*check_rowcount_hook_type) (int es_processed);
 extern PGDLLEXPORT check_rowcount_hook_type check_rowcount_hook;
 
+typedef bool (*skip_ExecutorCheckPerms_hook_type) (Oid relid);
+extern PGDLLEXPORT skip_ExecutorCheckPerms_hook_type skip_ExecutorCheckPerms_hook;
+
 /*
  * prototypes from functions in execAmi.c
  */
@@ -690,7 +693,5 @@ extern ResultRelInfo *ExecLookupResultRelByOid(ModifyTableState *node,
 											   Oid resultoid,
 											   bool missing_ok,
 											   bool update_cache);
-
-extern Bitmapset *tempRelids;
 
 #endif							/* EXECUTOR_H  */

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -111,8 +111,8 @@ extern PGDLLIMPORT ExecUpdateResultTypeTL_hook_type ExecUpdateResultTypeTL_hook;
 typedef bool (*check_rowcount_hook_type) (int es_processed);
 extern PGDLLEXPORT check_rowcount_hook_type check_rowcount_hook;
 
-typedef bool (*skip_ExecutorCheckPerms_hook_type) (Oid relid);
-extern PGDLLEXPORT skip_ExecutorCheckPerms_hook_type skip_ExecutorCheckPerms_hook;
+typedef bool (*ExecCheckOneRelPerms_hook_type) (RTEPermissionInfo *perminfo);
+extern PGDLLEXPORT ExecCheckOneRelPerms_hook_type ExecCheckOneRelPerms_hook;
 
 /*
  * prototypes from functions in execAmi.c
@@ -227,7 +227,8 @@ extern void standard_ExecutorEnd(QueryDesc *queryDesc);
 extern void ExecutorRewind(QueryDesc *queryDesc);
 extern bool ExecCheckPermissions(List *rangeTable,
 								 List *rteperminfos, bool ereport_on_violation);
-extern bool ExecCheckOneRelPerms(RTEPermissionInfo *perminfo);
+/* Wrapper around ExecCheckOneRelPerms */
+extern bool ExecCheckOneRelPerms_wrapper(RTEPermissionInfo *perminfo);
 extern void CheckValidResultRel(ResultRelInfo *resultRelInfo, CmdType operation,
 								List *mergeActions);
 extern void InitResultRelInfo(ResultRelInfo *resultRelInfo,

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -227,6 +227,7 @@ extern void standard_ExecutorEnd(QueryDesc *queryDesc);
 extern void ExecutorRewind(QueryDesc *queryDesc);
 extern bool ExecCheckPermissions(List *rangeTable,
 								 List *rteperminfos, bool ereport_on_violation);
+extern bool ExecCheckOneRelPerms(RTEPermissionInfo *perminfo);
 extern void CheckValidResultRel(ResultRelInfo *resultRelInfo, CmdType operation,
 								List *mergeActions);
 extern void InitResultRelInfo(ResultRelInfo *resultRelInfo,


### PR DESCRIPTION
### Description

Consider following facts,

1. Babelfish temp tables are implemented using ENR which is not shared between different backends. So if Parallel worker
tries to check permissions on Babelfish then it will fail.

2. Any user should be able to access Babelfish temp tables under given session. 

3. Postgres by default does not allow parallel operations on temp tables. Attempt to do so will result in run time error.

Due to above facts, we should avoid permission check on temp tables within parallel workers while ensuring that leader
does required permission check on other tables. This commits achieves this behaviour by introducing following three
hooks, 

1. ParallelQueryMain_hook -- Hook that allows other extensions to pass on additional details from Leader node to
parallel worker. For example, Babelfish extension can pass details of Babelfish temp table defined under current
session with Parallel workers.

2. ExecInitParallelPlan_hook -- Hook that allows Parallel worker to gather additional details passed by Leader node.
For example, Babelfish extension can collect the details of Babelfish temp table shared by Leader node so that it
can avoid permission checks.

3. ExecCheckOneRelPerms_hook -- Hook that allows extension control permission checking on given relation/table.
For example, Babelfish can use it to avoid permission check on temp tables under parallel worker.
 
### Issues Resolved

BABEL-5703
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
