### PR TITLE
Handling correct typmod for money/smallmoney during coercion and dump-restore

### DIFF
--- a/src/backend/nodes/nodeFuncs.c
+++ b/src/backend/nodes/nodeFuncs.c
@@ -302,6 +302,14 @@ exprTypmod(const Node *expr)
 {
 	if (!expr)
 		return -1;
+	if (exprTypmod_hook)
+	{
+		int32 typmod = exprTypmod_hook(NULL, (Node *) expr);
+		if (typmod != -1)
+		{
+			return typmod;
+		}
+	}
 
 	switch (nodeTag(expr))
 	{
@@ -540,9 +548,6 @@ exprTypmod(const Node *expr)
 		default:
 			break;
 	}
-
-	if (exprTypmod_hook)
-		return exprTypmod_hook(NULL, (Node *) expr);
 
 	return -1;
 }

--- a/src/backend/nodes/nodeFuncs.c
+++ b/src/backend/nodes/nodeFuncs.c
@@ -302,14 +302,6 @@ exprTypmod(const Node *expr)
 {
 	if (!expr)
 		return -1;
-	if (exprTypmod_hook)
-	{
-		int32 typmod = exprTypmod_hook(NULL, (Node *) expr);
-		if (typmod != -1)
-		{
-			return typmod;
-		}
-	}
 
 	switch (nodeTag(expr))
 	{
@@ -548,6 +540,9 @@ exprTypmod(const Node *expr)
 		default:
 			break;
 	}
+
+	if (exprTypmod_hook)
+		return exprTypmod_hook(NULL, (Node *) expr);
 
 	return -1;
 }

--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -797,9 +797,7 @@ coerce_to_domain(Node *arg, Oid baseTypeId, int32 baseTypeMod, Oid typeId,
 		 strcmp(type_name, "nchar") == 0 ||
 		 strcmp(type_name, "varbinary") == 0 ||
 		 strcmp(type_name, "binary") == 0 ||
-		 strcmp(type_name, "decimal") == 0 ||
-		 strcmp(type_name, "money") == 0 ||
-		 strcmp(type_name, "smallmoney") == 0))
+		 strcmp(type_name, "decimal") == 0))
 		result->resulttypmod = baseTypeMod;
 
 	return (Node *) result;

--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -797,7 +797,9 @@ coerce_to_domain(Node *arg, Oid baseTypeId, int32 baseTypeMod, Oid typeId,
 		 strcmp(type_name, "nchar") == 0 ||
 		 strcmp(type_name, "varbinary") == 0 ||
 		 strcmp(type_name, "binary") == 0 ||
-		 strcmp(type_name, "decimal") == 0))
+		 strcmp(type_name, "decimal") == 0 ||
+		 strcmp(type_name, "smallmoney") == 0||
+		 strcmp(type_name, "money") == 0))
 		result->resulttypmod = baseTypeMod;
 
 	return (Node *) result;

--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -797,7 +797,9 @@ coerce_to_domain(Node *arg, Oid baseTypeId, int32 baseTypeMod, Oid typeId,
 		 strcmp(type_name, "nchar") == 0 ||
 		 strcmp(type_name, "varbinary") == 0 ||
 		 strcmp(type_name, "binary") == 0 ||
-		 strcmp(type_name, "decimal") == 0))
+		 strcmp(type_name, "decimal") == 0 ||
+		 strcmp(type_name, "money") == 0 ||
+		 strcmp(type_name, "smallmoney") == 0))
 		result->resulttypmod = baseTypeMod;
 
 	return (Node *) result;

--- a/src/backend/parser/parse_type.c
+++ b/src/backend/parser/parse_type.c
@@ -369,7 +369,7 @@ typenameTypeMod(ParseState *pstate, const TypeName *typeName, Type typ)
 	typeoid = ((Form_pg_type) GETSTRUCT(typ))->oid;
 	typbasetype = ((Form_pg_type) GETSTRUCT(typ))->typbasetype;
 
