### PR TITLE
[BABEL-6046] Added wrapper functions that can be used to call corresponding xml functions

### DIFF
--- a/src/backend/utils/adt/xml.c
+++ b/src/backend/utils/adt/xml.c
@@ -5114,3 +5114,28 @@ XmlTableDestroyOpaque(TableFuncScanState *state)
 	NO_XML_SUPPORT();
 #endif							/* not USE_LIBXML */
 }
+
+#ifdef USE_LIBXML
+xmlDocPtr
+xml_parse_wrapper(text *data, XmlOptionType xmloption_arg,
+		  bool preserve_whitespace, int encoding,
+		  XmlOptionType *parsed_xmloptiontype, xmlNodePtr *parsed_nodes,
+		  Node *escontext)
+{
+	return xml_parse(data, xmloption_arg, preserve_whitespace,
+					encoding, parsed_xmloptiontype, parsed_nodes, escontext);
+}
+
+xmlChar *
+pg_xmlCharStrndup_wrapper(const char *str, size_t len)
+{
+	return pg_xmlCharStrndup(str, len);
+}
+
+int
+parse_xml_decl_wrapper(const xmlChar *str, size_t *lenp,
+						   xmlChar **version, xmlChar **encoding, int *standalone)
+{
+	return parse_xml_decl(str, lenp, version, encoding, standalone);
+}
+#endif							/* USE_LIBXML */

--- a/src/include/utils/xml.h
+++ b/src/include/utils/xml.h
@@ -19,6 +19,9 @@
 #include "fmgr.h"
 #include "nodes/execnodes.h"
 #include "nodes/primnodes.h"
+#ifdef USE_LIBXML
+#include <libxml/tree.h>
+#endif
 
 typedef struct varlena xmltype;
 
@@ -84,6 +87,16 @@ extern char *escape_xml(const char *str);
 extern char *map_sql_identifier_to_xml_name(const char *ident, bool fully_escaped, bool escape_period);
 extern char *map_xml_name_to_sql_identifier(const char *name);
 extern char *map_sql_value_to_xml_value(Datum value, Oid type, bool xml_escape_strings);
+
+#ifdef USE_LIBXML
+extern xmlDocPtr xml_parse_wrapper(text *data, XmlOptionType xmloption_arg,
+							bool preserve_whitespace, int encoding,
+							XmlOptionType *parsed_xmloptiontype, xmlNodePtr *parsed_nodes,
+							Node *escontext);
+extern xmlChar *pg_xmlCharStrndup_wrapper(const char *str, size_t len);
+extern int parse_xml_decl_wrapper(const xmlChar *str, size_t *lenp,
+						   xmlChar **version, xmlChar **encoding, int *standalone);
+#endif							/* USE_LIBXML */
 
 extern PGDLLIMPORT int xmlbinary;	/* XmlBinaryType, but int for guc enum */
 


### PR DESCRIPTION
### Description
To add support for OPENXML without WITH clause in Babelfish, we need following functions 
* xml_parse
* pg_xmlCharStrndup
* parse_xml_decl

although these functions are defined as static. To use them in Babelfish, added wrapper function which will internally call these functions and return the result.

Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4091

Authored-by: Rohit Bhagat [rohitbgt@amazon.com](mailto:rohitbgt@amazon.com)
Signed-off-by: Rohit Bhagat [rohitbgt@amazon.com](mailto:rohitbgt@amazon.com)
 
### Issues Resolved

BABEL-6046
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
