### PR TITLE
Fix: Rectified dialect check in ENRGetSystableScan function to also check for the conn_type (#632)

### DIFF
--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -32,6 +32,7 @@
 #include "catalog/catalog.h"
 #include "catalog/dependency.h"
 #include "catalog/indexing.h"
+#include "catalog/namespace.h"
 #include "catalog/pg_authid.h"
 #include "catalog/pg_collation.h"
 #include "catalog/pg_opclass.h"
@@ -421,14 +422,22 @@ bool ENRGetSystableScan(Relation rel, Oid indexId, int nkeys, ScanKey key, List 
 
 	Oid reloid = RelationGetRelid(rel);
 
-	if (sql_dialect != SQL_DIALECT_TSQL)
+	/*
+	 * We should allow ENR scans for T_SQL dialect as well as 
+	 * PG dialect from TDS endpoint. 
+	 * Because there are cases where dialect is set to temporarily to 
+	 * PG when executing PG functions and it tries to scan ENRs.
+	 *
+	 * Note: Due to this condition, scanning for ENR temp tables
+	 * from PG endpoint and in PG dialect will not work.
+	 */
+	if (sql_dialect != SQL_DIALECT_TSQL && !(is_bbf_tds_connection_hook && is_bbf_tds_connection_hook()))
 	{
 		/*
-		* We cannot return false right away when sql_dialect is not TSQL.
-		* There are cases when sql_dialect is temporarily set to PG when
-		* executing PG functions such as nextval_internal() in the case of
-		* identity sequence.
-		*/
+		 * There are cases when sql_dialect is temporarily set to PG when
+		 * executing PG functions such as nextval_internal() in the case of
+		 * identity sequence.
+		 */
 		if (reloid != SequenceRelationId)
 			return false;
 


### PR DESCRIPTION
### Cherry-pick
Engine PR - https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/632
Engine commit - https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/commit/406faf99c77655000f5aa2a6f681d51fe98dab4b
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
