### PR TITLE
Support select Top N Percent

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -92,8 +92,9 @@ pre_transform_setop_sort_clause_hook_type pre_transform_setop_sort_clause_hook =
 /* Hook to transform TSQL pivot clause in select stmt */
 transform_pivot_clause_hook_type transform_pivot_clause_hook = NULL;
 
-/* Hook to transform TSQL unpivot clauses in select stmt */
-transform_unpivot_clause_hook_type transform_unpivot_clause_hook = NULL;
+/* Hook to transform TSQL unpivot, top N percent clauses in select stmt */
+transform_tsql_select_stmt_hook_type transform_tsql_select_stmt_hook = NULL;
+
 
 static Query *transformOptionalSelectInto(ParseState *pstate, Node *parseTree);
 static Query *transformDeleteStmt(ParseState *pstate, DeleteStmt *stmt);
@@ -1442,10 +1443,10 @@ transformSelectStmt(ParseState *pstate, SelectStmt *stmt)
 
 	qry->commandType = CMD_SELECT;
 
-	/* Unpack and process TSQL UNPIVOT nodes in stmt->fromClause, if present */
-	if(transform_unpivot_clause_hook)
+	/* Unpack and process TSQL UNPIVOT nodes in stmt->fromClause, Process Top N Percent, if present */
+	if(transform_tsql_select_stmt_hook)
 	{
-		(*transform_unpivot_clause_hook)(pstate, stmt);
+		(*transform_tsql_select_stmt_hook)(pstate, stmt);
 	}
 
 	/* process the WITH clause independently of all else */

--- a/src/include/nodes/nodes.h
+++ b/src/include/nodes/nodes.h
@@ -441,6 +441,7 @@ typedef enum LimitOption
 	LIMIT_OPTION_COUNT,			/* FETCH FIRST... ONLY */
 	LIMIT_OPTION_WITH_TIES,		/* FETCH FIRST... WITH TIES */
 	LIMIT_OPTION_DEFAULT,		/* No limit present */
+	LIMIT_OPTION_PERCENT,		/* FETCH FIRST... PERCENT FOR TSQL */
 } LimitOption;
 
 #endif							/* NODES_H */

--- a/src/include/parser/analyze.h
+++ b/src/include/parser/analyze.h
@@ -69,8 +69,9 @@ typedef void (*transform_pivot_clause_hook_type)(ParseState *pstate, SelectStmt 
 extern PGDLLEXPORT transform_pivot_clause_hook_type transform_pivot_clause_hook;
 
 /* Hook for transform unpivot clause in tsql select stmt */
-typedef void (*transform_unpivot_clause_hook_type)(ParseState *pstate, SelectStmt *stmt);
-extern PGDLLEXPORT transform_unpivot_clause_hook_type transform_unpivot_clause_hook;
+typedef void (*transform_tsql_select_stmt_hook_type)(ParseState *pstate, SelectStmt *stmt);
+extern PGDLLEXPORT transform_tsql_select_stmt_hook_type transform_tsql_select_stmt_hook;
+
 
 extern Query *parse_analyze_fixedparams(RawStmt *parseTree, const char *sourceText,
 										const Oid *paramTypes, int numParams, QueryEnvironment *queryEnv);


### PR DESCRIPTION
### Description
This PR implements comprehensive support for SELECT TOP N PERCENT syntax in Babelfish, addressing JIRA-BABEL-1358. The implementation adds percentage-based row limiting functionality to align with SQL Server behavior.

### Problem
Babelfish previously only supported SELECT TOP N (fixed count) but lacked support for SELECT TOP N PERCENT (percentage-based limiting), which is a commonly used SQL Server feature for selecting a percentage of rows from result sets.

### Related PR -
Extension Link - https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4111

### Solution

**Core Changes**

- [ ] **1. Grammar Extensions ( gram-tsql-rule.y)**
- Updated Grammer to support Percent Operator
- Also changed return type of tsql_top_clause node to selectLimit to match its behavior with postgres.

- [ ] **2. Parser Updates ( gram-tsql-epilogue.y.c)**
- Added a new field in LimitOption enum **"LIMIT_OPTION_PERCENT"** to represent Percent Op in TSQL.

- [ ] **3. Hook Implementation ( hooks.c)**
- Added error handling for unsupported UPDATE/DELETE/INSERT TOP N PERCENT
- Handled top N Percent by rewriting N -> select count(*) from parent_query
- handled group by by rewriting N -> select count(*) from (select groupby_cols from parent_query group by groupby_cols )

### Test Coverage
1. 43+ test cases covering all scenarios
2. Basic percentage operations (50%, 25%, 0%, 100%)
3. Edge cases (0.5%, 33.33% decimal precision)
4. Complex queries (JOINs, CTEs, window functions, subqueries)
5. FOR JSON integration 
6. Dependent Objects Test Case
7. UNION operations
8. Cross-schema functionality 
9. Error cases for UPDATE/DELETE TOP N PERCENT
10. Update/Delete/insert + Output clause
11.  Complex Update/Delete/insert top 100 percent

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
