### PR TITLE
[OSS-ONLY]Revert Output clause changes in Executor to match with PG Returning

### DIFF
--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -827,9 +827,9 @@ ExecInsert(ModifyTableContext *context,
 			return NULL;		/* "do nothing" */
 	}
 
-	/* Process RETURNING if present */
-	if (resultRelInfo->ri_projectReturning && sql_dialect == SQL_DIALECT_TSQL)
-		result = ExecProcessReturning(resultRelInfo, slot, planSlot);
+	// /* Process RETURNING if present */
+	// if (resultRelInfo->ri_projectReturning && sql_dialect == SQL_DIALECT_TSQL)
+	// 	result = ExecProcessReturning(resultRelInfo, slot, planSlot);
 
 	/* INSTEAD OF ROW INSERT Triggers */
 	if (resultRelInfo->ri_TrigDesc &&
@@ -1220,7 +1220,7 @@ ExecInsert(ModifyTableContext *context,
 		ExecWithCheckOptions(WCO_VIEW_CHECK, resultRelInfo, slot, estate);
 
 	/* Process RETURNING if present */
-	if (resultRelInfo->ri_projectReturning && sql_dialect != SQL_DIALECT_TSQL)
+	if (resultRelInfo->ri_projectReturning)
 		result = ExecProcessReturning(resultRelInfo, slot, planSlot);
 
 	if (inserted_tuple)
@@ -1459,7 +1459,7 @@ ExecDelete(ModifyTableContext *context,
 	Relation	resultRelationDesc = resultRelInfo->ri_RelationDesc;
 	TupleTableSlot *slot = NULL;
 	TM_Result	result;
-	TupleTableSlot *rslot_output = NULL;
+	// TupleTableSlot *rslot_output = NULL;
 
 	if (tupleDeleted)
 		*tupleDeleted = false;
@@ -1473,41 +1473,41 @@ ExecDelete(ModifyTableContext *context,
 		return NULL;
 
 	/* Process RETURNING if present and if requested */
-	if (processReturning && resultRelInfo->ri_projectReturning && sql_dialect == SQL_DIALECT_TSQL)
-	{
-		/*
-		 * We have to put the target tuple into a slot, which means first we
-		 * gotta fetch it.  We can use the trigger tuple slot.
-		 */
-		if (resultRelInfo->ri_FdwRoutine)
-		{
-			/* FDW must have provided a slot containing the deleted row */
-			Assert(!TupIsNull(slot));
-		}
-		else
-		{
-			slot = ExecGetReturningSlot(estate, resultRelInfo);
-			if (oldtuple != NULL)
-			{
-				ExecForceStoreHeapTuple(oldtuple, slot, false);
-			}
-			else
-			{
-				if (!table_tuple_fetch_row_version(resultRelationDesc, tupleid,
-												   SnapshotAny, slot))
-					elog(ERROR, "failed to fetch deleted tuple for DELETE RETURNING");
-			}
-		}
-		rslot_output = ExecProcessReturning(resultRelInfo, slot, context->planSlot);
+	// if (processReturning && resultRelInfo->ri_projectReturning && sql_dialect == SQL_DIALECT_TSQL)
+	// {
+	// 	/*
+	// 	 * We have to put the target tuple into a slot, which means first we
+	// 	 * gotta fetch it.  We can use the trigger tuple slot.
+	// 	 */
+	// 	if (resultRelInfo->ri_FdwRoutine)
+	// 	{
+	// 		/* FDW must have provided a slot containing the deleted row */
+	// 		Assert(!TupIsNull(slot));
+	// 	}
+	// 	else
+	// 	{
+	// 		slot = ExecGetReturningSlot(estate, resultRelInfo);
+	// 		if (oldtuple != NULL)
+	// 		{
+	// 			ExecForceStoreHeapTuple(oldtuple, slot, false);
+	// 		}
+	// 		else
+	// 		{
+	// 			if (!table_tuple_fetch_row_version(resultRelationDesc, tupleid,
+	// 											   SnapshotAny, slot))
+	// 				elog(ERROR, "failed to fetch deleted tuple for DELETE RETURNING");
+	// 		}
+	// 	}
+	// 	rslot_output = ExecProcessReturning(resultRelInfo, slot, context->planSlot);
 
-		/*
-		 * Before releasing the target tuple again, make sure rslot has a
-		 * local copy of any pass-by-reference values.
-		 */
-		ExecMaterializeSlot(rslot_output);
+	// 	/*
+	// 	 * Before releasing the target tuple again, make sure rslot has a
+	// 	 * local copy of any pass-by-reference values.
+	// 	 */
+	// 	ExecMaterializeSlot(rslot_output);
 
-		ExecClearTuple(slot);
-	}
+	// 	ExecClearTuple(slot);
+	// }
 
 	if (resultRelInfo->ri_TrigDesc &&
 		resultRelInfo->ri_TrigDesc->trig_delete_instead_statement &&
@@ -1744,7 +1744,7 @@ ldelete:;
 	ExecDeleteEpilogue(context, resultRelInfo, tupleid, oldtuple, changingPart);
 
 	/* Process RETURNING if present and if requested */
-	if (processReturning && resultRelInfo->ri_projectReturning && sql_dialect != SQL_DIALECT_TSQL)
+	if (processReturning && resultRelInfo->ri_projectReturning)
 	{
 		/*
 		 * We have to put the target tuple into a slot, which means first we
@@ -1785,8 +1785,8 @@ ldelete:;
 		return rslot;
 	}
 
-	if (processReturning && resultRelInfo->ri_projectReturning && rslot_output)
-		return rslot_output;
+	// if (processReturning && resultRelInfo->ri_projectReturning && rslot_output)
+	// 	return rslot_output;
 
 	return NULL;
 }
@@ -2352,7 +2352,7 @@ ExecUpdate(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
 	Relation	resultRelationDesc = resultRelInfo->ri_RelationDesc;
 	UpdateContext updateCxt = {0};
 	TM_Result	result;
-	TupleTableSlot *rslot = NULL;
+	// TupleTableSlot *rslot = NULL;
 
 	/*
 	 * abort the operation if not running transactions
@@ -2367,9 +2367,9 @@ ExecUpdate(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
 	if (!ExecUpdatePrologue(context, resultRelInfo, tupleid, oldtuple, slot, NULL))
 		return NULL;
 
-	/* Process RETURNING if present */
-	if (resultRelInfo->ri_projectReturning && sql_dialect == SQL_DIALECT_TSQL)
-		rslot = ExecProcessReturning(resultRelInfo, slot, context->planSlot);
+	// /* Process RETURNING if present */
+	// if (resultRelInfo->ri_projectReturning && sql_dialect == SQL_DIALECT_TSQL)
+	// 	rslot = ExecProcessReturning(resultRelInfo, slot, context->planSlot);
 
 	if (resultRelInfo->ri_TrigDesc &&
 		resultRelInfo->ri_TrigDesc->trig_update_instead_statement &&
@@ -2593,12 +2593,15 @@ redo_act:
 	ExecUpdateEpilogue(context, &updateCxt, resultRelInfo, tupleid, oldtuple,
 					   slot);
 
-	/* Process RETURNING if present */
-	if (resultRelInfo->ri_projectReturning && sql_dialect != SQL_DIALECT_TSQL)
-		return ExecProcessReturning(resultRelInfo, slot, context->planSlot);
+	// /* Process RETURNING if present */
+	// if (resultRelInfo->ri_projectReturning && sql_dialect != SQL_DIALECT_TSQL)
+	// 	return ExecProcessReturning(resultRelInfo, slot, context->planSlot);
 
 	if (resultRelInfo->ri_projectReturning)
-		return rslot;
+		return ExecProcessReturning(resultRelInfo, slot, context->planSlot);
+
+	// if (resultRelInfo->ri_projectReturning)
+	// 	return rslot;
 
 	return NULL;
 }

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -827,10 +827,6 @@ ExecInsert(ModifyTableContext *context,
 			return NULL;		/* "do nothing" */
 	}
 
-	// /* Process RETURNING if present */
-	// if (resultRelInfo->ri_projectReturning && sql_dialect == SQL_DIALECT_TSQL)
-	// 	result = ExecProcessReturning(resultRelInfo, slot, planSlot);
-
 	/* INSTEAD OF ROW INSERT Triggers */
 	if (resultRelInfo->ri_TrigDesc &&
 		resultRelInfo->ri_TrigDesc->trig_insert_instead_row)
@@ -1459,7 +1455,6 @@ ExecDelete(ModifyTableContext *context,
 	Relation	resultRelationDesc = resultRelInfo->ri_RelationDesc;
 	TupleTableSlot *slot = NULL;
 	TM_Result	result;
-	// TupleTableSlot *rslot_output = NULL;
 
 	if (tupleDeleted)
 		*tupleDeleted = false;
@@ -1471,43 +1466,6 @@ ExecDelete(ModifyTableContext *context,
 	if (!ExecDeletePrologue(context, resultRelInfo, tupleid, oldtuple,
 							epqreturnslot, tmresult))
 		return NULL;
-
-	/* Process RETURNING if present and if requested */
-	// if (processReturning && resultRelInfo->ri_projectReturning && sql_dialect == SQL_DIALECT_TSQL)
-	// {
-	// 	/*
-	// 	 * We have to put the target tuple into a slot, which means first we
-	// 	 * gotta fetch it.  We can use the trigger tuple slot.
-	// 	 */
-	// 	if (resultRelInfo->ri_FdwRoutine)
-	// 	{
-	// 		/* FDW must have provided a slot containing the deleted row */
-	// 		Assert(!TupIsNull(slot));
-	// 	}
-	// 	else
-	// 	{
-	// 		slot = ExecGetReturningSlot(estate, resultRelInfo);
-	// 		if (oldtuple != NULL)
-	// 		{
-	// 			ExecForceStoreHeapTuple(oldtuple, slot, false);
-	// 		}
-	// 		else
-	// 		{
-	// 			if (!table_tuple_fetch_row_version(resultRelationDesc, tupleid,
-	// 											   SnapshotAny, slot))
-	// 				elog(ERROR, "failed to fetch deleted tuple for DELETE RETURNING");
-	// 		}
-	// 	}
-	// 	rslot_output = ExecProcessReturning(resultRelInfo, slot, context->planSlot);
-
-	// 	/*
-	// 	 * Before releasing the target tuple again, make sure rslot has a
-	// 	 * local copy of any pass-by-reference values.
-	// 	 */
-	// 	ExecMaterializeSlot(rslot_output);
-
-	// 	ExecClearTuple(slot);
-	// }
 
 	if (resultRelInfo->ri_TrigDesc &&
 		resultRelInfo->ri_TrigDesc->trig_delete_instead_statement &&
@@ -1784,9 +1742,6 @@ ldelete:;
 
 		return rslot;
 	}
-
-	// if (processReturning && resultRelInfo->ri_projectReturning && rslot_output)
-	// 	return rslot_output;
 
 	return NULL;
 }
@@ -2352,7 +2307,6 @@ ExecUpdate(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
 	Relation	resultRelationDesc = resultRelInfo->ri_RelationDesc;
 	UpdateContext updateCxt = {0};
 	TM_Result	result;
-	// TupleTableSlot *rslot = NULL;
 
 	/*
 	 * abort the operation if not running transactions
@@ -2366,10 +2320,6 @@ ExecUpdate(ModifyTableContext *context, ResultRelInfo *resultRelInfo,
 	 */
 	if (!ExecUpdatePrologue(context, resultRelInfo, tupleid, oldtuple, slot, NULL))
 		return NULL;
-
-	// /* Process RETURNING if present */
-	// if (resultRelInfo->ri_projectReturning && sql_dialect == SQL_DIALECT_TSQL)
-	// 	rslot = ExecProcessReturning(resultRelInfo, slot, context->planSlot);
 
 	if (resultRelInfo->ri_TrigDesc &&
 		resultRelInfo->ri_TrigDesc->trig_update_instead_statement &&
@@ -2593,15 +2543,9 @@ redo_act:
 	ExecUpdateEpilogue(context, &updateCxt, resultRelInfo, tupleid, oldtuple,
 					   slot);
 
-	// /* Process RETURNING if present */
-	// if (resultRelInfo->ri_projectReturning && sql_dialect != SQL_DIALECT_TSQL)
-	// 	return ExecProcessReturning(resultRelInfo, slot, context->planSlot);
-
+	/* Process RETURNING if present */
 	if (resultRelInfo->ri_projectReturning)
 		return ExecProcessReturning(resultRelInfo, slot, context->planSlot);
-
-	// if (resultRelInfo->ri_projectReturning)
-	// 	return rslot;
 
 	return NULL;
 }


### PR DESCRIPTION
### Description

We are dealing with a critical crash bug in Babelfish's EPQ (EvalPlanQual) handling during concurrent UPDATE operations with OUTPUT clauses. The crash occurs when two sessions simultaneously modify the same row, where the column is of type "varchar" causing tuple alignment problems during EPQ re-evaluation. This is a memory corruption issue where PostgreSQL's EPQ mechanism fails to properly handle tuple structure changes when Babelfish processes OUTPUT clauses, leading to segmentation faults or assertion failures.

### The Problem
Babelfish was processing the OUTPUT clause (RETURNING clause) BEFORE EPQ evaluation, which created a race condition crash because:

1. Original Design Rationale: OUTPUT clause was moved before EPQ to ensure it executed before triggers
2. Race Condition: When EPQ re-evaluation occurred, the OUTPUT clause had already processed using stale tuple data 
3. Crash Point: EPQ tried to re-evaluate with changed tuple structure, but OUTPUT processing was already complete with wrong memory references

### The Solution
Align Babelfish OUTPUT clause execution with PostgreSQL's native RETURNING clause flow:

### Key Insights from Fix

- [ ]  Trigger Execution Order: Analysis revealed that OUTPUT clause doesn't actually need to run before triggers in Babelfish context
- [ ]  PostgreSQL Alignment: Following PostgreSQL's native RETURNING execution flow eliminates the race condition
- [ ]  EPQ Compatibility: Processing OUTPUT after EPQ ensures it always works with the correct, final tuple data
- [ ]  Memory Safety: Eliminates tuple alignment crashes by ensuring OUTPUT clause processes current data structure

### Related PR - 
Extension PR - https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4347
### Issues Resolved

BABEL-4880
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
