### PR TITLE
[BABEL] Cleanup babelfish code

### DIFF
--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -926,14 +926,6 @@ transformColumnRef(ParseState *pstate, ColumnRef *cref)
 		}
 	}
 
-	if (pstate->p_column_ref_overwrite_hook && sql_dialect == SQL_DIALECT_TSQL)
-	{
-		Node *hookresult = pstate->p_column_ref_overwrite_hook(pstate, cref, node);
-
-		if (hookresult)
-			node = hookresult;
-	}
-
 	return node;
 }
 

--- a/src/backend/parser/parse_node.c
+++ b/src/backend/parser/parse_node.c
@@ -62,7 +62,6 @@ make_parsestate(ParseState *parentParseState)
 		pstate->p_pre_columnref_hook = parentParseState->p_pre_columnref_hook;
 		pstate->p_post_columnref_hook = parentParseState->p_post_columnref_hook;
 		pstate->p_post_expand_star_hook = parentParseState->p_post_expand_star_hook;
-		pstate->p_column_ref_overwrite_hook = parentParseState->p_column_ref_overwrite_hook;
 		pstate->p_paramref_hook = parentParseState->p_paramref_hook;
 		pstate->p_coerce_param_hook = parentParseState->p_coerce_param_hook;
 		pstate->p_ref_hook_state = parentParseState->p_ref_hook_state;

--- a/src/backend/utils/fmgr/fmgr.c
+++ b/src/backend/utils/fmgr/fmgr.c
@@ -213,12 +213,6 @@ fmgr_info_cxt_security(Oid functionId, FmgrInfo *finfo, MemoryContext mcxt,
 	if (!ignore_security &&
 		(procedureStruct->prosecdef ||
 		 !heap_attisnull(procedureTuple, Anum_pg_proc_proconfig, NULL) ||
-		 /*
-		  * If babelfishpg_tsql extension is installed, set proconfig of functions
-		  * to have sql_dialect be either postgres or tsql according to
-		  * their language.
-		  */
-		 (get_func_language_oids_hook != NULL) ||
 		 FmgrHookIsNeeded(functionId)))
 	{
 		finfo->fn_addr = fmgr_security_definer;

--- a/src/include/parser/parse_node.h
+++ b/src/include/parser/parse_node.h
@@ -237,7 +237,6 @@ struct ParseState
 	PreParseColumnRefHook p_pre_columnref_hook;
 	PostParseColumnRefHook p_post_columnref_hook;
 	PostParseExpandStarHook p_post_expand_star_hook;
-	ColumnRefOverwriteHook p_column_ref_overwrite_hook;
 	ParseParamRefHook p_paramref_hook;
 	CoerceParamHook p_coerce_param_hook;
 	void	   *p_ref_hook_state;	/* common passthrough link for above */


### PR DESCRIPTION
### Description

Remove unused member of pstate p_column_ref_overwrite_hook.
Also implement needs_fmgr_hook and remove hack to force
fmgr_security_definer for babelfish database.
 
### Issues Resolved

https://github.com/babelfish-for-postgresql/babelfish_extensions/issues/3071
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
