### PR TITLE
Fix: Rectified condition which led to constraint catalog corruption in ENR for TSQL temp tables

### DIFF
--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -1012,10 +1012,18 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 					tf1 = (Form_pg_constraint) GETSTRUCT(tup);
 					foreach(curlc, enr->md.cattups[ENR_CATTUP_CONSTRAINT]) {
 						tf2 = (Form_pg_constraint) GETSTRUCT((HeapTuple) lfirst(curlc));
-						if (tf2->oid >= tf1->oid) {
-							lc = curlc;
-							insert_at = foreach_current_index(curlc) + 1;
-							break;
+						switch (op)
+						{
+							case ENR_OP_ADD:
+								insert_at = foreach_current_index(curlc) + 1; // will simply be the end of list after iteration
+								break;
+							case ENR_OP_DROP:
+							case ENR_OP_UPDATE:
+								if (tf2->oid >= tf1->oid)
+									lc = curlc;
+								break;
+							default:
+								break;
 						}
 					}
 					ret = true;

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -1010,21 +1010,27 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 
 					list_ptr = &enr->md.cattups[ENR_CATTUP_CONSTRAINT];
 					tf1 = (Form_pg_constraint) GETSTRUCT(tup);
-					foreach(curlc, enr->md.cattups[ENR_CATTUP_CONSTRAINT]) {
-						tf2 = (Form_pg_constraint) GETSTRUCT((HeapTuple) lfirst(curlc));
-						switch (op)
-						{
-							case ENR_OP_ADD:
-								insert_at = foreach_current_index(curlc) + 1; // will simply be the end of list after iteration
-								break;
-							case ENR_OP_DROP:
-							case ENR_OP_UPDATE:
+					
+					switch (op)
+					{
+						case ENR_OP_ADD:
+							/* For ADD, simply append to the end of the list */
+							insert_at = list_length(enr->md.cattups[ENR_CATTUP_CONSTRAINT]);
+							break;
+						case ENR_OP_DROP:
+						case ENR_OP_UPDATE:
+							/* For DROP/UPDATE, find the matching tuple by OID */
+							foreach(curlc, enr->md.cattups[ENR_CATTUP_CONSTRAINT]) {
+								tf2 = (Form_pg_constraint) GETSTRUCT((HeapTuple) lfirst(curlc));
 								if (tf2->oid == tf1->oid)
+								{
 									lc = curlc;
-								break;
-							default:
-								break;
-						}
+									break;
+								}
+							}
+							break;
+						default:
+							break;
 					}
 					ret = true;
 				}

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -1030,6 +1030,7 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 							}
 							break;
 						default:
+							elog(ERROR, "Unexpected operation type for ENR_tuple_operation: %d", op);
 							break;
 					}
 					ret = true;

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -1019,7 +1019,7 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 								break;
 							case ENR_OP_DROP:
 							case ENR_OP_UPDATE:
-								if (tf2->oid >= tf1->oid)
+								if (tf2->oid == tf1->oid)
 									lc = curlc;
 								break;
 							default:


### PR DESCRIPTION
### Description

PG18 introduced a new constraint which is created for all non-null attributes including p_keys. So now, an attribute which is a p_key will create two constraints - p_key and not-null constraint.

When adding these constraints on the catalog in ENR, the condition tf2.oid > tf1.oid will keep the catalog list sorted, however, while removing or updating any tuple in this catalog list, we compare oids in a way which is interpreted as remove/update oid of tuple which has an oid greater than or equal to the requested oid. This leads to catalog corruption since we are removing/updating a different tuple than the requested one.

This change rectifies this condition and breaks it down based on the operation being performed.

More details can be found in the internal document which lists down the detail of the issue and the fix.


### Issues Resolved

BABEL-6211
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
