### PR TITLE
[BABEL] Added BBF hook to simplify const expressions during planning

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -900,7 +900,7 @@ subquery_planner(PlannerGlobal *glob, Query *parse, PlannerInfo *parent_root,
 	preprocess_qual_conditions(root, (Node *) parse->jointree);
 
 	if(planner_node_transformer_hook)
-		parse->havingQual = planner_node_transformer_hook(root, parse->havingQual, EXPRKIND_QUAL);
+		parse->havingQual = planner_node_transformer_hook(root, parse->havingQual, EXPRKIND_QUAL, NULL);
 
 	parse->havingQual = preprocess_expression(root, parse->havingQual,
 											  EXPRKIND_QUAL);
@@ -1166,6 +1166,7 @@ subquery_planner(PlannerGlobal *glob, Query *parse, PlannerInfo *parent_root,
 static Node *
 preprocess_expression(PlannerInfo *root, Node *expr, int kind)
 {
+	int			prev_expr_kind;
 	/*
 	 * Fall out quickly if expression is empty.  This occurs often enough to
 	 * be worth checking.  Note that null->null is the correct conversion for
@@ -1191,7 +1192,7 @@ preprocess_expression(PlannerInfo *root, Node *expr, int kind)
 		expr = flatten_join_alias_vars(root, root->parse, expr);
 
 	if(EXPRKIND_TARGET == kind && planner_node_transformer_hook)
-		expr = planner_node_transformer_hook(root, expr, kind);
+		expr = planner_node_transformer_hook(root, expr, kind, &prev_expr_kind);
 
 	/*
 	 * Simplify constant expressions.  For function RTEs, this was already
@@ -1217,7 +1218,7 @@ preprocess_expression(PlannerInfo *root, Node *expr, int kind)
 
 	/* Reset context of expression */
 	if(EXPRKIND_TARGET == kind && planner_node_transformer_hook)
-		(void) planner_node_transformer_hook(root, NULL, -1);
+		(void) planner_node_transformer_hook(root, NULL, -1, &prev_expr_kind);
 
 	/*
 	 * If it's a qual or havingQual, canonicalize it.
@@ -1290,7 +1291,7 @@ preprocess_qual_conditions(PlannerInfo *root, Node *jtnode)
 			preprocess_qual_conditions(root, lfirst(l));
 
 		if(planner_node_transformer_hook)
-			f->quals = planner_node_transformer_hook(root, f->quals, EXPRKIND_QUAL);
+			f->quals = planner_node_transformer_hook(root, f->quals, EXPRKIND_QUAL, NULL);
 
 		f->quals = preprocess_expression(root, f->quals, EXPRKIND_QUAL);
 	}
@@ -1302,7 +1303,7 @@ preprocess_qual_conditions(PlannerInfo *root, Node *jtnode)
 		preprocess_qual_conditions(root, j->rarg);
 
 		if(planner_node_transformer_hook)
-			j->quals = planner_node_transformer_hook(root, j->quals, EXPRKIND_QUAL);
+			j->quals = planner_node_transformer_hook(root, j->quals, EXPRKIND_QUAL, NULL);
 
 		j->quals = preprocess_expression(root, j->quals, EXPRKIND_QUAL);
 	}

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -76,7 +76,7 @@ planner_node_transformer_hook_type planner_node_transformer_hook = NULL;
 /* Hook for plugins to get control when grouping_planner() plans upper rels */
 create_upper_paths_hook_type create_upper_paths_hook = NULL;
 /* Hook for plugins to flag whether parameters are dynamic */
-planner_simplify_const_expression_type planner_simplify_const_expression_hook = NULL;
+eval_const_expressions_in_preprocess_hook_type eval_const_expressions_in_preprocess_hook = NULL;
 
 
 /* Expression kind codes for preprocess_expression */
@@ -1192,6 +1192,9 @@ preprocess_expression(PlannerInfo *root, Node *expr, int kind)
 		  kind == EXPRKIND_TABLEFUNC))
 		expr = flatten_join_alias_vars(root, root->parse, expr);
 
+	if(EXPRKIND_TARGET == kind && planner_node_transformer_hook)
+		expr = planner_node_transformer_hook(root, expr, kind);
+
 	/*
 	 * Simplify constant expressions.  For function RTEs, this was already
 	 * done by preprocess_function_rtes.  (But note we must do it again for
@@ -1213,8 +1216,8 @@ preprocess_expression(PlannerInfo *root, Node *expr, int kind)
 	 */
 	if (kind != EXPRKIND_RTFUNC)
 	{
-		if (planner_simplify_const_expression_hook)
-			expr = planner_simplify_const_expression_hook(root, expr, kind);
+		if (eval_const_expressions_in_preprocess_hook)
+			expr = eval_const_expressions_in_preprocess_hook(root, expr, kind);
 		else
 			expr = eval_const_expressions(root, expr);
 	}

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -900,7 +900,7 @@ subquery_planner(PlannerGlobal *glob, Query *parse, PlannerInfo *parent_root,
 	preprocess_qual_conditions(root, (Node *) parse->jointree);
 
 	if(planner_node_transformer_hook)
-		parse->havingQual = planner_node_transformer_hook(root, parse->havingQual, EXPRKIND_QUAL, NULL);
+		parse->havingQual = planner_node_transformer_hook(root, parse->havingQual, EXPRKIND_QUAL);
 
 	parse->havingQual = preprocess_expression(root, parse->havingQual,
 											  EXPRKIND_QUAL);
@@ -1166,7 +1166,6 @@ subquery_planner(PlannerGlobal *glob, Query *parse, PlannerInfo *parent_root,
 static Node *
 preprocess_expression(PlannerInfo *root, Node *expr, int kind)
 {
-	int			prev_expr_kind;
 	/*
 	 * Fall out quickly if expression is empty.  This occurs often enough to
 	 * be worth checking.  Note that null->null is the correct conversion for
@@ -1192,7 +1191,7 @@ preprocess_expression(PlannerInfo *root, Node *expr, int kind)
 		expr = flatten_join_alias_vars(root, root->parse, expr);
 
 	if(EXPRKIND_TARGET == kind && planner_node_transformer_hook)
-		expr = planner_node_transformer_hook(root, expr, kind, &prev_expr_kind);
+		expr = planner_node_transformer_hook(root, expr, kind);
 
 	/*
 	 * Simplify constant expressions.  For function RTEs, this was already
@@ -1218,7 +1217,7 @@ preprocess_expression(PlannerInfo *root, Node *expr, int kind)
 
 	/* Reset context of expression */
 	if(EXPRKIND_TARGET == kind && planner_node_transformer_hook)
-		(void) planner_node_transformer_hook(root, NULL, -1, &prev_expr_kind);
+		(void) planner_node_transformer_hook(root, NULL, -1);
 
 	/*
 	 * If it's a qual or havingQual, canonicalize it.
@@ -1291,7 +1290,7 @@ preprocess_qual_conditions(PlannerInfo *root, Node *jtnode)
 			preprocess_qual_conditions(root, lfirst(l));
 
 		if(planner_node_transformer_hook)
-			f->quals = planner_node_transformer_hook(root, f->quals, EXPRKIND_QUAL, NULL);
+			f->quals = planner_node_transformer_hook(root, f->quals, EXPRKIND_QUAL);
 
 		f->quals = preprocess_expression(root, f->quals, EXPRKIND_QUAL);
 	}
@@ -1303,7 +1302,7 @@ preprocess_qual_conditions(PlannerInfo *root, Node *jtnode)
 		preprocess_qual_conditions(root, j->rarg);
 
 		if(planner_node_transformer_hook)
-			j->quals = planner_node_transformer_hook(root, j->quals, EXPRKIND_QUAL, NULL);
+			j->quals = planner_node_transformer_hook(root, j->quals, EXPRKIND_QUAL);
 
 		j->quals = preprocess_expression(root, j->quals, EXPRKIND_QUAL);
 	}

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -75,6 +75,8 @@ planner_hook_type planner_hook = NULL;
 planner_node_transformer_hook_type planner_node_transformer_hook = NULL;
 /* Hook for plugins to get control when grouping_planner() plans upper rels */
 create_upper_paths_hook_type create_upper_paths_hook = NULL;
+/* Hook for plugins to flag whether parameters are dynamic */
+planner_simplify_const_expression_type planner_simplify_const_expression_hook = NULL;
 
 
 /* Expression kind codes for preprocess_expression */
@@ -1190,9 +1192,6 @@ preprocess_expression(PlannerInfo *root, Node *expr, int kind)
 		  kind == EXPRKIND_TABLEFUNC))
 		expr = flatten_join_alias_vars(root, root->parse, expr);
 
-	if(EXPRKIND_TARGET == kind && planner_node_transformer_hook)
-		expr = planner_node_transformer_hook(root, expr, kind);
-
 	/*
 	 * Simplify constant expressions.  For function RTEs, this was already
 	 * done by preprocess_function_rtes.  (But note we must do it again for
@@ -1213,11 +1212,12 @@ preprocess_expression(PlannerInfo *root, Node *expr, int kind)
 	 * with AND directly under AND, nor OR directly under OR.
 	 */
 	if (kind != EXPRKIND_RTFUNC)
-		expr = eval_const_expressions(root, expr);
-
-	/* Reset context of expression */
-	if(EXPRKIND_TARGET == kind && planner_node_transformer_hook)
-		(void) planner_node_transformer_hook(root, NULL, -1);
+	{
+		if (planner_simplify_const_expression_hook)
+			expr = planner_simplify_const_expression_hook(root, expr, kind);
+		else
+			expr = eval_const_expressions(root, expr);
+	}
 
 	/*
 	 * If it's a qual or havingQual, canonicalize it.

--- a/src/include/optimizer/planner.h
+++ b/src/include/optimizer/planner.h
@@ -32,7 +32,8 @@ extern PGDLLEXPORT planner_hook_type planner_hook;
 /* Hook for plugins to transform qual nodes in planner */
 typedef Node* (*planner_node_transformer_hook_type) (PlannerInfo *root,
 												  Node *expr,
-												  int kind);
+												  int kind,
+												  int *prev_kind);
 extern PGDLLEXPORT planner_node_transformer_hook_type planner_node_transformer_hook;
 
 /* Hook for plugins to get control when grouping_planner() plans upper rels */

--- a/src/include/optimizer/planner.h
+++ b/src/include/optimizer/planner.h
@@ -32,8 +32,7 @@ extern PGDLLEXPORT planner_hook_type planner_hook;
 /* Hook for plugins to transform qual nodes in planner */
 typedef Node* (*planner_node_transformer_hook_type) (PlannerInfo *root,
 												  Node *expr,
-												  int kind,
-												  int *prev_kind);
+												  int kind);
 extern PGDLLEXPORT planner_node_transformer_hook_type planner_node_transformer_hook;
 
 /* Hook for plugins to get control when grouping_planner() plans upper rels */

