### PR TITLE
Handling correct typmod for money/smallmoney during coercion and dump-restore

### DIFF
--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -797,7 +797,9 @@ coerce_to_domain(Node *arg, Oid baseTypeId, int32 baseTypeMod, Oid typeId,
 		 strcmp(type_name, "nchar") == 0 ||
 		 strcmp(type_name, "varbinary") == 0 ||
 		 strcmp(type_name, "binary") == 0 ||
-		 strcmp(type_name, "decimal") == 0))
+		 strcmp(type_name, "decimal") == 0 ||
+		 strcmp(type_name, "smallmoney") == 0||
+		 strcmp(type_name, "money") == 0))
 		result->resulttypmod = baseTypeMod;
 
 	return (Node *) result;

--- a/src/backend/parser/parse_type.c
+++ b/src/backend/parser/parse_type.c
@@ -33,6 +33,7 @@ static int32 typenameTypeMod(ParseState *pstate, const TypeName *typeName,
 check_or_set_default_typmod_hook_type check_or_set_default_typmod_hook = NULL;
 validate_var_datatype_scale_hook_type validate_var_datatype_scale_hook = NULL;
 handle_default_collation_hook_type handle_default_collation_hook = NULL;
+get_domain_typmodin_hook_type get_domain_typmodin_hook = NULL;
 
 /*
  * LookupTypeName
@@ -360,6 +361,12 @@ typenameTypeMod(ParseState *pstate, const TypeName *typeName, Type typ)
 				 parser_errposition(pstate, typeName->location)));
 
 	typmodin = ((Form_pg_type) GETSTRUCT(typ))->typmodin;
+
+	/*
+	 * Find the OID of domain's typmodin function, which is same as its basetype's typmodin OID.
+	 */
+	if (get_domain_typmodin_hook)
+		typmodin = (*get_domain_typmodin_hook)(typ);
 
 	if (typmodin == InvalidOid)
 		ereport(ERROR,

--- a/src/include/parser/parse_type.h
+++ b/src/include/parser/parse_type.h
@@ -72,4 +72,11 @@ extern PGDLLEXPORT validate_var_datatype_scale_hook_type validate_var_datatype_s
 typedef Oid (*handle_default_collation_hook_type) (Type typ, bool handle_pg_type);
 extern PGDLLEXPORT handle_default_collation_hook_type handle_default_collation_hook;
 
+/*
+ * Hook to find oid of typmodin function for a given domain which is essentially same as
+ * the oid of it's basetype's typmodin function.
+ */
+typedef Oid (*get_domain_typmodin_hook_type) (Type typ);
+extern PGDLLIMPORT get_domain_typmodin_hook_type get_domain_typmodin_hook;
+
 #endif							/* PARSE_TYPE_H */


### PR DESCRIPTION
### Description

This PR handles the dump/restore case for smallmoney/money and handles typmod for these dataype while coercing to domain.

Signed-off-by: Tanya Gupta tanyagp@amazon.com

Cherry-pick PR : https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/575
Extension PR : https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3808

### Issues Resolved
BABEL-5512
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
