### PR TITLE
[OSS-ONLY] Fix: Remove the pg_depend tuple in case depender object is already deleted

### DIFF
--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -103,6 +103,7 @@ static void ENRDeleteUncommittedTupleData(SubTransactionId subid, EphemeralNamed
 static void ENRRollbackUncommittedTuple(QueryEnvironment *queryEnv, ENRUncommittedTuple uncommitted_tup);
 static bool IsCatalogOidENR(Oid reloid, bool extended);
 static EphemeralNamedRelation find_enr(Form_pg_depend entry);
+static EphemeralNamedRelation find_pg_depend_tuple(Form_pg_depend tf);
 
 QueryEnvironment *
 create_queryEnv(void)
@@ -931,6 +932,38 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 						}
 						ret = true;
 					}
+					else
+					{
+						/*
+						 * While deletion, we first drop the object and then delete all its outgoing edges.
+						 * See: deleteOneObject in dependency.c
+						 * 
+						 * In which case, we can run into a situation where the associated ENR cannot be 
+						 * identified because pg_depend tuple does not contain enough information; for example 
+						 * a arraytype to ENR temp table pg_depend tuple - in this case, the arraytype is removed
+						 * from ENR, hence find_associated_enr will return NULL; but in that case, we can simply directly 
+						 * look for the pg_depend entry by matching the exact tuple (classid, objid, refclassid, refobjid).
+						 */
+						ListCell *tmplc;
+						if ((enr = find_pg_depend_tuple(tf1)))
+						{
+							list_ptr = &enr->md.cattups[ENR_CATTUP_DEPEND];
+							foreach(tmplc, enr->md.cattups[ENR_CATTUP_DEPEND]) {
+								Form_pg_depend tup = (Form_pg_depend) GETSTRUCT((HeapTuple) lfirst(tmplc));
+								if (tup->classid == tf1->classid &&
+									tup->objid == tf1->objid && 
+									tup->objsubid == tf1->objsubid && 
+									tup->refclassid == tf1->refclassid &&
+									tup->refobjid == tf1->refobjid && 
+									tup->refobjsubid== tf1->refobjsubid)
+								{
+									lc = tmplc;
+									break;
+								}
+							}
+							ret = true;
+						}
+					}
 					break;
 				}
 			case SharedDependRelationId:
@@ -1232,6 +1265,36 @@ static EphemeralNamedRelation find_enr(Form_pg_depend entry)
 
 			default:
 				break;
+		}
+		queryEnv = queryEnv->parentEnv;
+	}
+	return NULL;
+}
+
+static 
+EphemeralNamedRelation find_pg_depend_tuple(Form_pg_depend tf)
+{
+	QueryEnvironment 	*queryEnv = currentQueryEnv;
+	ListCell 			*outerlc, *innerlc;
+	
+	while (queryEnv)
+	{
+		foreach(outerlc, queryEnv->namedRelList)
+		{
+			EphemeralNamedRelation enr = (EphemeralNamedRelation) lfirst(outerlc);
+			if (enr->md.enrtype != ENR_TSQL_TEMP)
+				continue;
+
+			foreach(innerlc, enr->md.cattups[ENR_CATTUP_DEPEND]) {
+				Form_pg_depend tup = (Form_pg_depend) GETSTRUCT((HeapTuple) lfirst(innerlc));
+				if (tup->classid == tf->classid &&
+					tup->objid == tf->objid && 
+					tup->objsubid == tf->objsubid && 
+					tup->refclassid == tf->refclassid &&
+					tup->refobjid == tf->refobjid && 
+					tup->refobjsubid== tf->refobjsubid)
+					return enr;
+			}
 		}
 		queryEnv = queryEnv->parentEnv;
 	}


### PR DESCRIPTION
### Description

Original PR - https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/708

While deletion, we first drop the object and then delete all its outgoing edges. In which case, we can run into a situation where the associated ENR cannot be identified because pg_depend tuple does not contain enough information, hence find_associated_enr will return NULL but in that case, we can simply directly look for the pg_depend entry by matching the exact tuple.

Extension PR - babelfish-for-postgresql/babelfish_extensions#4576

Authored-by: Ayush Shah <ayushdsh@amazon.com>
(cherry picked from commit d4a75a3aa74a5b47c866cad8ec222c8b87035b94)
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
