### PR TITLE
Dump Babelfish operator classes for numeric-fixeddecimal comparisons to support index scan

### DIFF
--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -1778,8 +1778,8 @@ babelfishDumpOpclassHelper(Archive *fout, const OpclassInfo *opcinfo, PQExpBuffe
 		pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"numeric_int4_ops\"" : "sys.numeric_int4_ops") != 0 &&
 		pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"int8_numeric_ops\"" : "sys.int8_numeric_ops") != 0 &&
 		pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"numeric_int8_ops\"" : "sys.numeric_int8_ops") != 0 &&
-		pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"numeric_fixeddecimal_ops\"" : "sys.numeric_fixeddecimal_ops") != 0 &&
-		pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"fixeddecimal_numeric_ops\"" : "sys.fixeddecimal_numeric_ops") != 0)
+		pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"numeric_fixeddecimal_cmp_ops\"" : "sys.numeric_fixeddecimal_cmp_ops") != 0 &&
+		pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"fixeddecimal_numeric_cmp_ops\"" : "sys.fixeddecimal_numeric_cmp_ops") != 0)
 		return;
 
 	query = createPQExpBuffer();
@@ -1924,7 +1924,7 @@ babelfishDumpOpclassHelper(Archive *fout, const OpclassInfo *opcinfo, PQExpBuffe
 				"FUNCTION 1 sys.numeric_int8_cmp(numeric, int8) ";
 	}
 
-	if (pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"numeric_fixeddecimal_ops\"" : "sys.numeric_fixeddecimal_ops") == 0)
+	if (pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"numeric_fixeddecimal_cmp_ops\"" : "sys.numeric_fixeddecimal_cmp_ops") == 0)
 	{
 		str = quote_all_identifiers ?
 				"OPERATOR 1 \"sys\".< (numeric, \"sys\".\"fixeddecimal\") ,\n	"
@@ -1941,7 +1941,7 @@ babelfishDumpOpclassHelper(Archive *fout, const OpclassInfo *opcinfo, PQExpBuffe
 				"FUNCTION 1 sys.numeric_fixeddecimal_cmp(numeric, sys.fixeddecimal) ";
 	}
 
-	if (pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"fixeddecimal_numeric_ops\"" : "sys.fixeddecimal_numeric_ops") == 0)
+	if (pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"fixeddecimal_numeric_cmp_ops\"" : "sys.fixeddecimal_numeric_cmp_ops") == 0)
 	{
 		str = quote_all_identifiers ?
 				"OPERATOR 1 \"sys\".< (\"sys\".\"fixeddecimal\", numeric) ,\n	"

--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -1777,7 +1777,9 @@ babelfishDumpOpclassHelper(Archive *fout, const OpclassInfo *opcinfo, PQExpBuffe
 		pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"int4_numeric_ops\"" : "sys.int4_numeric_ops") != 0 &&
 		pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"numeric_int4_ops\"" : "sys.numeric_int4_ops") != 0 &&
 		pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"int8_numeric_ops\"" : "sys.int8_numeric_ops") != 0 &&
-		pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"numeric_int8_ops\"" : "sys.numeric_int8_ops") != 0)
+		pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"numeric_int8_ops\"" : "sys.numeric_int8_ops") != 0 &&
+		pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"numeric_fixeddecimal_ops\"" : "sys.numeric_fixeddecimal_ops") != 0 &&
+		pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"fixeddecimal_numeric_ops\"" : "sys.fixeddecimal_numeric_ops") != 0)
 		return;
 
 	query = createPQExpBuffer();
