### PR TITLE
Dump Babelfish operator classes for numeric-int comparisons to support index scan

### DIFF
--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -1611,7 +1611,13 @@ babelfishDumpOpclassHelper(Archive *fout, const OpclassInfo *opcinfo, PQExpBuffe
 		pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"int2_numeric\"" : "sys.int2_numeric") != 0 &&
 		pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"numeric_int2\"" : "sys.numeric_int2") != 0 &&
 		pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"int8_numeric\"" : "sys.int8_numeric") != 0 &&
-		pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"numeric_int8\"" : "sys.numeric_int8") != 0)
+		pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"numeric_int8\"" : "sys.numeric_int8") != 0 &&
+		pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"int2_numeric_ops\"" : "sys.int2_numeric_ops") != 0 &&
+		pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"numeric_int2_ops\"" : "sys.numeric_int2_ops") != 0 &&
+		pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"int4_numeric_ops\"" : "sys.int4_numeric_ops") != 0 &&
+		pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"numeric_int4_ops\"" : "sys.numeric_int4_ops") != 0 &&
+		pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"int8_numeric_ops\"" : "sys.int8_numeric_ops") != 0 &&
+		pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"numeric_int8_ops\"" : "sys.numeric_int8_ops") != 0)
 		return;
 
 	query = createPQExpBuffer();
@@ -1640,7 +1646,7 @@ babelfishDumpOpclassHelper(Archive *fout, const OpclassInfo *opcinfo, PQExpBuffe
 	}
 
 	if (strcasecmp(opfnamespace, "\"pg_catalog\"") != 0 ||
-		strcasecmp(opfname, "integer_ops") != 0)
+		(strcasecmp(opfname, "integer_ops") != 0 && strcasecmp(opfname, "numeric_ops") != 0))
 	{
 		PQclear(res);
 		return;
@@ -1648,7 +1654,8 @@ babelfishDumpOpclassHelper(Archive *fout, const OpclassInfo *opcinfo, PQExpBuffe
 
 	PQclear(res);
 
-	if (pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"int_numeric\"" : "sys.int_numeric") == 0)
+	if (pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"int_numeric\"" : "sys.int_numeric") == 0 ||
+		pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"int4_numeric_ops\"" : "sys.int4_numeric_ops") == 0)
 	{
 		str = quote_all_identifiers ?
 				"OPERATOR 1 \"sys\".< (int4, numeric) ,\n	"
@@ -1665,7 +1672,8 @@ babelfishDumpOpclassHelper(Archive *fout, const OpclassInfo *opcinfo, PQExpBuffe
 				"FUNCTION 1 sys.int4_numeric_cmp(int4, numeric) ";
 	}
 
-	if (pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"numeric_int\"" : "sys.numeric_int") == 0)
+	if (pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"numeric_int\"" : "sys.numeric_int") == 0 ||
+		pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"numeric_int4_ops\"" : "sys.numeric_int4_ops") == 0)
 	{
 		str = quote_all_identifiers ?
 				"OPERATOR 1 \"sys\".< (numeric, int4) ,\n	"
@@ -1682,7 +1690,8 @@ babelfishDumpOpclassHelper(Archive *fout, const OpclassInfo *opcinfo, PQExpBuffe
 				"FUNCTION 1 sys.numeric_int4_cmp(numeric, int4) ";
 	}
 
-	if (pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"int2_numeric\"" : "sys.int2_numeric") == 0)
+	if (pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"int2_numeric\"" : "sys.int2_numeric") == 0 ||
+		pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"int2_numeric_ops\"" : "sys.int2_numeric_ops") == 0)
 	{
 		str = quote_all_identifiers ?
 			"OPERATOR 1 \"sys\".< (int2, numeric) ,\n	"
@@ -1699,7 +1708,8 @@ babelfishDumpOpclassHelper(Archive *fout, const OpclassInfo *opcinfo, PQExpBuffe
 			"FUNCTION 1 sys.int2_numeric_cmp(int2, numeric) ";
 	}
 
-	if (pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"numeric_int2\"" : "sys.numeric_int2") == 0)
+	if (pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"numeric_int2\"" : "sys.numeric_int2") == 0 ||
+		pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"numeric_int2_ops\"" : "sys.numeric_int2_ops") == 0)
 	{
 		str = quote_all_identifiers ?
 				"OPERATOR 1 \"sys\".< (numeric, int2) ,\n	"
@@ -1716,7 +1726,8 @@ babelfishDumpOpclassHelper(Archive *fout, const OpclassInfo *opcinfo, PQExpBuffe
 				"FUNCTION 1 sys.numeric_int2_cmp(numeric, int2)	";
 	}
 
-	if (pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"int8_numeric\"" : "sys.int8_numeric") == 0)
+	if (pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"int8_numeric\"" : "sys.int8_numeric") == 0 ||
+		pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"int8_numeric_ops\"" : "sys.int8_numeric_ops") == 0)
 	{
 		str = quote_all_identifiers ?
 				"OPERATOR 1 \"sys\".< (int8, numeric) ,\n	"
@@ -1733,7 +1744,8 @@ babelfishDumpOpclassHelper(Archive *fout, const OpclassInfo *opcinfo, PQExpBuffe
 				"FUNCTION 1 sys.int8_numeric_cmp(int8, numeric) ";
 	}
 
-	if (pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"numeric_int8\"" : "sys.numeric_int8") == 0)
+	if (pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"numeric_int8\"" : "sys.numeric_int8") == 0 ||
+		pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"numeric_int8_ops\"" : "sys.numeric_int8_ops") == 0)
 	{
 		str = quote_all_identifiers ?
 				"OPERATOR 1 \"sys\".< (numeric, int8) ,\n	"


### PR DESCRIPTION
### Description
Since Postgres does not dump user-defined operator classes over built-in data
types, this commit makes changes to dump new operator classes added in babelfish 
extension as part of the numeric operator family (https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3761).


These operator classes are essential for supporting index scans between int and
numeric types when the index is created on a numeric column. The change ensures
that the operator classes are properly preserved during pg_upgrade operations,
maintaining the index scan capabilities in the upgraded database.
 


Signed-off-by: Sumit Jaiswal <sumiji@amazon.com>
 
### Issues Resolved

Task: BABEL-5648

### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
