### PR TITLE
Case insensitivity of column names in UNPIVOT result

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -17687,7 +17687,7 @@ ColIdDef:	IDENT
 					/* Now downcase the colname if in the TSQL dialect and the default
 					 * collation is case-insensitive.
 					 */
-					  $$ = downcaseIfTsqlAndCaseInsensitive($1);
+					  $$ = $1;
 				  }
 			| unreserved_keyword
 				  {
@@ -17697,7 +17697,7 @@ ColIdDef:	IDENT
 					  /* Now downcase the colname in the TSQL dialect if the database collation
 					   * is case-sensitive.
 					   */
-					  $$ = downcaseIfTsqlAndCaseInsensitive(pstrdup($1));
+					  $$ = pstrdup($1);
 				  }
 			| col_name_keyword
 				  {
@@ -17707,7 +17707,7 @@ ColIdDef:	IDENT
 					  /* Now downcase the colname in the TSQL dialect if the database collation
 					   * is case-sensitive.
 					   */
-					  $$ = downcaseIfTsqlAndCaseInsensitive(pstrdup($1));
+					  $$ = pstrdup($1);
 				  }
 		;
 


### PR DESCRIPTION
### Description

Removed downcase function from ColIdDef parse rule. Testing to see if this affects rest of the codebase.
 
### Issues Resolved

Task: BABEL-5761
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