-	if (dump_restore && (strcmp(dump_restore, "on") == 0) && !typmodin && typbasetype)
+	if (dump_restore && (strcmp(dump_restore, "on") == 0) && !OidIsValid(typmodin) && OidIsValid(typbasetype))
 	{
 		basetypeid = getBaseType(typeoid);
 		tup = SearchSysCache1(TYPEOID, ObjectIdGetDatum(basetypeid));

--- a/src/backend/parser/parse_type.c
+++ b/src/backend/parser/parse_type.c
@@ -26,7 +26,6 @@
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
 #include "utils/syscache.h"
-#include "utils/guc.h"
 
 static int32 typenameTypeMod(ParseState *pstate, const TypeName *typeName,
 							 Type typ);

--- a/src/backend/parser/parse_type.c
+++ b/src/backend/parser/parse_type.c
@@ -33,7 +33,7 @@ static int32 typenameTypeMod(ParseState *pstate, const TypeName *typeName,
 check_or_set_default_typmod_hook_type check_or_set_default_typmod_hook = NULL;
 validate_var_datatype_scale_hook_type validate_var_datatype_scale_hook = NULL;
 handle_default_collation_hook_type handle_default_collation_hook = NULL;
-handle_basetype_typmodin_hook_type handle_basetype_typmodin_hook = NULL;
+get_domain_typmodin_hook_type get_domain_typmodin_hook = NULL;
 
 /*
  * LookupTypeName
@@ -362,9 +362,12 @@ typenameTypeMod(ParseState *pstate, const TypeName *typeName, Type typ)
 
 	typmodin = ((Form_pg_type) GETSTRUCT(typ))->typmodin;
 
-	/* Handle the typmodin for domains like smallmoney/money and UDTs on them. */
-	if (handle_basetype_typmodin_hook)
-		(*handle_basetype_typmodin_hook)(typ, &typmodin);
+	/*
+	 * Find the OID of domain's typmodin function, which is same as its basetype's typmodin OID,
+	 * for domains like smallmoney/money and their UDTs during restore.
+	 */
+	if (get_domain_typmodin_hook)
+		typmodin = (*get_domain_typmodin_hook)(typ);
 
 	if (typmodin == InvalidOid)
 		ereport(ERROR,

--- a/src/backend/parser/parse_type.c
+++ b/src/backend/parser/parse_type.c
@@ -339,6 +339,8 @@ typenameTypeMod(ParseState *pstate, const TypeName *typeName, Type typ)
 	int32		result;
 	Oid			typmodin;
 	Oid 		typbasetype;
+	Oid 		basetypeid;
+	Oid 		typeoid;
 	Datum	   *datums;
 	int			n;
 	ListCell   *l;
@@ -364,13 +366,15 @@ typenameTypeMod(ParseState *pstate, const TypeName *typeName, Type typ)
 				 parser_errposition(pstate, typeName->location)));
 
 	typmodin = ((Form_pg_type) GETSTRUCT(typ))->typmodin;
+	typeoid = ((Form_pg_type) GETSTRUCT(typ))->oid;
 	typbasetype = ((Form_pg_type) GETSTRUCT(typ))->typbasetype;
+	basetypeid = getBaseType(typeoid);
 
 	if (dump_restore && (strcmp(dump_restore, "on") == 0) && !typmodin && typbasetype)
 	{
-		tup = SearchSysCache1(TYPEOID, ObjectIdGetDatum(typbasetype));
+		tup = SearchSysCache1(TYPEOID, ObjectIdGetDatum(basetypeid));
 		if (!HeapTupleIsValid(tup)) /* should not happen */
-			elog(ERROR, "cache lookup failed for type %u", typbasetype);
+			elog(ERROR, "cache lookup failed for type %u", basetypeid);
 		typmodin = ((Form_pg_type) GETSTRUCT((Type)tup))->typmodin;
 		ReleaseSysCache(tup);
 	}

--- a/src/backend/parser/parse_type.c
+++ b/src/backend/parser/parse_type.c
@@ -34,6 +34,7 @@ static int32 typenameTypeMod(ParseState *pstate, const TypeName *typeName,
 check_or_set_default_typmod_hook_type check_or_set_default_typmod_hook = NULL;
 validate_var_datatype_scale_hook_type validate_var_datatype_scale_hook = NULL;
 handle_default_collation_hook_type handle_default_collation_hook = NULL;
+handle_basetype_typmodin_hook_type handle_basetype_typmodin_hook = NULL;
 
 /*
  * LookupTypeName
@@ -338,16 +339,11 @@ typenameTypeMod(ParseState *pstate, const TypeName *typeName, Type typ)
 {
 	int32		result;
 	Oid			typmodin;
-	Oid 		typbasetype;
-	Oid 		basetypeid;
-	Oid 		typeoid;
 	Datum	   *datums;
 	int			n;
 	ListCell   *l;
 	ArrayType  *arrtypmod;
 	ParseCallbackState pcbstate;
-	const char *dump_restore = GetConfigOption("babelfishpg_tsql.dump_restore", true, false);
-	HeapTuple	tup;
 
 	/* Return prespecified typmod if no typmod expressions */
 	if (typeName->typmods == NIL)
@@ -366,18 +362,10 @@ typenameTypeMod(ParseState *pstate, const TypeName *typeName, Type typ)
 				 parser_errposition(pstate, typeName->location)));
 
 	typmodin = ((Form_pg_type) GETSTRUCT(typ))->typmodin;
