### PR TITLE
[BABEL] Added BBF hook to simplify const expressions during planning …

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -77,6 +77,8 @@ planner_hook_type planner_hook = NULL;
 planner_node_transformer_hook_type planner_node_transformer_hook = NULL;
 /* Hook for plugins to get control when grouping_planner() plans upper rels */
 create_upper_paths_hook_type create_upper_paths_hook = NULL;
+/* Hook for plugins to flag whether parameters are dynamic */
+eval_const_expressions_in_preprocess_hook_type eval_const_expressions_in_preprocess_hook = NULL;
 
 
 /* Expression kind codes for preprocess_expression */
@@ -1312,11 +1314,12 @@ preprocess_expression(PlannerInfo *root, Node *expr, int kind)
 	 * with AND directly under AND, nor OR directly under OR.
 	 */
 	if (kind != EXPRKIND_RTFUNC)
-		expr = eval_const_expressions(root, expr);
-
-	/* Reset context of expression */
-	if(EXPRKIND_TARGET == kind && planner_node_transformer_hook)
-		(void) planner_node_transformer_hook(root, NULL, -1);
+	{
+		if (eval_const_expressions_in_preprocess_hook)
+			expr = eval_const_expressions_in_preprocess_hook(root, expr, kind);
+		else
+			expr = eval_const_expressions(root, expr);
+	}
 
 	/*
 	 * If it's a qual or havingQual, canonicalize it.

--- a/src/include/optimizer/planner.h
+++ b/src/include/optimizer/planner.h
@@ -31,9 +31,15 @@ extern PGDLLEXPORT planner_hook_type planner_hook;
 
 /* Hook for plugins to transform qual nodes in planner */
 typedef Node* (*planner_node_transformer_hook_type) (PlannerInfo *root,
-												  Node *expr,
-												  int kind);
+												  	 Node *expr,
+												  	 int kind);
 extern PGDLLEXPORT planner_node_transformer_hook_type planner_node_transformer_hook;
+
+/* Hook for plugins to simplify constant expressions in planner */
+typedef Node* (*eval_const_expressions_in_preprocess_hook_type) (PlannerInfo *root,
+												  				 Node *expr,
+												  				 int kind);
+extern PGDLLEXPORT eval_const_expressions_in_preprocess_hook_type eval_const_expressions_in_preprocess_hook;
 
 /* Hook for plugins to get control when grouping_planner() plans upper rels */
 typedef void (*create_upper_paths_hook_type) (PlannerInfo *root,


### PR DESCRIPTION
…(#701)

This commit adds eval_const_expressions_in_preprocess_hook to evaluate expressions that can be substituted by a Const node during planning.

Task: BABEL-3756

Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4532

Cherry-picked from https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/701

Authored by: Saurav Samantaray <sauravay@amazon.com>

### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