@@ -1920,6 +1922,40 @@ babelfishDumpOpclassHelper(Archive *fout, const OpclassInfo *opcinfo, PQExpBuffe
 				"OPERATOR 4 sys.>= (numeric, int8) ,\n	"
 				"OPERATOR 5 sys.> (numeric, int8) ,\n	"
 				"FUNCTION 1 sys.numeric_int8_cmp(numeric, int8) ";
+	}
+
+	if (pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"numeric_fixeddecimal_ops\"" : "sys.numeric_fixeddecimal_ops") == 0)
+	{
+		str = quote_all_identifiers ?
+				"OPERATOR 1 \"sys\".< (numeric, fixeddecimal) ,\n	"
+				"OPERATOR 2 \"sys\".<= (numeric, fixeddecimal) ,\n	"
+				"OPERATOR 3 \"sys\".= (numeric, fixeddecimal) ,\n	"
+				"OPERATOR 4 \"sys\".>= (numeric, fixeddecimal) ,\n	"
+				"OPERATOR 5 \"sys\".> (numeric, fixeddecimal) ,\n	"
+				"FUNCTION 1 \"sys\".\"numeric_fixeddecimal_cmp\"(numeric, fixeddecimal) " :
+				"OPERATOR 1 sys.< (numeric, fixeddecimal) ,\n	"
+				"OPERATOR 2 sys.<= (numeric, fixeddecimal) ,\n	"
+				"OPERATOR 3 sys.= (numeric, fixeddecimal) ,\n	"
+				"OPERATOR 4 sys.>= (numeric, fixeddecimal) ,\n	"
+				"OPERATOR 5 sys.> (numeric, fixeddecimal) ,\n	"
+				"FUNCTION 1 sys.numeric_fixeddecimal_cmp(numeric, fixeddecimal) ";
+	}
+
+	if (pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"fixeddecimal_numeric_ops\"" : "sys.fixeddecimal_numeric_ops") == 0)
+	{
+		str = quote_all_identifiers ?
+				"OPERATOR 1 \"sys\".< (fixeddecimal, numeric) ,\n	"
+				"OPERATOR 2 \"sys\".<= (fixeddecimal, numeric) ,\n	"
+				"OPERATOR 3 \"sys\".= (fixeddecimal, numeric) ,\n	"
+				"OPERATOR 4 \"sys\".>= (fixeddecimal, numeric) ,\n	"
+				"OPERATOR 5 \"sys\".> (fixeddecimal, numeric) ,\n	"
+				"FUNCTION 1 \"sys\".\"fixeddecimal_numeric_cmp\"(fixeddecimal, numeric) " :
+				"OPERATOR 1 sys.< (fixeddecimal, numeric) ,\n	"
+				"OPERATOR 2 sys.<= (fixeddecimal, numeric) ,\n	"
+				"OPERATOR 3 sys.= (fixeddecimal, numeric) ,\n	"
+				"OPERATOR 4 sys.>= (fixeddecimal, numeric) ,\n	"
+				"OPERATOR 5 sys.> (fixeddecimal, numeric) ,\n	"
+				"FUNCTION 1 sys.fixeddecimal_numeric_cmp(fixeddecimal, numeric) ";
 	}
 
 	if(str != NULL)

