### PR TITLE
Fix Invalid read of size 2 in numeric_add.

### DIFF
--- a/src/backend/utils/adt/numeric.c
+++ b/src/backend/utils/adt/numeric.c
@@ -2926,7 +2926,7 @@ numeric_add_opt_error(Numeric num1, Numeric num2, bool *have_error)
 	init_var(&result);
 	add_var(&arg1, &arg2, &result);
 
-	if (detect_numeric_overflow_hook && result.digits &&
+	if (detect_numeric_overflow_hook && result.digits && result.ndigits > 0 &&
 	    (*detect_numeric_overflow_hook)(result.weight, result.dscale, result.digits[0], DEC_DIGITS))
 		ereport(ERROR,
 				(errcode(ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE),


### PR DESCRIPTION
### Description

This commit fixes the nvalid read of size 2 in `numeric_add_opt_error` by checking if `result.ndigits > 0` before calling `result.digits[0]`.
 
### Issues Resolved

Task: BABEL-5945

cherry-pick from https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/618

Signed-off-by: yashneet vinayak [yashneet@amazon.com](mailto:yashneet@amazon.com)
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
