### PR TITLE
Ownership Chaining: Support relation references inside views

### DIFF
--- a/src/backend/optimizer/util/clauses.c
+++ b/src/backend/optimizer/util/clauses.c
@@ -2623,6 +2623,8 @@ eval_const_expressions_mutator(Node *node,
 				newexpr->inputcollid = expr->inputcollid;
 				newexpr->args = args;
 				newexpr->location = expr->location;
+				newexpr->parentOwnerId = expr->parentOwnerId;
+				newexpr->insideView = expr->insideView;
 				return (Node *) newexpr;
 			}
 		case T_OpExpr:

--- a/src/backend/rewrite/rewriteHandler.c
+++ b/src/backend/rewrite/rewriteHandler.c
@@ -48,6 +48,7 @@
 
 bbfViewHasInsteadofTrigger_hook_type bbfViewHasInsteadofTrigger_hook = NULL; /** BBF Hook to check Instead Of trigger on View */
 pre_QueryRewrite_hook_type pre_QueryRewrite_hook = NULL;
+walk_view_rule_hook_type walk_view_rule_hook = NULL;
 
 /* We use a list of these to detect recursion in RewriteQuery */
 typedef struct rewrite_event
@@ -1812,6 +1813,9 @@ ApplyRetrieveRule(Query *parsetree,
 	rule_action = copyObject(linitial(rule->actions));
 
 	AcquireRewriteLocks(rule_action, true, (rc != NULL));
+
+	if (walk_view_rule_hook)
+		walk_view_rule_hook(rule_action, relation->rd_rel->relowner);
 
 	/*
 	 * If FOR [KEY] UPDATE/SHARE of view, mark all the contained tables as

--- a/src/backend/rewrite/rewriteHandler.c
+++ b/src/backend/rewrite/rewriteHandler.c
@@ -49,6 +49,7 @@
 bbfViewHasInsteadofTrigger_hook_type bbfViewHasInsteadofTrigger_hook = NULL; /** BBF Hook to check Instead Of trigger on View */
 pre_QueryRewrite_hook_type pre_QueryRewrite_hook = NULL;
 walk_view_rule_hook_type walk_view_rule_hook = NULL;
+handle_target_view_hook_type handle_target_view_hook = NULL;
 
 /* We use a list of these to detect recursion in RewriteQuery */
 typedef struct rewrite_event
@@ -3561,6 +3562,8 @@ rewriteTargetView(Query *parsetree, Relation view)
 	new_rte->securityQuals = view_rte->securityQuals;
 	view_rte->securityQuals = NIL;
 
+	if (handle_target_view_hook)
+		handle_target_view_hook(new_perminfo, view_rte);
 	/*
 	 * Now update all Vars in the outer query that reference the view to
 	 * reference the appropriate column of the base relation instead.

--- a/src/backend/rewrite/rewriteHandler.c
+++ b/src/backend/rewrite/rewriteHandler.c
@@ -3563,7 +3563,7 @@ rewriteTargetView(Query *parsetree, Relation view)
 	view_rte->securityQuals = NIL;
 
 	if (handle_target_view_hook)
-		handle_target_view_hook(new_perminfo, view_rte);
+		handle_target_view_hook(new_perminfo, view_rte, view->rd_rel->relowner, base_rel->rd_rel->relowner);
 	/*
 	 * Now update all Vars in the outer query that reference the view to
 	 * reference the appropriate column of the base relation instead.

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -114,6 +114,9 @@ extern PGDLLEXPORT check_rowcount_hook_type check_rowcount_hook;
 typedef bool (*ExecCheckOneRelPerms_hook_type) (RTEPermissionInfo *perminfo);
 extern PGDLLEXPORT ExecCheckOneRelPerms_hook_type ExecCheckOneRelPerms_hook;
 
+typedef void (*walk_view_rule_hook_type) (Query *rule_action, Oid view_owner);
+extern PGDLLEXPORT walk_view_rule_hook_type walk_view_rule_hook;
+
 /*
  * prototypes from functions in execAmi.c
  */

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -114,9 +114,6 @@ extern PGDLLEXPORT check_rowcount_hook_type check_rowcount_hook;
 typedef bool (*ExecCheckOneRelPerms_hook_type) (RTEPermissionInfo *perminfo);
 extern PGDLLEXPORT ExecCheckOneRelPerms_hook_type ExecCheckOneRelPerms_hook;
 
-typedef void (*walk_view_rule_hook_type) (Query *rule_action, Oid view_owner);
-extern PGDLLEXPORT walk_view_rule_hook_type walk_view_rule_hook;
-
 /*
  * prototypes from functions in execAmi.c
  */

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -1297,6 +1297,8 @@ typedef struct RTEPermissionInfo
 	Bitmapset  *selectedCols;	/* columns needing SELECT permission */
 	Bitmapset  *insertedCols;	/* columns needing INSERT permission */
 	Bitmapset  *updatedCols;	/* columns needing UPDATE permission */
+	/* For Babelfish Ownership Chaining support */
+	int			insideView pg_node_attr(equal_ignore, query_jumble_ignore, read_write_ignore, read_as(0));
 } RTEPermissionInfo;
 
 /*

--- a/src/include/nodes/primnodes.h
+++ b/src/include/nodes/primnodes.h
@@ -768,6 +768,9 @@ typedef struct FuncExpr
 	List	   *args;
 	/* token location, or -1 if unknown */
 	ParseLoc	location;
