### PR TITLE
[OSS-ONLY] Fix: Preventing locking in case the object to be locked belongs to an ENR temp table.

### DIFF
--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -850,6 +850,9 @@ LockAcquireExtended(const LOCKTAG *locktag,
 	LWLock	   *partitionLock;
 	bool		found_conflict;
 	bool		log_lock = false;
+	bool		is_temp_relation_lock = pltsql_get_tsql_enr_from_oid_hook && locktag->locktag_type == LOCKTAG_RELATION && 
+										(*pltsql_get_tsql_enr_from_oid_hook)(locktag->locktag_field2);
+	bool		is_temp_object_lock = find_object_in_enr_hook && locktag->locktag_type == LOCKTAG_OBJECT && (*find_object_in_enr_hook) (locktag->locktag_field2, locktag->locktag_field3);
 
 	if (lockmethodid <= 0 || lockmethodid >= lengthof(LockMethods))
 		elog(ERROR, "unrecognized lock method: %d", lockmethodid);
@@ -867,8 +870,7 @@ LockAcquireExtended(const LOCKTAG *locktag,
 						lockMethodTable->lockModeNames[lockmode]),
 				 errhint("Only RowExclusiveLock or less can be acquired on database objects during recovery.")));
 
-	if (pltsql_get_tsql_enr_from_oid_hook && locktag->locktag_type == LOCKTAG_RELATION && 
-		(*pltsql_get_tsql_enr_from_oid_hook)(locktag->locktag_field2))
+	if (is_temp_relation_lock || is_temp_object_lock)
 	{
 		/*
 		 * Normally, opening a relation with AccessExclusiveLock will automatically trigger for an XID

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -56,6 +56,7 @@
 #define NUM_ENR_CATALOGS 11
 
 pltsql_get_tsql_enr_from_oid_hook_type pltsql_get_tsql_enr_from_oid_hook = NULL;
+find_object_in_enr_hook_type find_object_in_enr_hook = NULL;
 
 /*
  * Private state of a query environment.

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -92,7 +92,6 @@ static void ENRDeleteUncommittedTupleData(SubTransactionId subid, EphemeralNamed
 static void ENRRollbackUncommittedTuple(QueryEnvironment *queryEnv, ENRUncommittedTuple uncommitted_tup);
 static bool IsCatalogOidENR(Oid reloid, bool extended);
 static EphemeralNamedRelation find_enr(Form_pg_depend entry);
-static EphemeralNamedRelation find_pg_depend_tuple(Form_pg_depend tf);
 
 QueryEnvironment *
 create_queryEnv(void)
@@ -874,35 +873,6 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 						}
 						ret = true;
 					}
-					else
-					{
-						/*
-						 * This means that the dependent object (represented by pg_depend->objid) is either a non-ENR 
-						 * or is a already deleted dependent object. This happens because while performing deletion,
-						 * we first delete the object and then delete its outgoing edge.
-						 * See: deleteOneObject in dependency.c
-						 * In such cases, we will search for the actual pg_depend entry
-						 */
-						ListCell *tmplc;
-						if ((enr = find_pg_depend_tuple(tf1)))
-						{
-							list_ptr = &enr->md.cattups[ENR_CATTUP_DEPEND];
-							foreach(tmplc, enr->md.cattups[ENR_CATTUP_DEPEND]) {
-								Form_pg_depend tup = (Form_pg_depend) GETSTRUCT((HeapTuple) lfirst(tmplc));
-								if (tup->classid == tf1->classid &&
-									tup->objid == tf1->objid && 
-									tup->objsubid == tf1->objsubid && 
-									tup->refclassid == tf1->refclassid &&
-									tup->refobjid == tf1->refobjid && 
-									tup->refobjsubid== tf1->refobjsubid)
-								{
-									lc = tmplc;
-									break;
-								}
-							}
-							ret = true;
-						}
-					}
 					break;
 				}
 			case SharedDependRelationId:
@@ -1206,37 +1176,6 @@ static EphemeralNamedRelation find_enr(Form_pg_depend entry)
 	}
 	return NULL;
 }
