### PR TITLE
[OSS-ONLY] Fix: Preventing locking in case the object to be locked be longs to an ENR temp table. (#687)

### DIFF
--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -862,6 +862,9 @@ LockAcquireExtended(const LOCKTAG *locktag,
 	LWLock	   *partitionLock;
 	bool		found_conflict;
 	bool		log_lock = false;
+	bool		is_temp_relation_lock = pltsql_get_tsql_enr_from_oid_hook && locktag->locktag_type == LOCKTAG_RELATION && 
+										(*pltsql_get_tsql_enr_from_oid_hook)(locktag->locktag_field2);
+	bool		is_temp_object_lock = find_object_in_enr_hook && locktag->locktag_type == LOCKTAG_OBJECT && (*find_object_in_enr_hook) (locktag->locktag_field2, locktag->locktag_field3);
 
 	if (lockmethodid <= 0 || lockmethodid >= lengthof(LockMethods))
 		elog(ERROR, "unrecognized lock method: %d", lockmethodid);
@@ -879,8 +882,7 @@ LockAcquireExtended(const LOCKTAG *locktag,
 						lockMethodTable->lockModeNames[lockmode]),
 				 errhint("Only RowExclusiveLock or less can be acquired on database objects during recovery.")));
 
-	if (pltsql_get_tsql_enr_from_oid_hook && locktag->locktag_type == LOCKTAG_RELATION && 
-		(*pltsql_get_tsql_enr_from_oid_hook)(locktag->locktag_field2))
+	if (is_temp_relation_lock || is_temp_object_lock)
 	{
 		/*
 		 * Normally, opening a relation with AccessExclusiveLock will automatically trigger for an XID

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -56,18 +56,7 @@
 #define NUM_ENR_CATALOGS 11
 
 pltsql_get_tsql_enr_from_oid_hook_type pltsql_get_tsql_enr_from_oid_hook = NULL;
-
-/*
- * Private state of a query environment.
- */
-struct QueryEnvironment
-{
-	List	   *namedRelList;
-	List	   *dropped_namedRelList;
-	List 	   *savedCatcacheMessages;
-	struct QueryEnvironment *parentEnv;
-	MemoryContext	memctx;
-};
+find_object_in_enr_hook_type find_object_in_enr_hook = NULL;
 
 /*
  * This list must match ENRCatalogTupleType in queryenvironment.h.

--- a/src/include/utils/queryenvironment.h
+++ b/src/include/utils/queryenvironment.h
@@ -28,6 +28,18 @@ typedef enum EphemeralNameRelationType
 	ENR_TSQL_TEMP		/* Temp table created in procedure/function */
 } EphemeralNameRelationType;
 
+/*
+ * Private state of a query environment.
+ */
+struct QueryEnvironment
+{
+	List	   *namedRelList;
+	List	   *dropped_namedRelList;
+	List 	   *savedCatcacheMessages;
+	struct QueryEnvironment *parentEnv;
+	MemoryContext	memctx;
+};
+
 typedef enum ENRCatalogTupleType
 {
 	ENR_CATTUP_CLASS = 0,
@@ -170,5 +182,8 @@ extern bool has_existing_enr_relations(void);
 /* Hooks */
 typedef EphemeralNamedRelation (*pltsql_get_tsql_enr_from_oid_hook_type) (Oid oid);
 extern PGDLLIMPORT pltsql_get_tsql_enr_from_oid_hook_type pltsql_get_tsql_enr_from_oid_hook;
+
+typedef EphemeralNamedRelation (*find_object_in_enr_hook_type) (Oid catalog_oid, Oid object_id);
+extern PGDLLIMPORT find_object_in_enr_hook_type find_object_in_enr_hook;
 
 #endif							/* QUERYENVIRONMENT_H */


### PR DESCRIPTION
### Description

Previously, objects belonging to ENR temp tables were still unnecessarily being locked leading to contention during concurrent temp table operations. These changes add a hook which checks given an object and catalog id whether the object belongs to an ENR temp table, and if so, skip putting a lock for it.

Task : BABEL-5971
Original PR - https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/687

(cherry picked from commit b860395e48f294a36629dbbac1df33cf1d7609e0)

#### Merge conflicts - no conflicts
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
