### PR TITLE
Fix: get_ENR_withoid should also search through the parent queryEnvs to find if the ENR with given OID exists.

### DIFF
--- a/src/backend/catalog/aclchk.c
+++ b/src/backend/catalog/aclchk.c
@@ -1856,7 +1856,7 @@ ExecGrant_Relation(InternalGrant *istmt)
 		Oid			ownerId;
 		HeapTuple	tuple;
 		ListCell   *cell_colprivs;
-		bool		is_enr = (sql_dialect == SQL_DIALECT_TSQL && get_ENR_withoid(currentQueryEnv, relOid, ENR_TSQL_TEMP));
+		bool		is_enr = (sql_dialect == SQL_DIALECT_TSQL && get_ENR_withoid(currentQueryEnv, relOid, ENR_TSQL_TEMP, false));
 
 		if (is_enr)
 			tuple = SearchSysCache1(RELOID, ObjectIdGetDatum(relOid));
@@ -2206,7 +2206,7 @@ ExecGrant_common(InternalGrant *istmt, Oid classid, AclMode default_privs,
 		int			nnewmembers;
 		Oid		   *oldmembers;
 		Oid		   *newmembers;
-		bool		is_enr = (sql_dialect == SQL_DIALECT_TSQL && get_ENR_withoid(currentQueryEnv, objectid, ENR_TSQL_TEMP));
+		bool		is_enr = (sql_dialect == SQL_DIALECT_TSQL && get_ENR_withoid(currentQueryEnv, objectid, ENR_TSQL_TEMP, false));
 
 
 		if (is_enr)

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -778,7 +778,7 @@ index_create(Relation heapRelation,
 		 * PRIMARY KEYs and/or CONSTRAINTs.
 		 */
 		is_enr = (indexRelationName && strlen(indexRelationName) > 0 &&
-			(indexRelationName[0] == '@' || GetENRTempTableWithOid(heapRelationId)));
+			(indexRelationName[0] == '@' || GetENRTempTableWithOid(heapRelationId, false)));
 	}
 
 	relkind = partitioned ? RELKIND_PARTITIONED_INDEX : RELKIND_INDEX;

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -778,7 +778,7 @@ index_create(Relation heapRelation,
 		 * PRIMARY KEYs and/or CONSTRAINTs.
 		 */
 		is_enr = (indexRelationName && strlen(indexRelationName) > 0 &&
-			(indexRelationName[0] == '@' || GetENRTempTableWithOid(heapRelationId, false)));
+			(indexRelationName[0] == '@' || GetENRTempTableWithOid(heapRelationId, true)));
 	}
 
 	relkind = partitioned ? RELKIND_PARTITIONED_INDEX : RELKIND_INDEX;