-	typeoid = ((Form_pg_type) GETSTRUCT(typ))->oid;
-	typbasetype = ((Form_pg_type) GETSTRUCT(typ))->typbasetype;
 
-	if (dump_restore && (strcmp(dump_restore, "on") == 0) && !OidIsValid(typmodin) && OidIsValid(typbasetype))
-	{
-		basetypeid = getBaseType(typeoid);
-		tup = SearchSysCache1(TYPEOID, ObjectIdGetDatum(basetypeid));
-		if (!HeapTupleIsValid(tup)) /* should not happen */
-			elog(ERROR, "cache lookup failed for type %u", basetypeid);
-		typmodin = ((Form_pg_type) GETSTRUCT((Type)tup))->typmodin;
-		ReleaseSysCache(tup);
-	}
+	/* Handle the typmodin for domains like smallmoney/money and UDTs on them. */
+	if (handle_basetype_typmodin_hook)
+		(*handle_basetype_typmodin_hook)(typ, &typmodin);
 
 	if (typmodin == InvalidOid)
 		ereport(ERROR,

--- a/src/backend/parser/parse_type.c
+++ b/src/backend/parser/parse_type.c
@@ -337,11 +337,14 @@ typenameTypeMod(ParseState *pstate, const TypeName *typeName, Type typ)
 {
 	int32		result;
 	Oid			typmodin;
+	Oid 		typbasetype;
 	Datum	   *datums;
 	int			n;
 	ListCell   *l;
 	ArrayType  *arrtypmod;
 	ParseCallbackState pcbstate;
+	const char *dump_restore = GetConfigOption("babelfishpg_tsql.dump_restore", true, false);
+	HeapTuple	tup;
 
 	/* Return prespecified typmod if no typmod expressions */
 	if (typeName->typmods == NIL)
@@ -360,6 +363,16 @@ typenameTypeMod(ParseState *pstate, const TypeName *typeName, Type typ)
 				 parser_errposition(pstate, typeName->location)));
 
 	typmodin = ((Form_pg_type) GETSTRUCT(typ))->typmodin;