--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -1927,35 +1927,35 @@ babelfishDumpOpclassHelper(Archive *fout, const OpclassInfo *opcinfo, PQExpBuffe
 	if (pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"numeric_fixeddecimal_ops\"" : "sys.numeric_fixeddecimal_ops") == 0)
 	{
 		str = quote_all_identifiers ?
-				"OPERATOR 1 \"sys\".< (numeric, fixeddecimal) ,\n	"
-				"OPERATOR 2 \"sys\".<= (numeric, fixeddecimal) ,\n	"
-				"OPERATOR 3 \"sys\".= (numeric, fixeddecimal) ,\n	"
-				"OPERATOR 4 \"sys\".>= (numeric, fixeddecimal) ,\n	"
-				"OPERATOR 5 \"sys\".> (numeric, fixeddecimal) ,\n	"
-				"FUNCTION 1 \"sys\".\"numeric_fixeddecimal_cmp\"(numeric, fixeddecimal) " :
-				"OPERATOR 1 sys.< (numeric, fixeddecimal) ,\n	"
-				"OPERATOR 2 sys.<= (numeric, fixeddecimal) ,\n	"
-				"OPERATOR 3 sys.= (numeric, fixeddecimal) ,\n	"
-				"OPERATOR 4 sys.>= (numeric, fixeddecimal) ,\n	"
-				"OPERATOR 5 sys.> (numeric, fixeddecimal) ,\n	"
-				"FUNCTION 1 sys.numeric_fixeddecimal_cmp(numeric, fixeddecimal) ";
+				"OPERATOR 1 \"sys\".< (numeric, \"sys\".\"fixeddecimal\") ,\n	"
+				"OPERATOR 2 \"sys\".<= (numeric, \"sys\".\"fixeddecimal\") ,\n	"
+				"OPERATOR 3 \"sys\".= (numeric, \"sys\".\"fixeddecimal\") ,\n	"
+				"OPERATOR 4 \"sys\".>= (numeric, \"sys\".\"fixeddecimal\") ,\n	"
+				"OPERATOR 5 \"sys\".> (numeric, \"sys\".\"fixeddecimal\") ,\n	"
+				"FUNCTION 1 \"sys\".\"numeric_fixeddecimal_cmp\"(numeric, \"sys\".\"fixeddecimal\") " :
+				"OPERATOR 1 sys.< (numeric, sys.fixeddecimal) ,\n	"
+				"OPERATOR 2 sys.<= (numeric, sys.fixeddecimal) ,\n	"
+				"OPERATOR 3 sys.= (numeric, sys.fixeddecimal) ,\n	"
+				"OPERATOR 4 sys.>= (numeric, sys.fixeddecimal) ,\n	"
+				"OPERATOR 5 sys.> (numeric, sys.fixeddecimal) ,\n	"
+				"FUNCTION 1 sys.numeric_fixeddecimal_cmp(numeric, sys.fixeddecimal) ";
 	}
 
 	if (pg_strcasecmp(opclass, quote_all_identifiers ? "\"sys\".\"fixeddecimal_numeric_ops\"" : "sys.fixeddecimal_numeric_ops") == 0)
 	{
 		str = quote_all_identifiers ?
-				"OPERATOR 1 \"sys\".< (fixeddecimal, numeric) ,\n	"
-				"OPERATOR 2 \"sys\".<= (fixeddecimal, numeric) ,\n	"
-				"OPERATOR 3 \"sys\".= (fixeddecimal, numeric) ,\n	"
-				"OPERATOR 4 \"sys\".>= (fixeddecimal, numeric) ,\n	"
-				"OPERATOR 5 \"sys\".> (fixeddecimal, numeric) ,\n	"
-				"FUNCTION 1 \"sys\".\"fixeddecimal_numeric_cmp\"(fixeddecimal, numeric) " :
-				"OPERATOR 1 sys.< (fixeddecimal, numeric) ,\n	"
-				"OPERATOR 2 sys.<= (fixeddecimal, numeric) ,\n	"
-				"OPERATOR 3 sys.= (fixeddecimal, numeric) ,\n	"
-				"OPERATOR 4 sys.>= (fixeddecimal, numeric) ,\n	"
-				"OPERATOR 5 sys.> (fixeddecimal, numeric) ,\n	"
-				"FUNCTION 1 sys.fixeddecimal_numeric_cmp(fixeddecimal, numeric) ";
+				"OPERATOR 1 \"sys\".< (\"sys\".\"fixeddecimal\", numeric) ,\n	"
+				"OPERATOR 2 \"sys\".<= (\"sys\".\"fixeddecimal\", numeric) ,\n	"
+				"OPERATOR 3 \"sys\".= (\"sys\".\"fixeddecimal\", numeric) ,\n	"
+				"OPERATOR 4 \"sys\".>= (\"sys\".\"fixeddecimal\", numeric) ,\n	"
+				"OPERATOR 5 \"sys\".> (\"sys\".\"fixeddecimal\", numeric) ,\n	"
+				"FUNCTION 1 \"sys\".\"fixeddecimal_numeric_cmp\"(\"sys\".\"fixeddecimal\", numeric) " :
+				"OPERATOR 1 sys.< (sys.fixeddecimal, numeric) ,\n	"
+				"OPERATOR 2 sys.<= (sys.fixeddecimal, numeric) ,\n	"
+				"OPERATOR 3 sys.= (sys.fixeddecimal, numeric) ,\n	"
+				"OPERATOR 4 sys.>= (sys.fixeddecimal, numeric) ,\n	"
+				"OPERATOR 5 sys.> (sys.fixeddecimal, numeric) ,\n	"
+				"FUNCTION 1 sys.fixeddecimal_numeric_cmp(sys.fixeddecimal, numeric) ";
 	}
 
 	if(str != NULL)


### PR DESCRIPTION
### Description

[Describe what this change achieves]
 
### Issues Resolved

[List any issues this PR will resolve]
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