-
-static 
-EphemeralNamedRelation find_pg_depend_tuple(Form_pg_depend tf)
-{
-	QueryEnvironment 	*queryEnv = currentQueryEnv;
-	ListCell 			*outerlc, *innerlc;
-	
-	while (queryEnv)
-	{
-		foreach(outerlc, queryEnv->namedRelList)
-		{
-			EphemeralNamedRelation enr = (EphemeralNamedRelation) lfirst(outerlc);
-			if (enr->md.enrtype != ENR_TSQL_TEMP)
-				continue;
-
-			foreach(innerlc, enr->md.cattups[ENR_CATTUP_DEPEND]) {
-				Form_pg_depend tup = (Form_pg_depend) GETSTRUCT((HeapTuple) lfirst(innerlc));
-				if (tup->classid == tf->classid &&
-					tup->objid == tf->objid && 
-					tup->objsubid == tf->objsubid && 
-					tup->refclassid == tf->refclassid &&
-					tup->refobjid == tf->refobjid && 
-					tup->refobjsubid== tf->refobjsubid)
-					return enr;
-			}
-		}
-		queryEnv = queryEnv->parentEnv;
-	}
-	return NULL;
-}
-
 
 /*
  * Drop an ENR entry and delete it from the registered list.

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -59,18 +59,6 @@ pltsql_get_tsql_enr_from_oid_hook_type pltsql_get_tsql_enr_from_oid_hook = NULL;
 find_object_in_enr_hook_type find_object_in_enr_hook = NULL;
 
 /*
- * Private state of a query environment.
- */
-struct QueryEnvironment
-{
-	List	   *namedRelList;
-	List	   *dropped_namedRelList;
-	List 	   *savedCatcacheMessages;
-	struct QueryEnvironment *parentEnv;
-	MemoryContext	memctx;
-};
-
-/*
  * This list must match ENRCatalogTupleType in queryenvironment.h.
  *
  * These are the pg catalogs which we are placing in

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -92,6 +92,7 @@ static void ENRDeleteUncommittedTupleData(SubTransactionId subid, EphemeralNamed
 static void ENRRollbackUncommittedTuple(QueryEnvironment *queryEnv, ENRUncommittedTuple uncommitted_tup);
 static bool IsCatalogOidENR(Oid reloid, bool extended);
 static EphemeralNamedRelation find_enr(Form_pg_depend entry);
+static EphemeralNamedRelation find_pg_depend_tuple(Form_pg_depend tf);
 
 QueryEnvironment *
 create_queryEnv(void)
@@ -873,6 +874,35 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 						}
 						ret = true;
 					}
+					else
+					{
+						/*
+						 * This means that the dependent object (represented by pg_depend->objid) is either a non-ENR 
+						 * or is a already deleted dependent object. This happens because while performing deletion,
+						 * we first delete the object and then delete its outgoing edge.
+						 * See: deleteOneObject in dependency.c
+						 * In such cases, we will search for the actual pg_depend entry
+						 */
+						ListCell *tmplc;
+						if ((enr = find_pg_depend_tuple(tf1)))
+						{
+							list_ptr = &enr->md.cattups[ENR_CATTUP_DEPEND];
+							foreach(tmplc, enr->md.cattups[ENR_CATTUP_DEPEND]) {
+								Form_pg_depend tup = (Form_pg_depend) GETSTRUCT((HeapTuple) lfirst(tmplc));
+								if (tup->classid == tf1->classid &&
+									tup->objid == tf1->objid && 
+									tup->objsubid == tf1->objsubid && 
+									tup->refclassid == tf1->refclassid &&
+									tup->refobjid == tf1->refobjid && 
+									tup->refobjsubid== tf1->refobjsubid)
+								{
+									lc = tmplc;
+									break;
+								}
+							}
+							ret = true;
+						}
+					}
 					break;
 				}
 			case SharedDependRelationId:
@@ -1176,6 +1206,37 @@ static EphemeralNamedRelation find_enr(Form_pg_depend entry)
 	}
 	return NULL;
 }
+
+static 
+EphemeralNamedRelation find_pg_depend_tuple(Form_pg_depend tf)
+{
+	QueryEnvironment 	*queryEnv = currentQueryEnv;
+	ListCell 			*outerlc, *innerlc;
+	
+	while (queryEnv)
+	{
+		foreach(outerlc, queryEnv->namedRelList)
+		{
+			EphemeralNamedRelation enr = (EphemeralNamedRelation) lfirst(outerlc);
+			if (enr->md.enrtype != ENR_TSQL_TEMP)
+				continue;
+
+			foreach(innerlc, enr->md.cattups[ENR_CATTUP_DEPEND]) {
+				Form_pg_depend tup = (Form_pg_depend) GETSTRUCT((HeapTuple) lfirst(innerlc));
+				if (tup->classid == tf->classid &&
+					tup->objid == tf->objid && 
+					tup->objsubid == tf->objsubid && 
+					tup->refclassid == tf->refclassid &&
+					tup->refobjid == tf->refobjid && 
+					tup->refobjsubid== tf->refobjsubid)
+					return enr;
+			}
+		}
+		queryEnv = queryEnv->parentEnv;
+	}
+	return NULL;
+}
+
 
 /*
  * Drop an ENR entry and delete it from the registered list.

--- a/src/include/utils/queryenvironment.h
+++ b/src/include/utils/queryenvironment.h
@@ -171,4 +171,7 @@ extern bool has_existing_enr_relations(void);
 typedef EphemeralNamedRelation (*pltsql_get_tsql_enr_from_oid_hook_type) (Oid oid);
 extern PGDLLIMPORT pltsql_get_tsql_enr_from_oid_hook_type pltsql_get_tsql_enr_from_oid_hook;
 
+typedef EphemeralNamedRelation (*find_object_in_enr_hook_type) (Oid catalog_oid, Oid object_id);
+extern PGDLLIMPORT find_object_in_enr_hook_type find_object_in_enr_hook;
+
 #endif							/* QUERYENVIRONMENT_H */

--- a/src/include/utils/queryenvironment.h
+++ b/src/include/utils/queryenvironment.h
@@ -28,6 +28,18 @@ typedef enum EphemeralNameRelationType
 	ENR_TSQL_TEMP,		/* Temp table created in procedure/function */
 } EphemeralNameRelationType;
 
+/*
+ * Private state of a query environment.
+ */
+struct QueryEnvironment
+{
+	List	   *namedRelList;
+	List	   *dropped_namedRelList;
+	List 	   *savedCatcacheMessages;
+	struct QueryEnvironment *parentEnv;
+	MemoryContext	memctx;
+};
+
 typedef enum ENRCatalogTupleType
 {
 	ENR_CATTUP_CLASS = 0,


### PR DESCRIPTION
### Description

Previously, objects belonging to ENR temp tables were still unnecessarily being locked leading to contention during concurrent temp table operations. These changes add a hook which checks given an object and catalog id whether the object belongs to an ENR temp table, and if so, skip putting a lock for it.
 
### Issues Resolved

BABEL-5971
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
