### PR TITLE
Band aid fix for row visibility issue in output clause

### DIFF
--- a/src/backend/executor/nodeTidscan.c
+++ b/src/backend/executor/nodeTidscan.c
@@ -24,6 +24,7 @@
 
 #include "access/sysattr.h"
 #include "access/tableam.h"
+#include "catalog/namespace.h"
 #include "catalog/pg_type.h"
 #include "executor/executor.h"
 #include "executor/nodeTidscan.h"
@@ -403,6 +404,13 @@ static bool
 TidRecheck(TidScanState *node, TupleTableSlot *slot)
 {
 	ItemPointer match;
+
+	/*
+	 * For babelfish skip the EPQ recheck condition in favour of previous
+	 * behaviour as it causes regression to output clause.
+	 */
+	if (is_bbf_tds_connection_hook && is_bbf_tds_connection_hook())
+		return true;
 
 	/* WHERE CURRENT OF always intends to resolve to the latest tuple */
 	if (node->tss_isCurrentOf)


### PR DESCRIPTION
### Description
Community commit "Add missing EPQ recheck for TID Scan" breaks babelfish's implementation of output clause as it depends upon self joining the target table for update with itself with ctid in join condition. As a short term fix we are disabling this community fix for babelfish connections and revisit this later on.
 
Authored-by: Tanzeel Khan [tzlkhan@amazon.com](mailto:tzlkhan@amazon.com)
Signed-off-by: Jaspal Singh [ijaspals@amazon.com](mailto:ijaspals@amazon.com)

### Issues Resolved
BABEL-6276
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
