### PR TITLE
Obtain correct first character in pattern for ESCAPE in LIKE (#649)

### DIFF
--- a/src/backend/utils/adt/like_match.c
+++ b/src/backend/utils/adt/like_match.c
@@ -77,6 +77,7 @@
 #endif
 
 #define BBF_ESC_CHAR_REPLC "\357\277\277"
+#define BBF_ESC_CHAR_REPLC_LEN (sizeof(BBF_ESC_CHAR_REPLC) - 1)
 
 static int
 MatchText(const char *t, int tlen, const char *p, int plen,
@@ -101,12 +102,12 @@ MatchText(const char *t, int tlen, const char *p, int plen,
 	{
 		/* Default escape '\\' is disabled in babelfish */
 		if ((*p == '\\' && sql_dialect == SQL_DIALECT_PG)||
-			(strncmp(p, BBF_ESC_CHAR_REPLC, strlen(BBF_ESC_CHAR_REPLC)) == 0 && sql_dialect == SQL_DIALECT_TSQL))
+			(sql_dialect == SQL_DIALECT_TSQL && strncmp(p, BBF_ESC_CHAR_REPLC, BBF_ESC_CHAR_REPLC_LEN) == 0))
 		{
 			/* Next pattern byte must match literally, whatever it is */
 			if (sql_dialect == SQL_DIALECT_TSQL)
 			{
-				for (int i = 0; i < strlen(BBF_ESC_CHAR_REPLC); i++)
+				for (int i = 0; i < BBF_ESC_CHAR_REPLC_LEN; i++)
 				{
 					NextByte(p, plen);
 				}
@@ -181,6 +182,15 @@ MatchText(const char *t, int tlen, const char *p, int plen,
 							 errmsg("LIKE pattern must not end with escape character")));
 				firstpat = GETCHAR(p[1]);
 			}
+			else if (sql_dialect == SQL_DIALECT_TSQL && strncmp(p, BBF_ESC_CHAR_REPLC, BBF_ESC_CHAR_REPLC_LEN) == 0)
+			{
+				int esc_len = BBF_ESC_CHAR_REPLC_LEN;
+				if (plen <= esc_len)
+					ereport(ERROR,
+							(errcode(ERRCODE_INVALID_ESCAPE_SEQUENCE),
+							 errmsg("LIKE pattern must not end with escape character")));
+				firstpat = GETCHAR(p[esc_len]);
+			}
 			else
 				firstpat = GETCHAR(*p);
 
@@ -193,7 +203,7 @@ MatchText(const char *t, int tlen, const char *p, int plen,
 
 					if (matched != LIKE_FALSE)
 						return matched; /* TRUE or ABORT */
-				} else if (firstpat == '[' && sql_dialect == SQL_DIALECT_TSQL)
+				} else if (sql_dialect == SQL_DIALECT_TSQL && firstpat == '[')
 				{
 					int			matched = MatchText(t, tlen, p, plen,
 													locale, locale_is_c);
@@ -217,7 +227,7 @@ MatchText(const char *t, int tlen, const char *p, int plen,
 			NextByte(p, plen);
 			continue;
 		}
-		else if (*p == '[' && sql_dialect == SQL_DIALECT_TSQL)
+		else if (sql_dialect == SQL_DIALECT_TSQL && *p == '[')
 		{
 			/* Tsql deal with [ and ] wild character */
 			Oid cid = InvalidOid;
@@ -299,7 +309,7 @@ MatchText(const char *t, int tlen, const char *p, int plen,
 		NextByte(p, plen);
 	}
 
-	if (tlen > 0 && sql_dialect == SQL_DIALECT_TSQL)
+	if (sql_dialect == SQL_DIALECT_TSQL && tlen > 0)
 	{
 		/* End of pattern, but not of text.
 		 *
@@ -367,7 +377,7 @@ do_like_escape(text *pat, text *esc)
 		result = (text *) palloc(plen * 2 + VARHDRSZ);
 	r = VARDATA(result);
 
-	if (elen==0 && sql_dialect == SQL_DIALECT_TSQL)
+	if (sql_dialect == SQL_DIALECT_TSQL && elen==0)
 	{
 		/*
 		 * Escape string is empty, just throw the error.
@@ -417,7 +427,7 @@ do_like_escape(text *pat, text *esc)
 				{
 					/* check if direct copy string (unicode char) is valid */
 					
-					for (int i = 0; i < strlen(BBF_ESC_CHAR_REPLC); i++){
+					for (int i = 0; i < BBF_ESC_CHAR_REPLC_LEN; i++){
 						*r++ = BBF_ESC_CHAR_REPLC[i];
 					}
 					NextChar(p, plen);


### PR DESCRIPTION
Whenever there is ESCAPE in LIKE operator and the pattern is either infix or postfix, Babelfish is unable to handle the wildcard properly.

This commit fixes that by ignoring the ESCAPE character in the pattern and finding the correct pattern. Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4281

Task: BABEL-6180

Signed-off-by: Shameem Ahmed shmeeh@amazon.com
(cherry picked from commit 3aa4957dcd2dbb39447437b50ae08547e3d6cf2e)

### Description

[Describe what this change achieves]
 
### Issues Resolved

[List any issues this PR will resolve]
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
