### PR TITLE
[BABEL] Fix circular memory context in nested transactions with SPI cleanup

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -41,6 +41,7 @@
 #include "common/pg_prng.h"
 #include "executor/spi.h"
 #include "libpq/be-fsstubs.h"
+#include "libpq/libpq.h"
 #include "libpq/pqsignal.h"
 #include "miscadmin.h"
 #include "pg_trace.h"
@@ -2032,13 +2033,26 @@ AtSubCleanup_Memory(void)
 
 	Assert(s->parent != NULL);
 
-	/*
-	 * Return to the memory context that was current before we started the
-	 * subtransaction.  (In principle, this could not be any of the contexts
-	 * we are about to delete.  If it somehow is, assertions in mcxt.c will
-	 * complain.)
-	 */
-	MemoryContextSwitchTo(s->priorContext);
+	if (MyProcPort && MyProcPort->is_tds_conn && sql_dialect == SQL_DIALECT_TSQL)
+	{
+		/*
+		* For TDS/T-SQL connections, use parent's transaction context instead of
+		* priorContext. This avoids using stale priorContext pointers that may
+		* reference deleted SPI memory contexts, which can cause assertion failures
+		* when the memory is reused and creates circular parent-child relationships.
+		*/
+		MemoryContextSwitchTo(s->parent->curTransactionContext);
+	}
+	else
+	{
+		/*
+		* Return to the memory context that was current before we started the
+		* subtransaction.  (In principle, this could not be any of the contexts
+		* we are about to delete.  If it somehow is, assertions in mcxt.c will
+		* complain.)
+		*/
+		MemoryContextSwitchTo(s->priorContext);
+	}
 
 	/* Update CurTransactionContext (might not be same as priorContext) */
 	CurTransactionContext = s->parent->curTransactionContext;

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -41,7 +41,6 @@
 #include "common/pg_prng.h"
 #include "executor/spi.h"
 #include "libpq/be-fsstubs.h"
-#include "libpq/libpq.h"
 #include "libpq/pqsignal.h"
 #include "miscadmin.h"
 #include "pg_trace.h"
@@ -1607,13 +1606,26 @@ AtCommit_Memory(void)
 {
 	TransactionState s = CurrentTransactionState;
 
-	/*
-	 * Return to the memory context that was current before we started the
-	 * transaction.  (In principle, this could not be any of the contexts we
-	 * are about to delete.  If it somehow is, assertions in mcxt.c will
-	 * complain.)
-	 */
-	MemoryContextSwitchTo(s->priorContext);
+	if (is_bbf_tds_connection_hook && is_bbf_tds_connection_hook())
+	{
+		/*
+		 * For TDS/T-SQL connections, use top memory context instead of
+		 * priorContext. This avoids using stale priorContext pointers that may
+		 * reference deleted SPI memory contexts.
+		 */
+		MemoryContextSwitchTo(TopMemoryContext);
+	}
+	else
+	{
+		/*
+		 * Return to the memory context that was current before we started the
+		 * transaction.  (In principle, this could not be any of the contexts we
+		 * are about to delete.  If it somehow is, assertions in mcxt.c will
+		 * complain.)
+		 */
+		MemoryContextSwitchTo(s->priorContext);
+	}
+	
 
 	/*
 	 * Release all transaction-local memory.  TopTransactionContext survives
@@ -1986,13 +1998,25 @@ AtCleanup_Memory(void)
 	/* Should be at top level */
 	Assert(s->parent == NULL);
 
-	/*
-	 * Return to the memory context that was current before we started the
-	 * transaction.  (In principle, this could not be any of the contexts we
-	 * are about to delete.  If it somehow is, assertions in mcxt.c will
-	 * complain.)
-	 */
-	MemoryContextSwitchTo(s->priorContext);
+	if (is_bbf_tds_connection_hook && is_bbf_tds_connection_hook())
+	{
+		/*
+		 * For TDS/T-SQL connections, use top memory context instead of
+		 * priorContext. This avoids using stale priorContext pointers that may
+		 * reference deleted SPI memory contexts.
+		 */
+		MemoryContextSwitchTo(TopMemoryContext);
+	}
+	else
+	{
+		/*
+		 * Return to the memory context that was current before we started the
+		 * transaction.  (In principle, this could not be any of the contexts we
+		 * are about to delete.  If it somehow is, assertions in mcxt.c will
+		 * complain.)
+		 */
+		MemoryContextSwitchTo(s->priorContext);
+	}
 
 	/*
 	 * Clear the special abort context for next time.
@@ -2033,14 +2057,14 @@ AtSubCleanup_Memory(void)
 
 	Assert(s->parent != NULL);
 
-	if (MyProcPort && MyProcPort->is_tds_conn && sql_dialect == SQL_DIALECT_TSQL)
+	if (is_bbf_tds_connection_hook && is_bbf_tds_connection_hook())
 	{
 		/*
-		* For TDS/T-SQL connections, use parent's transaction context instead of
-		* priorContext. This avoids using stale priorContext pointers that may
-		* reference deleted SPI memory contexts, which can cause assertion failures
-		* when the memory is reused and creates circular parent-child relationships.
-		*/
+		 * For TDS/T-SQL connections, use parent's transaction context instead of
+		 * priorContext. This avoids using stale priorContext pointers that may
+		 * reference deleted SPI memory contexts, which can cause assertion failures
+		 * when the memory is reused and creates circular parent-child relationships.
+		 */
 		MemoryContextSwitchTo(s->parent->curTransactionContext);
 	}
 	else


### PR DESCRIPTION
### Description
Fix circular memory context in nested transactions with SPI cleanup

Upstream commit 1afe31f03c changed transaction commit to restore the original memory context instead of switching to TopMemoryContext, fixing session-lifespan memory leaks. However, this exposed an issue in Babelfish
where SPI_finish() destroys temporary "SPI Proc" contexts that may still be referenced as priorContext in active transactions.

The problem manifests when executing bulk insert within a transaction with savepoints. During rollback, the subtransaction's priorContext points to the deleted SPI context. When this deleted memory is reused, it can create a circular reference where curTransactionContext->priorContext->parent points back to curTransactionContext, violating PostgreSQL's assertion that "context != CurrentMemoryContext".

This commit uses parent's transaction context instead of priorContext during subtransaction cleanup for TDS connections to avoid circular dependencies.

Extension PR https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4447 

### Issues Resolved

BABEL-6374, BABEL-6286
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
