### PR TITLE
Fix: Rectified dialect check in ENRGetSystableScan function to also check for the conn_type

### DIFF
--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -52,8 +52,6 @@
 #include "utils/syscache.h"
 #include "utils/queryenvironment.h"
 #include "utils/rel.h"
-#include "libpq/libpq.h"
-#include "miscadmin.h"
 
 #define NUM_ENR_CATALOGS 11
 

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -51,8 +51,11 @@
 #include "utils/syscache.h"
 #include "utils/queryenvironment.h"
 #include "utils/rel.h"
+#include "libpq/libpq.h"
+#include "miscadmin.h"
 
 #define NUM_ENR_CATALOGS 11
+#define IS_TDS_CONN() (MyProcPort && MyProcPort->is_tds_conn)
 
 pltsql_get_tsql_enr_from_oid_hook_type pltsql_get_tsql_enr_from_oid_hook = NULL;
 
@@ -421,7 +424,7 @@ bool ENRGetSystableScan(Relation rel, Oid indexId, int nkeys, ScanKey key, List 
 
 	Oid reloid = RelationGetRelid(rel);
 
-	if (sql_dialect != SQL_DIALECT_TSQL)
+	if (sql_dialect != SQL_DIALECT_TSQL && !IS_TDS_CONN())
 	{
 		/*
 		* We cannot return false right away when sql_dialect is not TSQL.

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -32,6 +32,7 @@
 #include "catalog/catalog.h"
 #include "catalog/dependency.h"
 #include "catalog/indexing.h"
+#include "catalog/namespace.h"
 #include "catalog/pg_authid.h"
 #include "catalog/pg_collation.h"
 #include "catalog/pg_opclass.h"
@@ -55,7 +56,6 @@
 #include "miscadmin.h"
 
 #define NUM_ENR_CATALOGS 11
-#define IS_TDS_CONN() (MyProcPort && MyProcPort->is_tds_conn)
 
 pltsql_get_tsql_enr_from_oid_hook_type pltsql_get_tsql_enr_from_oid_hook = NULL;
 
@@ -424,14 +424,19 @@ bool ENRGetSystableScan(Relation rel, Oid indexId, int nkeys, ScanKey key, List 
 
 	Oid reloid = RelationGetRelid(rel);
 
-	if (sql_dialect != SQL_DIALECT_TSQL && !IS_TDS_CONN())
+	/*
+	 * We should allow ENR scans for T_SQL dialect as well as 
+	 * PG dialect from TDS endpoint. 
+	 * Because there are cases where dialect is set to temporarily to 
+	 * PG when executing PG functions and it tries to scan ENRs.
+	 */
+	if (sql_dialect != SQL_DIALECT_TSQL && !(is_bbf_tds_connection_hook && is_bbf_tds_connection_hook()))
 	{
 		/*
-		* We cannot return false right away when sql_dialect is not TSQL.
-		* There are cases when sql_dialect is temporarily set to PG when
-		* executing PG functions such as nextval_internal() in the case of
-		* identity sequence.
-		*/
+		 * There are cases when sql_dialect is temporarily set to PG when
+		 * executing PG functions such as nextval_internal() in the case of
+		 * identity sequence.
+		 */
 		if (reloid != SequenceRelationId)
 			return false;
 

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -427,6 +427,9 @@ bool ENRGetSystableScan(Relation rel, Oid indexId, int nkeys, ScanKey key, List 
 	 * PG dialect from TDS endpoint. 
 	 * Because there are cases where dialect is set to temporarily to 
 	 * PG when executing PG functions and it tries to scan ENRs.
+	 *
+	 * Note: Due to this condition, scanning for ENR temp tables
+	 * from PG endpoint and in PG dialect will not work.
 	 */
 	if (sql_dialect != SQL_DIALECT_TSQL && !(is_bbf_tds_connection_hook && is_bbf_tds_connection_hook()))
 	{


### PR DESCRIPTION
### Description
In ENRGetSystableScan, if the dialect is not TSQL_DIALECT and there is a scan initiated for a catalog (other than Sequence), we return false i.e. the tuple being scanned for does not exist in ENR. But this is not reliable in case this scan is initiated from a PG function since the dialect then would be PG_DIALECT and the scan in ENR would return false, even though the actual tuple being searched for is in ENR (in case it's a T-SQL temp table). This results in a "could not open a relation" error since the tuple also does not exist in pg_catalog.

Extension PR (tests) - https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4174

Other dialect checks and why they don't need to change?
```
static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOperationType op, bool skip_cache_inval, bool in_enr_rollback)
{
        ...
	if (sql_dialect != SQL_DIALECT_TSQL)
		return false;

	catalog_oid = RelationGetRelid(catalog_rel);
```
> This is done during adding dependent objects and tuples into ENR temp tables. Since creation of T-SQL temp table should only happen from the tsql dialect, addition of tuples into ENR md should also happen only in tsql dialect.
 
```
void ENRDropEntry(Oid id)
{
	EphemeralNamedRelation	enr;
	MemoryContext oldcxt;

	if (sql_dialect != SQL_DIALECT_TSQL || !currentQueryEnv)
		return;

```
> Again, operations on ENR should happen in the sql_dialect; hence we don't need a conn check here

And other helpers -
```
bool IsTsqlTableVariable(Relation relation)
{
	return sql_dialect == SQL_DIALECT_TSQL 


bool IsTsqlTempTable(char relpersistence)
{
	return sql_dialect == SQL_DIALECT_TSQL 


bool UseTempOidBuffer()
{
	return sql_dialect == SQL_DIALECT_TSQL 

```

> These functions are also used during creation of temp table and dependent objects.

### Issues Resolved
Task: BABEL-6099
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