+	typbasetype = ((Form_pg_type) GETSTRUCT(typ))->typbasetype;
+
+	if (dump_restore && (strcmp(dump_restore, "on") == 0) && !typmodin && typbasetype)
+	{
+		tup = SearchSysCache1(TYPEOID, ObjectIdGetDatum(typbasetype));
+		if (!HeapTupleIsValid(tup)) /* should not happen */
+			elog(ERROR, "cache lookup failed for type %u", typbasetype);
+		typmodin = ((Form_pg_type) GETSTRUCT((Type)tup))->typmodin;
+		ReleaseSysCache(tup);
+	}
 
 	if (typmodin == InvalidOid)
 		ereport(ERROR,

--- a/src/backend/parser/parse_type.c
+++ b/src/backend/parser/parse_type.c
@@ -26,6 +26,7 @@
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
 #include "utils/syscache.h"
+#include "utils/guc.h"
 
 static int32 typenameTypeMod(ParseState *pstate, const TypeName *typeName,
 							 Type typ);

--- a/src/backend/parser/parse_type.c
+++ b/src/backend/parser/parse_type.c
@@ -363,8 +363,7 @@ typenameTypeMod(ParseState *pstate, const TypeName *typeName, Type typ)
 	typmodin = ((Form_pg_type) GETSTRUCT(typ))->typmodin;
 
 	/*
-	 * Find the OID of domain's typmodin function, which is same as its basetype's typmodin OID,
-	 * for domains like smallmoney/money and their UDTs during restore.
+	 * Find the OID of domain's typmodin function, which is same as its basetype's typmodin OID.
 	 */
 	if (get_domain_typmodin_hook)
 		typmodin = (*get_domain_typmodin_hook)(typ);

--- a/src/backend/parser/parse_type.c
+++ b/src/backend/parser/parse_type.c
@@ -368,10 +368,10 @@ typenameTypeMod(ParseState *pstate, const TypeName *typeName, Type typ)
 	typmodin = ((Form_pg_type) GETSTRUCT(typ))->typmodin;
 	typeoid = ((Form_pg_type) GETSTRUCT(typ))->oid;
 	typbasetype = ((Form_pg_type) GETSTRUCT(typ))->typbasetype;
-	basetypeid = getBaseType(typeoid);
 
 	if (dump_restore && (strcmp(dump_restore, "on") == 0) && !typmodin && typbasetype)
 	{
+		basetypeid = getBaseType(typeoid);
 		tup = SearchSysCache1(TYPEOID, ObjectIdGetDatum(basetypeid));
 		if (!HeapTupleIsValid(tup)) /* should not happen */
 			elog(ERROR, "cache lookup failed for type %u", basetypeid);

--- a/src/include/parser/parse_type.h
+++ b/src/include/parser/parse_type.h
@@ -72,4 +72,11 @@ extern PGDLLEXPORT validate_var_datatype_scale_hook_type validate_var_datatype_s
 typedef Oid (*handle_default_collation_hook_type) (Type typ, bool handle_pg_type);
 extern PGDLLEXPORT handle_default_collation_hook_type handle_default_collation_hook;
 
+/*
+ * Hook to find the typmodin for domains like smallmoney/money
+ * and UDTs created on them, in case of dump_restore.
+ */
+typedef void (*handle_basetype_typmodin_hook_type) (Type typ, Oid *typmodin);
+extern PGDLLEXPORT handle_basetype_typmodin_hook_type handle_basetype_typmodin_hook;
+
 #endif							/* PARSE_TYPE_H */

--- a/src/include/parser/parse_type.h
+++ b/src/include/parser/parse_type.h
@@ -73,10 +73,11 @@ typedef Oid (*handle_default_collation_hook_type) (Type typ, bool handle_pg_type
 extern PGDLLEXPORT handle_default_collation_hook_type handle_default_collation_hook;
 
 /*
- * Hook to find the typmodin for domains like smallmoney/money
- * and UDTs created on them, in case of dump_restore.
+ * Hook to find oid of typmodin function for a given domain tuple which is essentially same as
+ * the oid of it's basetype's typmodin function. This is only used during restore to handle domains
+ * like smallmoney/money and UDTs created on them.
  */
-typedef void (*handle_basetype_typmodin_hook_type) (Type typ, Oid *typmodin);
-extern PGDLLEXPORT handle_basetype_typmodin_hook_type handle_basetype_typmodin_hook;
+typedef Oid (*get_domain_typmodin_hook_type) (Type typ);
+extern PGDLLEXPORT get_domain_typmodin_hook_type get_domain_typmodin_hook;
 
 #endif							/* PARSE_TYPE_H */

--- a/src/include/parser/parse_type.h
+++ b/src/include/parser/parse_type.h
@@ -73,9 +73,8 @@ typedef Oid (*handle_default_collation_hook_type) (Type typ, bool handle_pg_type
 extern PGDLLEXPORT handle_default_collation_hook_type handle_default_collation_hook;
 
 /*
- * Hook to find oid of typmodin function for a given domain tuple which is essentially same as
- * the oid of it's basetype's typmodin function. This is only used during restore to handle domains
- * like smallmoney/money and UDTs created on them.
+ * Hook to find oid of typmodin function for a given domain which is essentially same as
+ * the oid of it's basetype's typmodin function.
  */
 typedef Oid (*get_domain_typmodin_hook_type) (Type typ);
 extern PGDLLIMPORT get_domain_typmodin_hook_type get_domain_typmodin_hook;

--- a/src/include/parser/parse_type.h
+++ b/src/include/parser/parse_type.h
@@ -78,6 +78,6 @@ extern PGDLLEXPORT handle_default_collation_hook_type handle_default_collation_h
  * like smallmoney/money and UDTs created on them.
  */
 typedef Oid (*get_domain_typmodin_hook_type) (Type typ);
-extern PGDLLEXPORT get_domain_typmodin_hook_type get_domain_typmodin_hook;
+extern PGDLLIMPORT get_domain_typmodin_hook_type get_domain_typmodin_hook;
 
 #endif							/* PARSE_TYPE_H */


### PR DESCRIPTION
### Description

This PR handles the dump/restore case for smallmoney/money and handles typmod for these dataype while coercing to domain.

Signed-off-by: Tanya Gupta [tanyagp@amazon.com](mailto:tanyagp@amazon.com)

Extension PR : https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3719
 
### Issues Resolved
BABEL-5512

[List any issues this PR will resolve]
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
