### PR TITLE
[BABEL] Added BBF hook to set typmod for Operator expression

### DIFF
--- a/src/backend/parser/parse_expr.c
+++ b/src/backend/parser/parse_expr.c
@@ -102,6 +102,8 @@ static List *ExpandChecksumStar(ParseState *pstate, FuncCall *fn, int location);
 lookup_param_hook_type lookup_param_hook = NULL;
 handle_constant_literals_hook_type handle_constant_literals_hook = NULL;
 set_common_typmod_case_expr_hook_type set_common_typmod_case_expr_hook = NULL;
+post_transform_expr_recurse_hook_type post_transform_expr_recurse_hook = NULL;
+
 /*
  * transformExpr -
  *	  Analyze and transform expressions. Type checking and type casting is
@@ -349,6 +351,9 @@ transformExprRecurse(ParseState *pstate, Node *expr)
 			result = NULL;		/* keep compiler quiet */
 			break;
 	}
+
+	if (post_transform_expr_recurse_hook)
+		result = (*post_transform_expr_recurse_hook)(pstate, result);
 
 	return result;
 }

--- a/src/include/parser/parse_coerce.h
+++ b/src/include/parser/parse_coerce.h
@@ -148,4 +148,7 @@ extern PGDLLEXPORT handle_constant_literals_hook_type handle_constant_literals_h
 typedef void (*set_common_typmod_case_expr_hook_type) (ParseState *pstate, List *exprs, CaseExpr *newc);
 extern PGDLLIMPORT set_common_typmod_case_expr_hook_type set_common_typmod_case_expr_hook;
 
+typedef Node *(*post_transform_expr_recurse_hook_type) (ParseState *pstate, Node *expr);
+extern PGDLLIMPORT post_transform_expr_recurse_hook_type post_transform_expr_recurse_hook;
+
 #endif							/* PARSE_COERCE_H */


### PR DESCRIPTION
### Description

In this we are adding `post_transform_expr_recurse_hook` that help us to calculate correct typmod for `T_Oper` expression.

### Issues Resolved

Task: BABEL-6116

cherry-picked from https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/661

Extension PR:https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4306

Signed-off-by: yashneet vinayak [yashneet@amazon.com](mailto:yashneet@amazon.com)
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