--- a/src/backend/catalog/toasting.c
+++ b/src/backend/catalog/toasting.c
@@ -198,7 +198,7 @@ create_toast_table(Relation rel, Oid toastOid, Oid toastIndexOid,
 	 */
 	if (IsTsqlTableVariable(rel))
 		pg_toast_prefix = "@pg_toast";
-	else if (IsTsqlTempTable(rel->rd_rel->relpersistence) && GetENRTempTableWithOid(rel->rd_id, false))
+	else if (IsTsqlTempTable(rel->rd_rel->relpersistence) && GetENRTempTableWithOid(rel->rd_id, true))
 		pg_toast_prefix = "#pg_toast";
 
 	snprintf(toast_relname, sizeof(toast_relname),

--- a/src/backend/catalog/toasting.c
+++ b/src/backend/catalog/toasting.c
@@ -198,7 +198,7 @@ create_toast_table(Relation rel, Oid toastOid, Oid toastIndexOid,
 	 */
 	if (IsTsqlTableVariable(rel))
 		pg_toast_prefix = "@pg_toast";
-	else if (IsTsqlTempTable(rel->rd_rel->relpersistence) && GetENRTempTableWithOid(rel->rd_id))
+	else if (IsTsqlTempTable(rel->rd_rel->relpersistence) && GetENRTempTableWithOid(rel->rd_id, false))
 		pg_toast_prefix = "#pg_toast";
 
 	snprintf(toast_relname, sizeof(toast_relname),

--- a/src/backend/commands/cluster.c
+++ b/src/backend/commands/cluster.c
@@ -740,7 +740,7 @@ make_new_heap(Oid OIDOldHeap, Oid NewTableSpace, Oid NewAccessMethod,
 	 * We also must ensure that these temp tables are properly named in TSQL
 	 * so that the metadata is properly cleaned up after in this function.
 	 */
-	if (IsTsqlTempTable(relpersistence) && GetENRTempTableWithOid(OIDOldHeap))
+	if (IsTsqlTempTable(relpersistence) && GetENRTempTableWithOid(OIDOldHeap, false))
 		snprintf(NewHeapName, sizeof(NewHeapName), "#pg_temp_%u", OIDOldHeap);
 	else
 		snprintf(NewHeapName, sizeof(NewHeapName), "pg_temp_%u", OIDOldHeap);
@@ -1601,7 +1601,7 @@ finish_heap_swap(Oid OIDOldHeap, Oid OIDNewHeap,
 			/* rename the toast table ... */
 			if (IsTsqlTableVariable(newrel))
 				pg_toast_prefix = "@pg_toast";
-			else if (IsTsqlTempTable(newrel->rd_rel->relpersistence) && GetENRTempTableWithOid(newrel->rd_id))
+			else if (IsTsqlTempTable(newrel->rd_rel->relpersistence) && GetENRTempTableWithOid(newrel->rd_id, false))
 				pg_toast_prefix = "#pg_toast";
 
 			snprintf(NewToastName, NAMEDATALEN, "%s_%u",

--- a/src/backend/commands/dbcommands.c
+++ b/src/backend/commands/dbcommands.c
@@ -1938,7 +1938,7 @@ RenameDatabase(const char *oldname, const char *newname)
 				 errdetail_busy_db(notherbackends, npreparedxacts)));
 
 	/* rename */
-	is_enr = (sql_dialect == SQL_DIALECT_TSQL && get_ENR_withoid(currentQueryEnv, db_id, ENR_TSQL_TEMP));
+	is_enr = (sql_dialect == SQL_DIALECT_TSQL && get_ENR_withoid(currentQueryEnv, db_id, ENR_TSQL_TEMP, false));
 	if (is_enr)
 		newtup = SearchSysCacheCopy1(DATABASEOID, ObjectIdGetDatum(db_id));
 	else

--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -4440,7 +4440,7 @@ update_relispartition(Oid relationId, bool newval)
 	HeapTuple	tup;
 	Relation	classRel;
 	ItemPointerData otid;
-	bool		is_enr = (sql_dialect == SQL_DIALECT_TSQL && get_ENR_withoid(currentQueryEnv, relationId, ENR_TSQL_TEMP));
+	bool		is_enr = (sql_dialect == SQL_DIALECT_TSQL && get_ENR_withoid(currentQueryEnv, relationId, ENR_TSQL_TEMP, false));
 
 	classRel = table_open(RelationRelationId, RowExclusiveLock);
 	if (is_enr)

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -3697,7 +3697,7 @@ SetRelationTableSpace(Relation rel,
 	ItemPointerData otid;
 	Form_pg_class rd_rel;
 	Oid			reloid = RelationGetRelid(rel);
-	bool		is_enr = (sql_dialect == SQL_DIALECT_TSQL && get_ENR_withoid(currentQueryEnv, reloid, ENR_TSQL_TEMP));
+	bool		is_enr = (sql_dialect == SQL_DIALECT_TSQL && get_ENR_withoid(currentQueryEnv, reloid, ENR_TSQL_TEMP, false));
 
 	Assert(CheckRelationTableSpaceMove(rel, newTableSpaceId));
 
@@ -4219,7 +4219,7 @@ RenameRelationInternal(Oid myrelid, const char *newrelname, bool is_internal, bo
 	HeapTuple	reltup;
 	Form_pg_class relform;
 	Oid			namespaceId;
-	bool		is_enr = (sql_dialect == SQL_DIALECT_TSQL && get_ENR_withoid(currentQueryEnv, myrelid, ENR_TSQL_TEMP));
+	bool		is_enr = (sql_dialect == SQL_DIALECT_TSQL && get_ENR_withoid(currentQueryEnv, myrelid, ENR_TSQL_TEMP, false));
 
 	/*
 	 * Grab a lock on the target relation, which we will NOT release until end
@@ -15188,7 +15188,7 @@ ATExecSetRelOptions(Relation rel, List *defList, AlterTableType operation,
 
 	/* Fetch heap tuple */
 	relid = RelationGetRelid(rel);
-	is_enr = (sql_dialect == SQL_DIALECT_TSQL && get_ENR_withoid(currentQueryEnv, relid, ENR_TSQL_TEMP));
+	is_enr = (sql_dialect == SQL_DIALECT_TSQL && get_ENR_withoid(currentQueryEnv, relid, ENR_TSQL_TEMP, false));
 	if (is_enr)
 		tuple = SearchSysCache1(RELOID, ObjectIdGetDatum(relid));
 	else
@@ -17446,7 +17446,7 @@ AlterRelationNamespaceInternal(Relation classRel, Oid relOid,
 	Form_pg_class classForm;
 	ObjectAddress thisobj;
 	bool		already_done = false;
-	bool		is_enr = (sql_dialect == SQL_DIALECT_TSQL && get_ENR_withoid(currentQueryEnv, relOid, ENR_TSQL_TEMP));
+	bool		is_enr = (sql_dialect == SQL_DIALECT_TSQL && get_ENR_withoid(currentQueryEnv, relOid, ENR_TSQL_TEMP, false));
 
 	/* no rel lock for relkind=c so use LOCKTAG_TUPLE */
 	if (is_enr)

--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -3816,7 +3816,7 @@ RelationSetNewRelfilenumber(Relation relation, char persistence)
 	 */
 	pg_class = table_open(RelationRelationId, RowExclusiveLock);
 
-	is_enr = (sql_dialect == SQL_DIALECT_TSQL && get_ENR_withoid(currentQueryEnv, RelationGetRelid(relation), ENR_TSQL_TEMP));
+	is_enr = (sql_dialect == SQL_DIALECT_TSQL && get_ENR_withoid(currentQueryEnv, RelationGetRelid(relation), ENR_TSQL_TEMP, true));
 	if (is_enr)
 		tuple = SearchSysCacheCopy1(RELOID,
 									ObjectIdGetDatum(RelationGetRelid(relation)));

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -319,16 +319,21 @@ EphemeralNamedRelation
 get_ENR_withoid(QueryEnvironment *queryEnv, Oid id, EphemeralNameRelationType type)
 {
 	ListCell   *lc;
+	QueryEnvironment *qe = queryEnv;
 
 	if (queryEnv == NULL || !OidIsValid(id))
 		return NULL;
 
-	foreach(lc, queryEnv->namedRelList)
+	while (qe)
 	{
-		EphemeralNamedRelation enr = (EphemeralNamedRelation) lfirst(lc);
+		foreach(lc, qe->namedRelList)
+		{
+			EphemeralNamedRelation enr = (EphemeralNamedRelation) lfirst(lc);
 
-		if (enr->md.reliddesc == id && enr->md.enrtype == type)
-			return enr;
+			if (enr->md.reliddesc == id && enr->md.enrtype == type)
+				return enr;
+		}
+		qe = qe->parentEnv;
 	}
 
 	return NULL;

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -222,7 +222,7 @@ register_ENR(QueryEnvironment *queryEnv, EphemeralNamedRelation enr)
 		 * as false, same as parent since table variable don't follow transactional
 		 * semantics.
 		 */
-		EphemeralNamedRelation parent_enr = GetENRTempTableWithOid(enr->md.parent_oid, false);
+		EphemeralNamedRelation parent_enr = GetENRTempTableWithOid(enr->md.parent_oid, true);
 		if(parent_enr)
 			enr->md.is_bbf_temp_table = parent_enr->md.is_bbf_temp_table;
 		else

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -222,7 +222,7 @@ register_ENR(QueryEnvironment *queryEnv, EphemeralNamedRelation enr)
 		 * as false, same as parent since table variable don't follow transactional
 		 * semantics.
 		 */
-		EphemeralNamedRelation parent_enr = GetENRTempTableWithOid(enr->md.parent_oid);
+		EphemeralNamedRelation parent_enr = GetENRTempTableWithOid(enr->md.parent_oid, false);
 		if(parent_enr)
 			enr->md.is_bbf_temp_table = parent_enr->md.is_bbf_temp_table;
 		else
@@ -316,7 +316,7 @@ get_ENR(QueryEnvironment *queryEnv, const char *name, bool search)
  * Same as get_ENR() but just search for relation oid
  */
 EphemeralNamedRelation
-get_ENR_withoid(QueryEnvironment *queryEnv, Oid id, EphemeralNameRelationType type)
+get_ENR_withoid(QueryEnvironment *queryEnv, Oid id, EphemeralNameRelationType type, bool recurse)
 {
 	ListCell   *lc;
 	QueryEnvironment *qe = queryEnv;
@@ -333,6 +333,8 @@ get_ENR_withoid(QueryEnvironment *queryEnv, Oid id, EphemeralNameRelationType ty
 			if (enr->md.reliddesc == id && enr->md.enrtype == type)
 				return enr;
 		}
+		if (!recurse)
+			break;
 		qe = qe->parentEnv;
 	}
 
@@ -344,9 +346,9 @@ get_ENR_withoid(QueryEnvironment *queryEnv, Oid id, EphemeralNameRelationType ty
  * provided arguments of currentQueryEnv and ENR_TSQL_TEMP.
  */
 EphemeralNamedRelation
-GetENRTempTableWithOid(Oid id)
+GetENRTempTableWithOid(Oid id, bool recurse)
 {
-	return get_ENR_withoid(currentQueryEnv, id, ENR_TSQL_TEMP);
+	return get_ENR_withoid(currentQueryEnv, id, ENR_TSQL_TEMP, recurse);
 }
 
 /*
@@ -826,7 +828,7 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 		switch (catalog_oid) {
 			case RelationRelationId:
 				rel_oid = ((Form_pg_class) GETSTRUCT(tup))->oid;
-				if ((enr = get_ENR_withoid(queryEnv, rel_oid, ENR_TSQL_TEMP))) {
+				if ((enr = get_ENR_withoid(queryEnv, rel_oid, ENR_TSQL_TEMP, false))) {
 					list_ptr = &enr->md.cattups[ENR_CATTUP_CLASS];
 					lc = list_head(enr->md.cattups[ENR_CATTUP_CLASS]);
 					ret = true;
@@ -888,7 +890,7 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 				{
 					Form_pg_shdepend tf1 = (Form_pg_shdepend) GETSTRUCT((HeapTuple)tup);
 					rel_oid = ((Form_pg_shdepend) GETSTRUCT(tup))->objid;
-					if ((enr = get_ENR_withoid(queryEnv, rel_oid, ENR_TSQL_TEMP))) {
+					if ((enr = get_ENR_withoid(queryEnv, rel_oid, ENR_TSQL_TEMP, false))) {
 						ListCell *curlc;
 						Form_pg_shdepend tf2; /* tuple forms*/
 
@@ -921,7 +923,7 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 				}
 			case IndexRelationId:
 				rel_oid = ((Form_pg_index) GETSTRUCT(tup))->indrelid;
-				if ((enr = get_ENR_withoid(queryEnv, rel_oid, ENR_TSQL_TEMP))) {
+				if ((enr = get_ENR_withoid(queryEnv, rel_oid, ENR_TSQL_TEMP, false))) {
 					list_ptr = &enr->md.cattups[ENR_CATTUP_INDEX];
 					lc = list_head(enr->md.cattups[ENR_CATTUP_INDEX]);
 					ret = true;
@@ -939,7 +941,7 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 				/* Composite type */
 				if (((Form_pg_type) GETSTRUCT(tup))->typelem == InvalidOid) {
 					rel_oid = ((Form_pg_type) GETSTRUCT(tup))->typrelid;
-					if ((enr = get_ENR_withoid(queryEnv, rel_oid, ENR_TSQL_TEMP))) {
+					if ((enr = get_ENR_withoid(queryEnv, rel_oid, ENR_TSQL_TEMP, false))) {
 						list_ptr = &enr->md.cattups[ENR_CATTUP_TYPE];
 						lc = list_head(enr->md.cattups[ENR_CATTUP_TYPE]);
 						ret = true;
@@ -975,7 +977,7 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 				break;
 			case AttributeRelationId:
 				rel_oid = ((Form_pg_attribute) GETSTRUCT(tup))->attrelid;
-				if ((enr = get_ENR_withoid(queryEnv, rel_oid, ENR_TSQL_TEMP))) {
+				if ((enr = get_ENR_withoid(queryEnv, rel_oid, ENR_TSQL_TEMP, false))) {
 					ListCell *curlc;
 					Form_pg_attribute tf1, tf2; /* tuple forms*/
 
@@ -1002,7 +1004,7 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 				break;
 			case ConstraintRelationId:
 				rel_oid = ((Form_pg_constraint) GETSTRUCT(tup))->conrelid;
-				if ((enr = get_ENR_withoid(queryEnv, rel_oid, ENR_TSQL_TEMP))) {
+				if ((enr = get_ENR_withoid(queryEnv, rel_oid, ENR_TSQL_TEMP, false))) {
 					Form_pg_constraint tf1, tf2; /* tuple forms*/
 					ListCell *curlc;
 
@@ -1021,7 +1023,7 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 				break;
 			case StatisticRelationId:
 				rel_oid = ((Form_pg_statistic) GETSTRUCT(tup))->starelid;
-				if ((enr = get_ENR_withoid(queryEnv, rel_oid, ENR_TSQL_TEMP))) {
+				if ((enr = get_ENR_withoid(queryEnv, rel_oid, ENR_TSQL_TEMP, false))) {
 					Form_pg_statistic tf1, tf2; /* tuple forms*/
 					ListCell *curlc;
 
@@ -1040,7 +1042,7 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 				break;
 			case StatisticExtRelationId:
 				rel_oid = ((Form_pg_statistic_ext) GETSTRUCT(tup))->stxrelid;
-				if ((enr = get_ENR_withoid(queryEnv, rel_oid, ENR_TSQL_TEMP))) {
+				if ((enr = get_ENR_withoid(queryEnv, rel_oid, ENR_TSQL_TEMP, false))) {
 					Form_pg_statistic_ext tf1, tf2; /* tuple forms*/
 					ListCell *curlc;
 
@@ -1059,7 +1061,7 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 				break;
 			case SequenceRelationId:
 				rel_oid = ((Form_pg_sequence) GETSTRUCT(tup))->seqrelid;
-				if ((enr = get_ENR_withoid(queryEnv, rel_oid, ENR_TSQL_TEMP))) {
+				if ((enr = get_ENR_withoid(queryEnv, rel_oid, ENR_TSQL_TEMP, false))) {
 					list_ptr = &enr->md.cattups[ENR_CATTUP_SEQUENCE];
 					lc = list_head(enr->md.cattups[ENR_CATTUP_SEQUENCE]);
 					ret = true;
@@ -1067,7 +1069,7 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 				break;
 			case AttrDefaultRelationId:
 				rel_oid = ((Form_pg_attrdef) GETSTRUCT(tup))->adrelid;
-				if ((enr = get_ENR_withoid(queryEnv, rel_oid, ENR_TSQL_TEMP))) {
+				if ((enr = get_ENR_withoid(queryEnv, rel_oid, ENR_TSQL_TEMP, false))) {
 					list_ptr = &enr->md.cattups[ENR_CATTUP_ATTR_DEF_REL];
 					lc = list_head(enr->md.cattups[ENR_CATTUP_ATTR_DEF_REL]);
 					ret = true;
@@ -1148,7 +1150,7 @@ static EphemeralNamedRelation find_enr(Form_pg_depend entry)
 			* to register the dependency of the ENR relation to this object.
 			*/
 			case RelationRelationId:
-				return get_ENR_withoid(queryEnv, entry->objid, ENR_TSQL_TEMP);
+				return get_ENR_withoid(queryEnv, entry->objid, ENR_TSQL_TEMP, false);
 
 			case TypeRelationId:
 				foreach(curlc, queryEnv->namedRelList) {
@@ -1176,7 +1178,7 @@ static EphemeralNamedRelation find_enr(Form_pg_depend entry)
 
 			case ConstraintRelationId:
 			case AttrDefaultRelationId:
-				return get_ENR_withoid(queryEnv, entry->refobjid, ENR_TSQL_TEMP);
+				return get_ENR_withoid(queryEnv, entry->refobjid, ENR_TSQL_TEMP, false);
 
 			default:
 				break;
@@ -1197,7 +1199,7 @@ void ENRDropEntry(Oid id)
 	if (sql_dialect != SQL_DIALECT_TSQL || !currentQueryEnv)
 		return;
 
-	if ((enr = GetENRTempTableWithOid(id)) == NULL)
+	if ((enr = GetENRTempTableWithOid(id, false)) == NULL)
 		return;
 
 	oldcxt = MemoryContextSwitchTo(currentQueryEnv->memctx);
@@ -1318,7 +1320,7 @@ void ENRDropCatalogEntry(Relation catalog_relation, Oid relid)
 	{
 		switch (catalog_oid) {
 			case AttributeRelationId:
-				if ((enr = get_ENR_withoid(queryEnv, relid, ENR_TSQL_TEMP))) {
+				if ((enr = get_ENR_withoid(queryEnv, relid, ENR_TSQL_TEMP, false))) {
 					list_ptr = &enr->md.cattups[ENR_CATTUP_ATTRIBUTE];
 					ret = true;
 				}
@@ -1711,7 +1713,7 @@ ENRRollbackUncommittedTuple(QueryEnvironment *queryEnv, ENRUncommittedTuple unco
 		*/
 		
 		Form_pg_index idx_form = (Form_pg_index) GETSTRUCT(uncommitted_tup->tup);
-		if (get_ENR_withoid(queryEnv, idx_form->indrelid, ENR_TSQL_TEMP))
+		if (get_ENR_withoid(queryEnv, idx_form->indrelid, ENR_TSQL_TEMP, false))
 		{
 			skip_cache_inval = true;
 		}
@@ -1843,7 +1845,7 @@ bool UseTempOidBuffer()
 bool UseTempOidBufferForOid(Oid relId)
 {
 	return UseTempOidBuffer()
-		&& GetENRTempTableWithOid(relId);
+		&& GetENRTempTableWithOid(relId, false);
 }
 
 bool has_existing_enr_relations()

--- a/src/include/utils/queryenvironment.h
+++ b/src/include/utils/queryenvironment.h
@@ -137,8 +137,8 @@ extern void register_ENR(QueryEnvironment *queryEnv, EphemeralNamedRelation enr)
 extern void unregister_ENR(QueryEnvironment *queryEnv, const char *name);
 extern PGDLLEXPORT List *get_namedRelList(void);
 extern EphemeralNamedRelation get_ENR(QueryEnvironment *queryEnv, const char *name, bool search);
-extern PGDLLEXPORT EphemeralNamedRelation get_ENR_withoid(QueryEnvironment *queryEnv, Oid oid, EphemeralNameRelationType type);
-extern EphemeralNamedRelation GetENRTempTableWithOid(Oid id);
+extern PGDLLEXPORT EphemeralNamedRelation get_ENR_withoid(QueryEnvironment *queryEnv, Oid oid, EphemeralNameRelationType type, bool recurse);
+extern EphemeralNamedRelation GetENRTempTableWithOid(Oid id, bool recurse);
 extern TupleDesc ENRMetadataGetTupDesc(EphemeralNamedRelationMetadata enrmd);
 extern bool ENRGetSystableScan(Relation rel, Oid indexoid, int nkeys, ScanKey key, List **tuplist, int *tuplist_i, int *tuplist_flags);
 extern bool ENRAddTuple(Relation rel, HeapTuple tup);


### PR DESCRIPTION
### Description

* `get_ENR_withoid` previously only checked for the given OID within the provided queryEnv; however this function should be identical to `getENR` (as also suggested by the comment), which searches through parent envs as well. Hence, changing `get_ENR_withoid` to also search through parent queryEnvs
    * ~~`getENR` has a search flag which callers can use if they don't want to search through all the queryEnvs; `get_ENR_withoid` does not require this - Unlike getENR, getENR_withoid searches using OIDs and OIDs for every registered ENR will be different.~~
    * We have introduced a similar recurse flag which will be turned off for most cases, except the necessary ones. 

**NOTE: index and toast creation is still not correct as these relations get registered into the incorrect queryEnv. I've created a separate issue for it - BABEL-6272 and we will solve it next**

Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4334
 
### Issues Resolved

BABEL-5605, BABEL-6192
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
