### PR TITLE
[BABEL] Fix: Allow creation of dependency from ENR objects to system objects for babelfish ENR temporary tables (#709)

### DIFF
--- a/src/backend/catalog/pg_depend.c
+++ b/src/backend/catalog/pg_depend.c
@@ -106,6 +106,9 @@ recordMultipleDependencies(const ObjectAddress *depender,
 		 */
 		if (isObjectPinned(referenced))
 			continue;
+		
+		if (is_enr_to_sys_object_dependency_hook && (*is_enr_to_sys_object_dependency_hook) (depender, referenced))
+			continue;
 
 		if (slot_init_count < max_slots)
 		{

--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -909,7 +909,7 @@ LockAcquireExtended(const LOCKTAG *locktag,
 	bool		log_lock = false;
 	bool		is_temp_relation_lock = pltsql_get_tsql_enr_from_oid_hook && locktag->locktag_type == LOCKTAG_RELATION && 
 										(*pltsql_get_tsql_enr_from_oid_hook)(locktag->locktag_field2);
-	bool		is_temp_object_lock = find_object_in_enr_hook && locktag->locktag_type == LOCKTAG_OBJECT && (*find_object_in_enr_hook) (locktag->locktag_field2, locktag->locktag_field3);
+	bool		is_temp_object_lock = find_object_in_enr_hook && locktag->locktag_type == LOCKTAG_OBJECT && (*find_object_in_enr_hook) (locktag->locktag_field2, locktag->locktag_field3, NULL);
 
 	if (lockmethodid <= 0 || lockmethodid >= lengthof(LockMethods))
 		elog(ERROR, "unrecognized lock method: %d", lockmethodid);

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -57,6 +57,7 @@
 
 pltsql_get_tsql_enr_from_oid_hook_type pltsql_get_tsql_enr_from_oid_hook = NULL;
 find_object_in_enr_hook_type find_object_in_enr_hook = NULL;
+is_enr_to_sys_object_dependency_hook_type is_enr_to_sys_object_dependency_hook = NULL;
 
 /*
  * This list must match ENRCatalogTupleType in queryenvironment.h.
@@ -91,8 +92,8 @@ static void ENRAddUncommittedTupleData(EphemeralNamedRelation enr, Oid catoid, E
 static void ENRDeleteUncommittedTupleData(SubTransactionId subid, EphemeralNamedRelation enr);
 static void ENRRollbackUncommittedTuple(QueryEnvironment *queryEnv, ENRUncommittedTuple uncommitted_tup);
 static bool IsCatalogOidENR(Oid reloid, bool extended);
-static EphemeralNamedRelation find_enr(Form_pg_depend entry);
-static EphemeralNamedRelation find_pg_depend_tuple(Form_pg_depend tf);
+static EphemeralNamedRelation find_associated_enr(QueryEnvironment *queryEnv, Form_pg_depend entry);
+static EphemeralNamedRelation find_pg_depend_tuple(QueryEnvironment *qe, HeapTuple tosearch, ListCell **lc);
 
 QueryEnvironment *
 create_queryEnv(void)
@@ -793,10 +794,10 @@ bool ENRUpdateTuple(Relation rel, HeapTuple tup)
  * Find matching tuple in ENR catalog list for DROP/UPDATE operations.
  * Returns the ListCell containing the matching tuple, or NULL if not found.
  */
-static ListCell *
+static ListCell*
 find_tuple_in_enr_catalog(List *cattups, HeapTuple search_tup, Oid catalog_oid)
 {
-	ListCell *lc;
+	ListCell *lc = NULL;
 
 	foreach(lc, cattups)
 	{
@@ -806,25 +807,38 @@ find_tuple_in_enr_catalog(List *cattups, HeapTuple search_tup, Oid catalog_oid)
 		{
 			case IndexRelationId:
 			{
-				Form_pg_index idx1 = (Form_pg_index) GETSTRUCT(search_tup);
-				Form_pg_index idx2 = (Form_pg_index) GETSTRUCT(enr_tup);
-				if (idx1->indexrelid == idx2->indexrelid)
+				Form_pg_index tofind = (Form_pg_index) GETSTRUCT(search_tup);
+				Form_pg_index with = (Form_pg_index) GETSTRUCT(enr_tup);
+				if (tofind->indexrelid == with->indexrelid)
 					return lc;
 				break;
 			}
 			case AttrDefaultRelationId:
 			{
-				Form_pg_attrdef def1 = (Form_pg_attrdef) GETSTRUCT(search_tup);
-				Form_pg_attrdef def2 = (Form_pg_attrdef) GETSTRUCT(enr_tup);
-				if (def1->oid == def2->oid)
+				Form_pg_attrdef tofind = (Form_pg_attrdef) GETSTRUCT(search_tup);
+				Form_pg_attrdef with = (Form_pg_attrdef) GETSTRUCT(enr_tup);
+				if (tofind->oid == with->oid)
 					return lc;
 				break;
 			}
 			case ConstraintRelationId:
 			{
-				Form_pg_constraint con1 = (Form_pg_constraint) GETSTRUCT(search_tup);
-				Form_pg_constraint con2 = (Form_pg_constraint) GETSTRUCT(enr_tup);
-				if (con1->oid == con2->oid)
+				Form_pg_constraint tofind = (Form_pg_constraint) GETSTRUCT(search_tup);
+				Form_pg_constraint with = (Form_pg_constraint) GETSTRUCT(enr_tup);
+				if (tofind->oid == with->oid)
+					return lc;
+				break;
+			}
+			case DependRelationId:
+			{
+				Form_pg_depend tofind = (Form_pg_depend) GETSTRUCT(search_tup);
+				Form_pg_depend with = (Form_pg_depend) GETSTRUCT(enr_tup);
+				if (tofind->classid == with->classid &&
+					tofind->objid == with->objid && 
+					tofind->objsubid == with->objsubid && 
+					tofind->refclassid == with->refclassid &&
+					tofind->refobjid == with->refobjid && 
+					tofind->refobjsubid == with->refobjsubid)
 					return lc;
 				break;
 			}
@@ -892,7 +906,7 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 			case DependRelationId:
 				{
 					Form_pg_depend tf1 = (Form_pg_depend) GETSTRUCT((HeapTuple)tup);
-					if ((enr = find_enr(tf1))) {
+					if ((enr = find_associated_enr(queryEnv, tf1))) {
 						ListCell *curlc;
 						Form_pg_depend tf2; /* tuple forms*/
 
@@ -921,7 +935,7 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 						}
 						ret = true;
 					}
-					else
+					else if (op == ENR_OP_DROP)
 					{
 						/*
 						 * While deletion, we first drop the object and then delete all its outgoing edges.
@@ -933,23 +947,11 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 						 * from ENR, hence find_associated_enr will return NULL; but in that case, we can simply directly 
 						 * look for the pg_depend entry by matching the exact tuple (classid, objid, refclassid, refobjid).
 						 */
-						ListCell *tmplc;
-						if ((enr = find_pg_depend_tuple(tf1)))
+						ListCell *tmplc = NULL;
+						if ((enr = find_pg_depend_tuple(queryEnv, tup, &tmplc)))
 						{
 							list_ptr = &enr->md.cattups[ENR_CATTUP_DEPEND];
-							foreach(tmplc, enr->md.cattups[ENR_CATTUP_DEPEND]) {
-								Form_pg_depend tup = (Form_pg_depend) GETSTRUCT((HeapTuple) lfirst(tmplc));
-								if (tup->classid == tf1->classid &&
-									tup->objid == tf1->objid && 
-									tup->objsubid == tf1->objsubid && 
-									tup->refclassid == tf1->refclassid &&
-									tup->refobjid == tf1->refobjid && 
-									tup->refobjsubid== tf1->refobjsubid)
-								{
-									lc = tmplc;
-									break;
-								}
-							}
+							lc = tmplc;
 							ret = true;
 						}
 					}
@@ -1206,86 +1208,79 @@ static bool _ENR_tuple_operation(Relation catalog_rel, HeapTuple tup, ENRTupleOp
 /*
  * Helper for _ENR_tuple_operation
  */
-static EphemeralNamedRelation find_enr(Form_pg_depend entry)
+static EphemeralNamedRelation
+find_associated_enr(QueryEnvironment *queryEnv, Form_pg_depend entry)
 {
-	QueryEnvironment *queryEnv = currentQueryEnv;
-	Oid catalog_oid = entry->classid;
+	EphemeralNamedRelation depender_object_enr = NULL;
+	/*
+	 * If the babelfishpg extension is not active, we shouldn't be coming into this
+	 * codepath at all. We will silently return NULL and let the caller handle it.
+	 */
+	if (!find_object_in_enr_hook)
+		return NULL;
+	
+	/*
+	 * pg_depend entry depicts a depender object depends on a referenced object.
+	 * If the depender object is a non-ENR, we will simply skip adding anything and
+	 * return NULL. The caller handles the rest.
+	 */
+	depender_object_enr = (*find_object_in_enr_hook) (entry->classid, entry->objid, queryEnv);
 
-	ListCell         *curlc;
+	if (!depender_object_enr)
+		return NULL;
 
-	while (queryEnv)
-	{
-		switch (catalog_oid) {
-			/*
-			* pg_depend entry shows relation/type/constraint depends on a given object.
-			* Find the relation from ENR. If found, make sure
-			* to register the dependency of the ENR relation to this object.
-			*/
-			case RelationRelationId:
-				return get_ENR_withoid(queryEnv, entry->objid, ENR_TSQL_TEMP, false);
-
-			case TypeRelationId:
-				foreach(curlc, queryEnv->namedRelList) {
-					EphemeralNamedRelation tmp_enr;
-					ListCell *type_lc;
-
-					tmp_enr = (EphemeralNamedRelation) lfirst(curlc);
-					if (tmp_enr->md.enrtype != ENR_TSQL_TEMP)
-						continue;
-
-					foreach(type_lc, tmp_enr->md.cattups[ENR_CATTUP_TYPE])
-					{
-						Form_pg_type tup = ((Form_pg_type)GETSTRUCT((HeapTuple)lfirst(type_lc)));
-						if (tup->oid == entry->objid)
-							return tmp_enr;
-					}
-					foreach(type_lc, tmp_enr->md.cattups[ENR_CATTUP_ARRAYTYPE])
-					{
-						Form_pg_type tup = ((Form_pg_type)GETSTRUCT((HeapTuple)lfirst(type_lc)));
-						if (tup->oid == entry->objid)
-							return tmp_enr;
-					}
-				}
-				break;
-
-			case ConstraintRelationId:
-			case AttrDefaultRelationId:
-				return get_ENR_withoid(queryEnv, entry->refobjid, ENR_TSQL_TEMP, false);
-
-			default:
-				break;
+	switch (entry->classid) {
+		case RelationRelationId:
+		case TypeRelationId:
+		{
+			return depender_object_enr;
 		}
-		queryEnv = queryEnv->parentEnv;
+		case ConstraintRelationId:
+		case AttrDefaultRelationId:
+		{
+			EphemeralNamedRelation referenced_object_enr = (*find_object_in_enr_hook) (entry->refclassid, entry->refobjid, queryEnv);
+
+			/*
+			 * If both the dependency and dependent objects are in ENR, then we simply return this ENR
+			 * so that the caller can add this tuple in ENR's pg_depend catalog.
+			 */
+			if (referenced_object_enr)
+			{
+				Assert(referenced_object_enr == depender_object_enr);
+				return referenced_object_enr;
+			}
+			else
+			{
+				ereport(ERROR,
+						(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+						errmsg("temporary objects cannot reference permanent non-system objects")));
+			}
+			break;
+		}
+		default:
+			break;
 	}
 	return NULL;
 }
 
-static 
-EphemeralNamedRelation find_pg_depend_tuple(Form_pg_depend tf)
+/*
+ * Finds the ENR and the tuple which matches the passed in tuple tosearch by searching
+ * the pg_depend catalog by traversing through all the ENRs in the given queryEnvironment.
+ */
+static EphemeralNamedRelation
+find_pg_depend_tuple(QueryEnvironment *qe, HeapTuple tosearch, ListCell** lc)
 {
-	QueryEnvironment 	*queryEnv = currentQueryEnv;
-	ListCell 			*outerlc, *innerlc;
+	ListCell *outerlc;
 	
-	while (queryEnv)
+	foreach(outerlc, qe->namedRelList)
 	{
-		foreach(outerlc, queryEnv->namedRelList)
-		{
-			EphemeralNamedRelation enr = (EphemeralNamedRelation) lfirst(outerlc);
-			if (enr->md.enrtype != ENR_TSQL_TEMP)
-				continue;
+		EphemeralNamedRelation enr = (EphemeralNamedRelation) lfirst(outerlc);
+		if (enr->md.enrtype != ENR_TSQL_TEMP)
+			continue;
 
-			foreach(innerlc, enr->md.cattups[ENR_CATTUP_DEPEND]) {
-				Form_pg_depend tup = (Form_pg_depend) GETSTRUCT((HeapTuple) lfirst(innerlc));
-				if (tup->classid == tf->classid &&
-					tup->objid == tf->objid && 
-					tup->objsubid == tf->objsubid && 
-					tup->refclassid == tf->refclassid &&
-					tup->refobjid == tf->refobjid && 
-					tup->refobjsubid== tf->refobjsubid)
-					return enr;
-			}
-		}
-		queryEnv = queryEnv->parentEnv;
+		*lc = find_tuple_in_enr_catalog(enr->md.cattups[ENR_CATTUP_DEPEND], tosearch, DependRelationId);
+		if ((*lc))
+			return enr;
 	}
 	return NULL;
 }

--- a/src/include/utils/queryenvironment.h
+++ b/src/include/utils/queryenvironment.h
@@ -17,6 +17,7 @@
 #include "access/tupdesc.h"
 #include "access/htup.h"
 #include "access/skey.h"
+#include "catalog/objectaddress.h"
 #include "utils/memutils.h"
 #include "utils/relcache.h"
 #include "storage/sinval.h"
@@ -183,7 +184,10 @@ extern bool has_existing_enr_relations(void);
 typedef EphemeralNamedRelation (*pltsql_get_tsql_enr_from_oid_hook_type) (Oid oid);
 extern PGDLLIMPORT pltsql_get_tsql_enr_from_oid_hook_type pltsql_get_tsql_enr_from_oid_hook;
 
-typedef EphemeralNamedRelation (*find_object_in_enr_hook_type) (Oid catalog_oid, Oid object_id);
+typedef EphemeralNamedRelation (*find_object_in_enr_hook_type) (Oid catalog_oid, Oid object_id, QueryEnvironment *qe);
 extern PGDLLIMPORT find_object_in_enr_hook_type find_object_in_enr_hook;
+
+typedef bool (*is_enr_to_sys_object_dependency_hook_type) (const ObjectAddress *depender, const ObjectAddress *referenced);
+extern PGDLLIMPORT is_enr_to_sys_object_dependency_hook_type is_enr_to_sys_object_dependency_hook;
 
 #endif							/* QUERYENVIRONMENT_H */


### PR DESCRIPTION
### Description

Original PR: #709

Currently, when we create a dependency from ENR object to a non-ENR, we add it to pg_catalog. On RO, we should prevent any ENR -> non-ENR dependency creation, however system objects are safe to create such dependencies because those cannot be deleted. Hence, in case the non-ENR is a system object, we can just skip adding this dependency at all.

Extension PR - babelfish-for-postgresql/babelfish_extensions#4577

Task: BABEL-6139

Authored-by: Ayush Shah <ayushdsh@amazon.com>
(cherry picked from commit b44618b66d55afdb82284d0d48003e54ed96ae87)
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
