### PR TITLE
Throw arithmetic overflow error while casting from higher to lower integral digits

### DIFF
--- a/src/backend/nodes/nodeFuncs.c
+++ b/src/backend/nodes/nodeFuncs.c
@@ -36,6 +36,7 @@ static bool planstate_walk_members(PlanState **planstates, int nplans,
 
 coalesce_typmod_hook_type coalesce_typmod_hook = NULL;
 exprTypmod_hook_type exprTypmod_hook = NULL;
+numeric_overflow_error_hook_type numeric_overflow_error_hook = NULL;
 
 /*
  *	exprType -
@@ -657,6 +658,10 @@ applyRelabelType(Node *arg, Oid rtype, int32 rtypmod, Oid rcollid,
 		if (!overwrite_ok)
 			con = copyObject(con);
 		con->consttype = rtype;
+		
+		if (numeric_overflow_error_hook)
+			numeric_overflow_error_hook(con, rtype, rtypmod);
+
 		con->consttypmod = rtypmod;
 		con->constcollid = rcollid;
 		/* We keep the Const's original location. */

--- a/src/include/nodes/nodeFuncs.h
+++ b/src/include/nodes/nodeFuncs.h
@@ -226,4 +226,7 @@ extern PGDLLEXPORT coalesce_typmod_hook_type coalesce_typmod_hook;
 typedef int32 (*exprTypmod_hook_type)(Plan *plan, Node *expr);
 extern PGDLLIMPORT exprTypmod_hook_type exprTypmod_hook;
 
+typedef void (*numeric_overflow_error_hook_type)(Const *con, Oid rtype, int32 rtypmod);
+extern PGDLLIMPORT numeric_overflow_error_hook_type numeric_overflow_error_hook;
+
 #endif							/* NODEFUNCS_H */


### PR DESCRIPTION
Signed-off-by: Yashneet Vinayak <>

### Description

[Describe what this change achieves]
 
### Issues Resolved

[List any issues this PR will resolve]
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
