### PR TITLE
Fix: Temp table indexes with name starting without '#' do not follow rollback semantics (#626)

### DIFF
--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1385,6 +1385,7 @@ heap_create_with_catalog(const char *relname,
 		strncpy(enr->md.name, relname, strlen(relname) + 1);
 		enr->md.reliddesc = relid;
 		enr->md.enrtype = ENR_TSQL_TEMP;
+		enr->md.parent_oid = InvalidOid;
 		register_ENR(currentQueryEnv, enr);
 		MemoryContextSwitchTo(oldcontext);
 	}

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -1002,6 +1002,7 @@ index_create(Relation heapRelation,
 		strncpy(enr->md.name, indexRelationName, strlen(indexRelationName) + 1);
 		enr->md.reliddesc = indexRelationId;
 		enr->md.enrtype = ENR_TSQL_TEMP;
+		enr->md.parent_oid = heapRelationId;
 		register_ENR(currentQueryEnv, enr);
 		MemoryContextSwitchTo(oldcontext);
 	}

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -3426,6 +3426,7 @@ SPI_register_trigger_data(TriggerData *tdata)
 		enr->md.enrtype = ENR_NAMED_TUPLESTORE;
 		enr->md.enrtuples = tuplestore_tuple_count(tdata->tg_newtable);
 		enr->reldata = tdata->tg_newtable;
+		enr->md.parent_oid = InvalidOid;
 		rc = SPI_register_relation(enr);
 		if (rc != SPI_OK_REL_REGISTER)
 			return rc;
@@ -3443,6 +3444,7 @@ SPI_register_trigger_data(TriggerData *tdata)
 		enr->md.enrtype = ENR_NAMED_TUPLESTORE;
 		enr->md.enrtuples = tuplestore_tuple_count(tdata->tg_oldtable);
 		enr->reldata = tdata->tg_oldtable;
+		enr->md.parent_oid = InvalidOid;
 		rc = SPI_register_relation(enr);
 		if (rc != SPI_OK_REL_REGISTER)
 			return rc;

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -212,10 +212,30 @@ register_ENR(QueryEnvironment *queryEnv, EphemeralNamedRelation enr)
 	Assert(enr != NULL);
 	Assert(get_ENR(queryEnv, enr->md.name, false) == NULL);
 
-	if (enr->md.name[0] == '#')
-		enr->md.is_bbf_temp_table = true;
-	else
-		enr->md.is_bbf_temp_table = false;
+	if (enr->md.parent_oid != InvalidOid)
+	{
+		/*
+		 * This is an index on a ENR temp object. We mark the flag by checking 
+		 * the parent relations flag.
+		 * If it is an implicit index over tsql table variable, it gets marked 
+		 * as false, same as parent since table variable don't follow transactional
+		 * semantics.
+		 */
+		EphemeralNamedRelation parent_enr = GetENRTempTableWithOid(enr->md.parent_oid);
+		if(parent_enr)
+			enr->md.is_bbf_temp_table = parent_enr->md.is_bbf_temp_table;
+		else
+			enr->md.is_bbf_temp_table = false;
+	} else {
+		/*
+		 * This is a table or some parent entity. If the name of this table
+		 * starts with '#', this is a tsql temp table.
+		 */
+		if (enr->md.name[0] == '#')
+			enr->md.is_bbf_temp_table = true;
+		else
+			enr->md.is_bbf_temp_table = false;
+	}
 
 	if (enr->md.is_bbf_temp_table && GetCurrentSubTransactionId() != InvalidSubTransactionId)
 		enr->md.created_subid = GetCurrentSubTransactionId();

--- a/src/include/utils/queryenvironment.h
+++ b/src/include/utils/queryenvironment.h
@@ -100,6 +100,8 @@ typedef struct EphemeralNamedRelationMetadataData
 	SubTransactionId dropped_subid;
 	/* List of uncommitted tuples. They must be processed on ROLLBACK, or cleared on commit. */
 	List		*uncommitted_cattups[ENR_CATTUP_END];
+	/* Maintain parent oid for tracking if child objects should follow transactional semantics based on parent nature */
+	Oid			parent_oid;
 } EphemeralNamedRelationMetadataData;
 
 typedef EphemeralNamedRelationMetadataData *EphemeralNamedRelationMetadata;


### PR DESCRIPTION
We use the is_bbf_temp_table flag in ENR metadata for transaction behaviour. Currently, we only mark this flag as true if the relname starts with '#', however all indexes on ENR temp tables should be have this flag set.
We are refactoring the register_ENR function and marking this flag early rather than in this method

Task: BABEL-6096, BABEL-5982

### Cherry pick - 6733da66333c8fe6525a671a5ad55e9ef1e53cbb
### Original PR - https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/626
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
