### PR TITLE
INSERT INTO table DEFAULT VALUES does not work properly for domain types

### DIFF
--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -65,6 +65,7 @@
 #include "parser/parse_collate.h"
 #include "parser/parse_expr.h"
 #include "parser/parse_relation.h"
+#include "parser/parse_target.h"
 #include "parser/parsetree.h"
 #include "partitioning/partdesc.h"
 #include "pgstat.h"
@@ -2997,6 +2998,9 @@ cookDefault(ParseState *pstate,
 							format_type_be(atttypid),
 							format_type_be(type_id)),
 					 errhint("You will need to rewrite or cast the expression.")));
+
+		if (handle_type_and_collation_hook)
+			handle_type_and_collation_hook(expr, atttypid, InvalidOid);
 	}
 
 	/*


### PR DESCRIPTION
### Description
Fix the cook default function behavior by setting function return type.
Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4247

Cherry-pick from PR : https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/625

### Issues Resolved
https://github.com/babelfish-for-postgresql/babelfish_extensions/issues/4069, BABEL-6085

### Check List
 Commits are signed per the DCO using --signoff
By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).