### PR TITLE
Adding typmod for RelabelType Node

### DIFF
--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -487,7 +487,11 @@ coerce_type(ParseState *pstate, Node *node,
 		}
 		else
 		{
-			int32		baseTypeMod;
+			int32		baseTypeMod,
+					typmod = -1;
+
+			if (exprTypmod_hook && typmod == -1)
+					typmod = (*exprTypmod_hook)(NULL, node);
 
 			/*
 			 * targetTypeMod is allowed for a domain only if enable_domain_typmod
@@ -511,10 +515,6 @@ coerce_type(ParseState *pstate, Node *node,
 									  false);
 			if (result == node)
 			{
-				int32	typmod = -1;
-
-				if (exprTypmod_hook && typmod == -1)
-					typmod = (*exprTypmod_hook)(NULL, node);
 				/*
 				 * XXX could we label result with exprTypmod(node) instead of
 				 * default -1 typmod, to save a possible length-coercion

--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -488,9 +488,9 @@ coerce_type(ParseState *pstate, Node *node,
 		else
 		{
 			int32		baseTypeMod,
-					typmod = -1;
+						typmod = -1;
 
-			if (exprTypmod_hook && typmod == -1)
+			if (exprTypmod_hook)
 					typmod = (*exprTypmod_hook)(NULL, node);
 
 			/*

--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -511,6 +511,10 @@ coerce_type(ParseState *pstate, Node *node,
 									  false);
 			if (result == node)
 			{
+				int32	typmod = -1;
+
+				if (exprTypmod_hook && typmod == -1)
+					typmod = (*exprTypmod_hook)(NULL, node);
 				/*
 				 * XXX could we label result with exprTypmod(node) instead of
 				 * default -1 typmod, to save a possible length-coercion
@@ -518,7 +522,7 @@ coerce_type(ParseState *pstate, Node *node,
 				 * typmod, which is likely but not certain.
 				 */
 				RelabelType *r = makeRelabelType((Expr *) result,
-												 targetTypeId, -1,
+												 targetTypeId, typmod,
 												 InvalidOid,
 												 cformat);
 


### PR DESCRIPTION
### Description

- added typmod handling for `RelabelType` Node .


### Issues Resolved

Task: BABEL-5976

Signed-off-by: yashneet vinayak <yashneet@amazon.com>

extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3953

### Test Scenarios Covered ###
* **Use case based -**


* **Boundary conditions -**


* **Arbitrary inputs -**


* **Negative test cases -**


* **Minor version upgrade tests -**


* **Major version upgrade tests -**


* **Performance tests -**


* **Tooling impact -**


* **Client tests -**



### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 and PostgreSQL licenses, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/babelfish_extensions/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).