### PR TITLE
Fix: Rectified removal and updates of incorrect tuples from ENR catalogs

### DIFF
--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -1081,7 +1081,30 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 				rel_oid = ((Form_pg_attrdef) GETSTRUCT(tup))->adrelid;
 				if ((enr = get_ENR_withoid(queryEnv, rel_oid, ENR_TSQL_TEMP, false))) {
 					list_ptr = &enr->md.cattups[ENR_CATTUP_ATTR_DEF_REL];
-					lc = list_head(enr->md.cattups[ENR_CATTUP_ATTR_DEF_REL]);
+					if (op ==ENR_OP_DROP || op ==ENR_OP_UPDATE)
+					{ 
+						Form_pg_attrdef tf1 = (Form_pg_attrdef) GETSTRUCT(tup);
+						ListCell *curlc;
+						lc= NULL;
+						foreach(curlc, enr->md.cattups[ENR_CATTUP_ATTR_DEF_REL]){
+							Form_pg_attrdef tf2 = (Form_pg_attrdef) GETSTRUCT((HeapTuple)lfirst(curlc));
+							if( tf1->oid==tf2->oid){
+								lc=curlc;
+								break;
+
+							}
+
+						}
+						if (lc==NULL){
+							ret=false;
+							break;
+						}
+
+					}
+					else{
+						lc = list_head(enr->md.cattups[ENR_CATTUP_ATTR_DEF_REL]);
+					}
+					
 					ret = true;
 				}
 				break;

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -914,7 +914,27 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 				rel_oid = ((Form_pg_index) GETSTRUCT(tup))->indrelid;
 				if ((enr = get_ENR_withoid(queryEnv, rel_oid, ENR_TSQL_TEMP, false))) {
 					list_ptr = &enr->md.cattups[ENR_CATTUP_INDEX];
+					if (op ==ENR_OP_DROP || op==ENR_OP_UPDATE){
+						Form_pg_index idxform1 = (Form_pg_index) GETSTRUCT(tup);
+						ListCell *curlc;
+						lc=NULL;
+						foreach(curlc, enr->md.cattups[ENR_CATTUP_INDEX]){
+							Form_pg_index idxform2 = (Form_pg_index) GETSTRUCT((HeapTuple)lfirst(curlc));
+							if( idxform1->indexrelid == idxform2->indexrelid){
+								lc=curlc;
+								break;
+
+							}
+
+						}
+						if (lc==NULL){
+							ret=false;
+							break;
+						}
+					}
+					else{
 					lc = list_head(enr->md.cattups[ENR_CATTUP_INDEX]);
+					}
 					ret = true;
 
 					if ((op == ENR_OP_ADD || op == ENR_OP_UPDATE) && HeapTupleIsValid(tup))
@@ -996,6 +1016,7 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 				if ((enr = get_ENR_withoid(queryEnv, rel_oid, ENR_TSQL_TEMP, false))) {
 					Form_pg_constraint tf1, tf2; /* tuple forms*/
 					ListCell *curlc;
+
 
 					list_ptr = &enr->md.cattups[ENR_CATTUP_CONSTRAINT];
 					tf1 = (Form_pg_constraint) GETSTRUCT(tup);

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -914,34 +914,44 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 				rel_oid = ((Form_pg_index) GETSTRUCT(tup))->indrelid;
 				if ((enr = get_ENR_withoid(queryEnv, rel_oid, ENR_TSQL_TEMP, false))) {
 					list_ptr = &enr->md.cattups[ENR_CATTUP_INDEX];
-					if (op ==ENR_OP_DROP || op==ENR_OP_UPDATE){
-						Form_pg_index idxform1 = (Form_pg_index) GETSTRUCT(tup);
-						ListCell *curlc;
-						lc=NULL;
-						foreach(curlc, enr->md.cattups[ENR_CATTUP_INDEX]){
-							Form_pg_index idxform2 = (Form_pg_index) GETSTRUCT((HeapTuple)lfirst(curlc));
-							if( idxform1->indexrelid == idxform2->indexrelid){
-								lc=curlc;
-								break;
-
+					
+					switch (op) {
+						case ENR_OP_DROP:
+						case ENR_OP_UPDATE:
+						{
+							/*For DROP/UPDATE operations, search for the exact pg_index 
+							 tuple by matching indexrelid. */
+							Form_pg_index idxform1 = (Form_pg_index) GETSTRUCT(tup);
+							ListCell *curlc;
+							lc = NULL;
+							
+							foreach(curlc, enr->md.cattups[ENR_CATTUP_INDEX]) {
+								Form_pg_index idxform2 = (Form_pg_index) GETSTRUCT((HeapTuple)lfirst(curlc));
+								if (idxform1->indexrelid == idxform2->indexrelid) {
+									lc = curlc;
+									break;
+								}
 							}
-
-						}
-						if (lc==NULL){
-							ret=false;
+							
+							if (lc == NULL) {
+								ret = false;
+							}
+							else {
+								ret = true;
+							}
 							break;
 						}
+						case ENR_OP_ADD:
+						default:
+							lc = list_head(enr->md.cattups[ENR_CATTUP_INDEX]);
+							ret = true;
+							break;
 					}
-					else{
-					lc = list_head(enr->md.cattups[ENR_CATTUP_INDEX]);
-					}
-					ret = true;
 
 					if ((op == ENR_OP_ADD || op == ENR_OP_UPDATE) && HeapTupleIsValid(tup))
 					{
 						Form_pg_index indexForm = (Form_pg_index) GETSTRUCT(tup);
-
-						if(indexForm->indisreplident)
+						if (indexForm->indisreplident)
 							elog(ERROR, "Invalid pg_index ENR entry.");
 					}
 				}
@@ -1017,7 +1027,6 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 					Form_pg_constraint tf1, tf2; /* tuple forms*/
 					ListCell *curlc;
 
-
 					list_ptr = &enr->md.cattups[ENR_CATTUP_CONSTRAINT];
 					tf1 = (Form_pg_constraint) GETSTRUCT(tup);
 					foreach(curlc, enr->md.cattups[ENR_CATTUP_CONSTRAINT]) {
@@ -1081,31 +1090,39 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 				rel_oid = ((Form_pg_attrdef) GETSTRUCT(tup))->adrelid;
 				if ((enr = get_ENR_withoid(queryEnv, rel_oid, ENR_TSQL_TEMP, false))) {
 					list_ptr = &enr->md.cattups[ENR_CATTUP_ATTR_DEF_REL];
-					if (op ==ENR_OP_DROP || op ==ENR_OP_UPDATE)
-					{ 
-						Form_pg_attrdef tf1 = (Form_pg_attrdef) GETSTRUCT(tup);
-						ListCell *curlc;
-						lc= NULL;
-						foreach(curlc, enr->md.cattups[ENR_CATTUP_ATTR_DEF_REL]){
-							Form_pg_attrdef tf2 = (Form_pg_attrdef) GETSTRUCT((HeapTuple)lfirst(curlc));
-							if( tf1->oid==tf2->oid){
-								lc=curlc;
-								break;
-
+					
+					switch (op) {
+						case ENR_OP_DROP:
+						case ENR_OP_UPDATE:
+						{
+							/* For DROP/UPDATE operations, search for the exact pg_attrdef 
+							tuple by matching oid.*/
+							Form_pg_attrdef tf1 = (Form_pg_attrdef) GETSTRUCT(tup);
+							ListCell *curlc;
+							lc = NULL;
+							
+							foreach(curlc, enr->md.cattups[ENR_CATTUP_ATTR_DEF_REL]) {
+								Form_pg_attrdef tf2 = (Form_pg_attrdef) GETSTRUCT((HeapTuple)lfirst(curlc));
+								if (tf1->oid == tf2->oid) {
+									lc = curlc;
+									break;
+								}
 							}
-
-						}
-						if (lc==NULL){
-							ret=false;
+							
+							if (lc == NULL) {
+								ret = false;
+							}
+							else {
+								ret = true;
+							}
 							break;
 						}
-
+						case ENR_OP_ADD:
+						default:
+							lc = list_head(enr->md.cattups[ENR_CATTUP_ATTR_DEF_REL]);
+							ret = true;
+							break;
 					}
-					else{
-						lc = list_head(enr->md.cattups[ENR_CATTUP_ATTR_DEF_REL]);
-					}
-					
-					ret = true;
 				}
 				break;
 			default:


### PR DESCRIPTION
### Description

1)Fixed the issue of dropping an intermediate index leads to "could not open relation with oid" error.

--When dropping an index on a temp table that has multiple indexes, the wrong pg_index tuple was being removed from ENR's cattups[ENR_CATTUP_INDEX] because list_head() was used, which always returns the first element regardless of 
which index is being dropped.

2)Fixed the issue -ALTER TABLE on temp table with multiple column defaults corrupts ENR, causing INSERT and DROP TABLE to fail.

-- When altering a column default on a temp table that has multiple columns with DEFAULT values, the wrong pg_attrdef tuple was being removed from ENR's cattups[ENR_CATTUP_ATTR_DEF_REL] because list_head() was used, which always returns the first element regardless of which column's default is being modified.
 
### Issues Resolved

Jiras Fixed - BABEL-6168 and  BABEL-6305

Authored-By- Ayush Pandey  ayushhx@amazon.com
Signed off-By -Ayush Pandey  ayushhx@amazon.com
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
