### PR TITLE
Fix: Rectified condition which led to constraint catalog corruption in ENR for TSQL temp tables (#692)

### DIFF
--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -1010,13 +1010,28 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 
 					list_ptr = &enr->md.cattups[ENR_CATTUP_CONSTRAINT];
 					tf1 = (Form_pg_constraint) GETSTRUCT(tup);
-					foreach(curlc, enr->md.cattups[ENR_CATTUP_CONSTRAINT]) {
-						tf2 = (Form_pg_constraint) GETSTRUCT((HeapTuple) lfirst(curlc));
-						if (tf2->oid >= tf1->oid) {
-							lc = curlc;
-							insert_at = foreach_current_index(curlc) + 1;
+					
+					switch (op)
+					{
+						case ENR_OP_ADD:
+							/* For ADD, simply append to the end of the list */
+							insert_at = list_length(enr->md.cattups[ENR_CATTUP_CONSTRAINT]);
 							break;
-						}
+						case ENR_OP_DROP:
+						case ENR_OP_UPDATE:
+							/* For DROP/UPDATE, find the matching tuple by OID */
+							foreach(curlc, enr->md.cattups[ENR_CATTUP_CONSTRAINT]) {
+								tf2 = (Form_pg_constraint) GETSTRUCT((HeapTuple) lfirst(curlc));
+								if (tf2->oid == tf1->oid)
+								{
+									lc = curlc;
+									break;
+								}
+							}
+							break;
+						default:
+							elog(ERROR, "Unexpected operation type for ENR_tuple_operation: %d", op);
+							break;
 					}
 					ret = true;
 				}


### PR DESCRIPTION
### Description

Cherry-pick
* 0c4df02b123232a2b8d7a363a7c2072785b3c7f2
* Original PR - https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/692

Task: BABEL-6211

(cherry picked from commit 0c4df02b123232a2b8d7a363a7c2072785b3c7f2)

 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
