### PR TITLE
Support for weak binding views to allow dropping of underlying objects 4_7_STABLE

### DIFF
--- a/src/backend/commands/dropcmds.c
+++ b/src/backend/commands/dropcmds.c
@@ -19,11 +19,13 @@
 #include "access/xact.h"
 #include "catalog/dependency.h"
 #include "catalog/namespace.h"
+#include "catalog/objectaccess.h"
 #include "catalog/objectaddress.h"
 #include "catalog/pg_class.h"
 #include "catalog/pg_namespace.h"
 #include "catalog/pg_proc.h"
 #include "commands/defrem.h"
+#include "commands/tablecmds.h"
 #include "miscadmin.h"
 #include "nodes/makefuncs.h"
 #include "parser/parser.h"
@@ -136,6 +138,11 @@ RemoveObjects(DropStmt *stmt)
 			table_close(relation, NoLock);
 
 		add_exact_object_address(&address, objects);
+
+		if (object_access_hook && (stmt->removeType == OBJECT_FUNCTION) && sql_dialect == SQL_DIALECT_TSQL)
+		{
+			InvokeObjectDropHook(ProcedureRelationId, address.objectId, -1);
+		}
 	}
 
 	/* Here we really delete them. */

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -1558,7 +1558,7 @@ RemoveRelations(DropStmt *drop)
 		* the trigger - we create it internally, and so the table cannot be dropped
 		* if there is a tsql trigger on it because of the dependency of the function.
 		*/
-		if (object_access_hook && drop->removeType == OBJECT_TABLE)
+		if (object_access_hook && (drop->removeType == OBJECT_TABLE || drop->removeType == OBJECT_VIEW))
 		{
 			InvokeObjectDropHook(RelationRelationId,relOid,0);
 		}

--- a/src/backend/commands/view.c
+++ b/src/backend/commands/view.c
@@ -530,3 +530,13 @@ StoreViewQuery(Oid viewOid, Query *viewParse, bool replace)
 	 */
 	DefineViewRules(viewOid, viewParse, replace);
 }
+
+/*
+ * Wrapper function for DefineVirtualRelation used by Babelfish view repair
+ */
+ObjectAddress
+bbf_define_virtual_relation(RangeVar *relation, List *tlist, bool replace,
+							List *options, Query *viewParse)
+{
+    return DefineVirtualRelation(relation, tlist, replace, options, viewParse);
+}

--- a/src/backend/rewrite/rewriteHandler.c
+++ b/src/backend/rewrite/rewriteHandler.c
@@ -48,6 +48,7 @@
 #include "utils/rel.h"
 
 bbfViewHasInsteadofTrigger_hook_type bbfViewHasInsteadofTrigger_hook = NULL; /** BBF Hook to check Instead Of trigger on View */
+pre_QueryRewrite_hook_type pre_QueryRewrite_hook = NULL;
 
 /* We use a list of these to detect recursion in RewriteQuery */
 typedef struct rewrite_event
@@ -4271,6 +4272,8 @@ QueryRewrite(Query *parsetree)
 	Assert(parsetree->querySource == QSRC_ORIGINAL);
 	Assert(parsetree->canSetTag);
 
+	if (pre_QueryRewrite_hook)
+		(*pre_QueryRewrite_hook) (parsetree);
 	/*
 	 * Step 1
 	 *

--- a/src/include/commands/view.h
+++ b/src/include/commands/view.h
@@ -27,4 +27,8 @@ extern PGDLLEXPORT store_view_definition_hook_type	store_view_definition_hook;
 
 typedef void (*inherit_view_constraints_from_table_hook_type) (ColumnDef  *col, Oid tableOid, AttrNumber colId);
 extern PGDLLEXPORT inherit_view_constraints_from_table_hook_type inherit_view_constraints_from_table_hook;
+
+extern ObjectAddress bbf_define_virtual_relation(RangeVar *relation, List *tlist, bool replace,
+												 List *options, Query *viewParse);
+
 #endif							/* VIEW_H */

--- a/src/include/rewrite/rewriteHandler.h
+++ b/src/include/rewrite/rewriteHandler.h
@@ -32,4 +32,8 @@ extern int	relation_is_updatable(Oid reloid,
 								  bool include_triggers,
 								  Bitmapset *include_cols);
 
+/* View repair hook */
+typedef bool (*pre_QueryRewrite_hook_type) (Query *parsetree);
+extern PGDLLEXPORT pre_QueryRewrite_hook_type pre_QueryRewrite_hook;									 
+
 #endif							/* REWRITEHANDLER_H */


### PR DESCRIPTION
cherry-picked from PR: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/585
 
### Issues Resolved

BABEL-1660
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
