### PR TITLE
[BABEL] Fix: Rectified removal and updates of incorrect tuples from ENR catalogs

### DIFF
--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -800,6 +800,53 @@ bool ENRUpdateTuple(Relation rel, HeapTuple tup)
 }
 
 /*
+ * Find matching tuple in ENR catalog list for DROP/UPDATE operations.
+ * Returns the ListCell containing the matching tuple, or NULL if not found.
+ */
+static ListCell *
+find_tuple_in_enr_catalog(List *cattups, HeapTuple search_tup, Oid catalog_oid)
+{
+	ListCell *lc;
+
+	foreach(lc, cattups)
+	{
+		HeapTuple enr_tup = (HeapTuple) lfirst(lc);
+		
+		switch (catalog_oid)
+		{
+			case IndexRelationId:
+			{
+				Form_pg_index idx1 = (Form_pg_index) GETSTRUCT(search_tup);
+				Form_pg_index idx2 = (Form_pg_index) GETSTRUCT(enr_tup);
+				if (idx1->indexrelid == idx2->indexrelid)
+					return lc;
+				break;
+			}
+			case AttrDefaultRelationId:
+			{
+				Form_pg_attrdef def1 = (Form_pg_attrdef) GETSTRUCT(search_tup);
+				Form_pg_attrdef def2 = (Form_pg_attrdef) GETSTRUCT(enr_tup);
+				if (def1->oid == def2->oid)
+					return lc;
+				break;
+			}
+			case ConstraintRelationId:
+			{
+				Form_pg_constraint con1 = (Form_pg_constraint) GETSTRUCT(search_tup);
+				Form_pg_constraint con2 = (Form_pg_constraint) GETSTRUCT(enr_tup);
+				if (con1->oid == con2->oid)
+					return lc;
+				break;
+			}
+			default:
+				elog(ERROR, "Unsupported catalog OID %u for tuple matching", catalog_oid);
+		}
+	}
+	
+	return NULL;
+}
+
+/*
  * Workhorse for add/update/drop tuples in the ENR.
  *
  * Return true if the asked operation is done.
@@ -925,8 +972,10 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 				rel_oid = ((Form_pg_index) GETSTRUCT(tup))->indrelid;
 				if ((enr = get_ENR_withoid(queryEnv, rel_oid, ENR_TSQL_TEMP, false))) {
 					list_ptr = &enr->md.cattups[ENR_CATTUP_INDEX];
-					lc = list_head(enr->md.cattups[ENR_CATTUP_INDEX]);
 					ret = true;
+					
+					if (op == ENR_OP_DROP || op == ENR_OP_UPDATE)
+						lc = find_tuple_in_enr_catalog(*list_ptr, tup, catalog_oid);
 
 					if ((op == ENR_OP_ADD || op == ENR_OP_UPDATE) && HeapTupleIsValid(tup))
 					{
@@ -1005,35 +1054,19 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 			case ConstraintRelationId:
 				rel_oid = ((Form_pg_constraint) GETSTRUCT(tup))->conrelid;
 				if ((enr = get_ENR_withoid(queryEnv, rel_oid, ENR_TSQL_TEMP, false))) {
-					Form_pg_constraint tf1, tf2; /* tuple forms*/
-					ListCell *curlc;
-
 					list_ptr = &enr->md.cattups[ENR_CATTUP_CONSTRAINT];
-					tf1 = (Form_pg_constraint) GETSTRUCT(tup);
+					ret = true;
 					
 					switch (op)
 					{
 						case ENR_OP_ADD:
-							/* For ADD, simply append to the end of the list */
 							insert_at = list_length(enr->md.cattups[ENR_CATTUP_CONSTRAINT]);
 							break;
 						case ENR_OP_DROP:
 						case ENR_OP_UPDATE:
-							/* For DROP/UPDATE, find the matching tuple by OID */
-							foreach(curlc, enr->md.cattups[ENR_CATTUP_CONSTRAINT]) {
-								tf2 = (Form_pg_constraint) GETSTRUCT((HeapTuple) lfirst(curlc));
-								if (tf2->oid == tf1->oid)
-								{
-									lc = curlc;
-									break;
-								}
-							}
-							break;
-						default:
-							elog(ERROR, "Unexpected operation type for ENR_tuple_operation: %d", op);
+							lc = find_tuple_in_enr_catalog(*list_ptr, tup, catalog_oid);
 							break;
 					}
-					ret = true;
 				}
 				break;
 			case StatisticRelationId:
@@ -1086,8 +1119,10 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 				rel_oid = ((Form_pg_attrdef) GETSTRUCT(tup))->adrelid;
 				if ((enr = get_ENR_withoid(queryEnv, rel_oid, ENR_TSQL_TEMP, false))) {
 					list_ptr = &enr->md.cattups[ENR_CATTUP_ATTR_DEF_REL];
-					lc = list_head(enr->md.cattups[ENR_CATTUP_ATTR_DEF_REL]);
 					ret = true;
+					
+					if (op == ENR_OP_DROP || op == ENR_OP_UPDATE)
+						lc = find_tuple_in_enr_catalog(*list_ptr, tup, catalog_oid);
 				}
 				break;
 			default:


### PR DESCRIPTION
#700 
### Description
When dropping an index or default constraint on a temp table that has multiple indexes and defaults, the wrong tuple was being removed from ENR catalogs because list_head() was used, which always returns the first element regardless of which index is being dropped.
This fix classifies the operations so that if the operation is a DROP or UPDATE, we try to match the exact tuple being dropped/updated using the OID of the object.
 
### Issues Resolved

BABEL-6168, BABEL-6305

 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