+	/* For Babelfish Ownership Chaining support */
+	Oid			parentOwnerId pg_node_attr(equal_ignore, query_jumble_ignore, read_write_ignore, read_as(0));
+	int			insideView pg_node_attr(equal_ignore, query_jumble_ignore, read_write_ignore, read_as(0));
 } FuncExpr;
 
 /*

--- a/src/include/rewrite/rewriteHandler.h
+++ b/src/include/rewrite/rewriteHandler.h
@@ -40,6 +40,12 @@ extern void error_view_not_updatable(Relation view,
 
 /* View repair hook */
 typedef bool (*pre_QueryRewrite_hook_type) (Query *parsetree);
-extern PGDLLEXPORT pre_QueryRewrite_hook_type pre_QueryRewrite_hook;									 
+extern PGDLLEXPORT pre_QueryRewrite_hook_type pre_QueryRewrite_hook;
+
+typedef void (*walk_view_rule_hook_type) (Query *rule_action, Oid view_owner);
+extern PGDLLEXPORT walk_view_rule_hook_type walk_view_rule_hook;
+
+typedef void (*handle_target_view_hook_type) (RTEPermissionInfo *new_perminfo, RangeTblEntry *view_rte);
+extern PGDLLEXPORT handle_target_view_hook_type handle_target_view_hook;
 
 #endif							/* REWRITEHANDLER_H */

--- a/src/include/rewrite/rewriteHandler.h
+++ b/src/include/rewrite/rewriteHandler.h
@@ -45,7 +45,7 @@ extern PGDLLEXPORT pre_QueryRewrite_hook_type pre_QueryRewrite_hook;
 typedef void (*walk_view_rule_hook_type) (Query *rule_action, Oid view_owner);
 extern PGDLLEXPORT walk_view_rule_hook_type walk_view_rule_hook;
 
-typedef void (*handle_target_view_hook_type) (RTEPermissionInfo *new_perminfo, RangeTblEntry *view_rte);
+typedef void (*handle_target_view_hook_type) (RTEPermissionInfo *new_perminfo, RangeTblEntry *view_rte, Oid view_owner, Oid base_rel_owner);
 extern PGDLLEXPORT handle_target_view_hook_type handle_target_view_hook;
 
 #endif							/* REWRITEHANDLER_H */


### PR DESCRIPTION
### Description

This commit implements the ownership chaining support for table/view object 
references inside view. The basic idea of Ownership chaining is that when 
one object references another, and both have the same owner, then permissions 
are only checked when the top-level object is accessed.

The scope of the current commit is to only support scenarios when parent 
object is view and child objects are table/view. "[parent] view -> [child] 
function" scenarios is out-of-scope for this effort.

Implementation:
- Add infrastructure changes to support ownership tracking:
  * insideView flag in RTEPermissionInfo for view context tracking
  * parentOwnerId and insideView fields in FuncExpr (for future use)
  * walk_view_rule_hook for extension-specific view rule processing and 
     apply view context marking in ApplyRetrieveRule

- Add walker to traverse view definition parse trees:
  * Mark relations and functions inside views for permission checking
  * Set checkAsUser to view_owner for owned relations to enable chaining
  * Track view context using insideView flag
  * Only applies to user-defined objects created in non-shared schemas in TSQL mode

This enables proper ownership chaining behavior where tables and 
views owned by the view owner can be accessed through the view.

Note: While infrastructure for function ownership chaining is included, 
the actual implementation of function ownership chaining is out of scope 
for this commit.
 
### Issues Resolved

BABEL-6026
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
