### PR TITLE
Require callers of coerce_to_domain() to supply base type/typmod.

### DIFF
--- a/.github/workflows/manual_tags.yml
+++ b/.github/workflows/manual_tags.yml
@@ -29,15 +29,18 @@ jobs:
           fetch-depth: 0
       - name: Run create-tag script
         env:
+          TAG_ID: ${{ github.event.inputs.tagId }}
           message: ${{ github.event.inputs.message }}
         # Run when commit hash is not provided (then the tag will be created on the latest commit of the current branch)
         if: ${{github.event.inputs.commit_hash == ''}} 
         run: |
-            bash ./.github/scripts/create-tag.sh -t ${{github.event.inputs.tagId}}
+            bash ./.github/scripts/create-tag.sh -t "$TAG_ID"
       - name: Run create-tag script when commit hash is provided
         env:
+          TAG_ID: ${{ github.event.inputs.tagId }}
+          COMMIT_HASH: ${{ github.event.inputs.commit_hash }}
           message: ${{ github.event.inputs.message }}
         # Run when commit hash is provided, tag will be created on top of the commit hash
         if: ${{github.event.inputs.commit_hash != ''}} 
         run: |
-            bash ./.github/scripts/create-tag.sh -c ${{github.event.inputs.commit_hash}} -t ${{github.event.inputs.tagId}}
+            bash ./.github/scripts/create-tag.sh -c "$COMMIT_HASH" -t "$TAG_ID"

--- a/src/backend/parser/parse_coerce.c
+++ b/src/backend/parser/parse_coerce.c
@@ -456,6 +456,12 @@ coerce_type(ParseState *pstate, Node *node,
 									 &funcId);
 	if (pathtype != COERCION_PATH_NONE)
 	{
+		Oid			baseTypeId;
+		int32		baseTypeMod;
+
+		baseTypeMod = targetTypeMod;
+		baseTypeId = getBaseTypeAndTypmod(targetTypeId, &baseTypeMod);
+
 		if (pathtype != COERCION_PATH_RELABELTYPE)
 		{
 			/*
@@ -465,12 +471,6 @@ coerce_type(ParseState *pstate, Node *node,
 			 * and we need to extract the correct typmod to use from the
 			 * domain's typtypmod.
 			 */
-			Oid			baseTypeId;
-			int32		baseTypeMod;
-
-			baseTypeMod = targetTypeMod;
-			baseTypeId = getBaseTypeAndTypmod(targetTypeId, &baseTypeMod);
-
 			result = build_coercion_expression(node, pathtype, funcId,
 											   baseTypeId, baseTypeMod,
 											   ccontext, cformat, location);
@@ -506,7 +506,8 @@ coerce_type(ParseState *pstate, Node *node,
 			 * that must be accounted for.  If the destination is a domain
 			 * then we won't need a RelabelType node.
 			 */
-			result = coerce_to_domain(node, InvalidOid, baseTypeMod, targetTypeId,
+			result = coerce_to_domain(node, baseTypeId, baseTypeMod,
+									  targetTypeId,
 									  ccontext, cformat, location,
 									  false);
 			if (result == node)
@@ -712,10 +713,8 @@ can_coerce_type(int nargs, const Oid *input_typeids, const Oid *target_typeids,
  * Create an expression tree to represent coercion to a domain type.
  *
  * 'arg': input expression
- * 'baseTypeId': base type of domain, if known (pass InvalidOid if caller
- *		has not bothered to look this up)
- * 'baseTypeMod': base type typmod of domain, if known (pass -1 if caller
- *		has not bothered to look this up)
+ * 'baseTypeId': base type of domain
+ * 'baseTypeMod': base type typmod of domain
  * 'typeId': target type to coerce to
  * 'ccontext': context indicator to control coercions
  * 'cformat': coercion display format
@@ -736,9 +735,8 @@ coerce_to_domain(Node *arg, Oid baseTypeId, int32 baseTypeMod, Oid typeId,
 		       *type_nsp;
 
 
-	/* Get the base type if it hasn't been supplied */
-	if (baseTypeId == InvalidOid)
-		baseTypeId = getBaseTypeAndTypmod(typeId, &baseTypeMod);
+	/* We now require the caller to supply correct baseTypeId/baseTypeMod */
+	Assert(OidIsValid(baseTypeId));
 
 	/* If it isn't a domain, return the node as it was passed in */
 	if (baseTypeId == typeId)


### PR DESCRIPTION
In view of the issue fixed in commit 0da39aa76, it no longer seems like a great idea for coerce_to_domain() to offer to perform a lookup that its caller probably should have done already.  The caller should be providing a value of the domain's base type, so it's hard to envision a valid case where it hasn't looked up that type.  After 0da39aa76 there is only one caller using the option for internal lookup, and that one can trivially be rearranged to not do that. So this seems more like a bug-encouraging misfeature than a useful shortcut; let's get rid of it (in HEAD only, there's no need to break any external callers in back branches).

Discussion: https://postgr.es/m/1865579.1738113656@sss.pgh.pa.us (cherry picked from commit ba0da16bd054de854c200a2dfa0b21c70e0300cf)

### Description

[Describe what this change achieves]
 
### Issues Resolved

[List any issues this PR will resolve]
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
