### PR TITLE
[BABEL] Fix the crash when dropping a temp table from nested QueryEnv

### DIFF
--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -1186,27 +1186,24 @@ void ENRDropEntry(Oid id)
 	MemoryContext oldcxt;
 	QueryEnvironment *queryEnv;
 
-	if (sql_dialect != SQL_DIALECT_TSQL || !currentQueryEnv)
+	if ((sql_dialect != SQL_DIALECT_TSQL && !(is_bbf_tds_connection_hook && is_bbf_tds_connection_hook())) || !currentQueryEnv)
 		return;
 
-	if ((enr = GetENRTempTableWithOid(id, true)) == NULL)
-		return;
-
-	/* Find which query environment actually contains this ENR */
+	/* Find the ENR and which query environment contains it */
 	queryEnv = currentQueryEnv;
 	while (queryEnv)
 	{
-		if (list_member(queryEnv->namedRelList, enr))
+		if ((enr = get_ENR_withoid(queryEnv, id, ENR_TSQL_TEMP, false)) != NULL)
 			break;
 		queryEnv = queryEnv->parentEnv;
 	}
 
 	/* ENR not found in any environment */
-	if (!queryEnv)
+	if (!enr)
 		return;
 
 	oldcxt = MemoryContextSwitchTo(queryEnv->memctx);
-	queryEnv->namedRelList = list_delete(queryEnv->namedRelList, enr);
+	queryEnv->namedRelList = list_delete_ptr(queryEnv->namedRelList, enr);
 
 	/* If we are dropping a committed ENR, wait until COMMIT to free it. */
 	if (temp_table_xact_support && enr->md.is_bbf_temp_table)

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -1184,21 +1184,35 @@ void ENRDropEntry(Oid id)
 {
 	EphemeralNamedRelation	enr;
 	MemoryContext oldcxt;
+	QueryEnvironment *queryEnv;
 
 	if (sql_dialect != SQL_DIALECT_TSQL || !currentQueryEnv)
 		return;
 
-	if ((enr = GetENRTempTableWithOid(id, false)) == NULL)
+	if ((enr = GetENRTempTableWithOid(id, true)) == NULL)
 		return;
 
-	oldcxt = MemoryContextSwitchTo(currentQueryEnv->memctx);
-	currentQueryEnv->namedRelList = list_delete(currentQueryEnv->namedRelList, enr);
+	/* Find which query environment actually contains this ENR */
+	queryEnv = currentQueryEnv;
+	while (queryEnv)
+	{
+		if (list_member(queryEnv->namedRelList, enr))
+			break;
+		queryEnv = queryEnv->parentEnv;
+	}
+
+	/* ENR not found in any environment */
+	if (!queryEnv)
+		return;
+
+	oldcxt = MemoryContextSwitchTo(queryEnv->memctx);
+	queryEnv->namedRelList = list_delete(queryEnv->namedRelList, enr);
 
 	/* If we are dropping a committed ENR, wait until COMMIT to free it. */
 	if (temp_table_xact_support && enr->md.is_bbf_temp_table)
 	{
 		enr->md.dropped_subid = GetCurrentSubTransactionId();
-		currentQueryEnv->dropped_namedRelList = lappend(currentQueryEnv->dropped_namedRelList, enr);
+		queryEnv->dropped_namedRelList = lappend(queryEnv->dropped_namedRelList, enr);
 	}
 	else
 	{


### PR DESCRIPTION
### Description

Fix the crash when dropping a temp table from nested QueryEnv.
Extension PR : https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4550

Authored by: harshdu@amazon.com
Signed-off by : harshdu@amazon.com
 
### Issues Resolved

[BABEL-6268]

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