--- a/src/include/optimizer/planner.h
+++ b/src/include/optimizer/planner.h
@@ -31,15 +31,15 @@ extern PGDLLEXPORT planner_hook_type planner_hook;
 
 /* Hook for plugins to transform qual nodes in planner */
 typedef Node* (*planner_node_transformer_hook_type) (PlannerInfo *root,
-												  Node *expr,
-												  int kind);
+												  	 Node *expr,
+												  	 int kind);
 extern PGDLLEXPORT planner_node_transformer_hook_type planner_node_transformer_hook;
 
 /* Hook for plugins to simplify constant expressions in planner */
-typedef Node* (*planner_simplify_const_expression_type) (PlannerInfo *root,
-												  Node *expr,
-												  int kind);
-extern PGDLLEXPORT planner_simplify_const_expression_type planner_simplify_const_expression_hook;
+typedef Node* (*eval_const_expressions_in_preprocess_hook_type) (PlannerInfo *root,
+												  				 Node *expr,
+												  				 int kind);
+extern PGDLLEXPORT eval_const_expressions_in_preprocess_hook_type eval_const_expressions_in_preprocess_hook;
 
 /* Hook for plugins to get control when grouping_planner() plans upper rels */
 typedef void (*create_upper_paths_hook_type) (PlannerInfo *root,

--- a/src/include/optimizer/planner.h
+++ b/src/include/optimizer/planner.h
@@ -35,6 +35,12 @@ typedef Node* (*planner_node_transformer_hook_type) (PlannerInfo *root,
 												  int kind);
 extern PGDLLEXPORT planner_node_transformer_hook_type planner_node_transformer_hook;
 
+/* Hook for plugins to simplify constant expressions in planner */
+typedef Node* (*planner_simplify_const_expression_type) (PlannerInfo *root,
+												  Node *expr,
+												  int kind);
+extern PGDLLEXPORT planner_simplify_const_expression_type planner_simplify_const_expression_hook;
+
 /* Hook for plugins to get control when grouping_planner() plans upper rels */
 typedef void (*create_upper_paths_hook_type) (PlannerInfo *root,
 											  UpperRelationKind stage,


### PR DESCRIPTION
### Description

This commit adds eval_const_expressions_in_preprocess_hook to evaluate expressions that can be substituted by a Const node during planning.
 
### Issues Resolved

Task: BABEL-3756
Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4425

### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
