### PR TITLE
[BABEL-5939] Remove custom 'createOrAlter' field in ViewStmt 

### DIFF
--- a/src/backend/parser/gram.y
+++ b/src/backend/parser/gram.y
@@ -11245,7 +11245,6 @@ ViewStmt: CREATE OptTemp VIEW qualified_name opt_column_list opt_reloptions
 					n->replace = false;
 					n->options = $6;
 					n->withCheckOption = $9;
-					n->createOrAlter = false;
 					$$ = (Node *) n;
 				}
 		| CREATE OR REPLACE OptTemp VIEW qualified_name opt_column_list opt_reloptions
@@ -11260,7 +11259,6 @@ ViewStmt: CREATE OptTemp VIEW qualified_name opt_column_list opt_reloptions
 					n->replace = true;
 					n->options = $8;
 					n->withCheckOption = $11;
-					n->createOrAlter = false;
 					$$ = (Node *) n;
 				}
 		| CREATE OptTemp RECURSIVE VIEW qualified_name '(' columnList ')' opt_reloptions
@@ -11280,7 +11278,6 @@ ViewStmt: CREATE OptTemp VIEW qualified_name opt_column_list opt_reloptions
 								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 								 errmsg("WITH CHECK OPTION not supported on recursive views"),
 								 parser_errposition(@12)));
-					n->createOrAlter = false;
 					$$ = (Node *) n;
 				}
 		| CREATE OR REPLACE OptTemp RECURSIVE VIEW qualified_name '(' columnList ')' opt_reloptions
@@ -11300,7 +11297,6 @@ ViewStmt: CREATE OptTemp VIEW qualified_name opt_column_list opt_reloptions
 								(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
 								 errmsg("WITH CHECK OPTION not supported on recursive views"),
 								 parser_errposition(@14)));
-					n->createOrAlter = false;
 					$$ = (Node *) n;
 				}
 		;

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -3782,9 +3782,6 @@ typedef struct ViewStmt
 	bool		replace;		/* replace an existing view? */
 	List	   *options;		/* options from WITH clause */
 	ViewCheckOption withCheckOption;	/* WITH CHECK OPTION */
-	bool        createOrAlter;  /* is query 'create view' or 'create or alter view' or 'alter view' */
-                                /* flag is set in gram-tsql-rule.y and gram.y */
-
 } ViewStmt;
 
 /* ----------------------


### PR DESCRIPTION
This PR removes a custom field that was added to the core PostgreSQL ViewStmt structure for supporting T-SQL ALTER VIEW operations. Previously, we added a `createOrAlter` boolean field to the ViewStmt structure to identify T-SQL `ALTER VIEW` operations. Instead of extending core structures, we'll use the `Viewstmt->options` list to determine T-SQL `ALTER VIEW` and `CREATE OR ALTER VIEW` operations

Corresponding extension PR - https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/3977

PR that introduced createOrAlter field - https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/545

### Issues Resolved

BABEL-5939

Signed off by: Rahul Parande rparande@amazon.com
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
