### PR TITLE
[BABEL] Fix for Index and Toast Creation Not getting registered in correct QueryEnvironment

### DIFF
--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1402,37 +1402,27 @@ heap_create_with_catalog(const char *relname,
 		enr->md.parent_oid = InvalidOid;
 
 		/*
-		 * For toast tables, register the ENR in the same queryEnv as the parent table
+		 * For toast tables, register the ENR in the same queryEnv as the parent table.
+		 * Toast table name format: #pg_toast_<parent_oid>
 		 */
-		if (relkind == RELKIND_TOASTVALUE)
+		if (relkind == RELKIND_TOASTVALUE && strncmp(relname, "#pg_toast_", 10) == 0)
 		{
-			Oid parent_oid = InvalidOid;
-			const char *oid_start = NULL;
+			Oid parent_oid = (Oid) strtoul(relname + 10, NULL, 10);
 
-			/* Extract parent OID from name pattern */
-			if (strncmp(relname, "#pg_toast_", 10) == 0)
-				oid_start = relname + 10;
-			else if (strncmp(relname, "@pg_toast_", 10) == 0)
-				oid_start = relname + 10;
-
-			if (oid_start)
+			if (OidIsValid(parent_oid))
 			{
-				parent_oid = (Oid) strtoul(oid_start, NULL, 10);
-				if (OidIsValid(parent_oid))
-				{
-					QueryEnvironment *qe = currentQueryEnv;
-					enr->md.parent_oid = parent_oid;
+				QueryEnvironment *qe = currentQueryEnv;
+				enr->md.parent_oid = parent_oid;
 
-					/* Find queryEnv where parent table is registered */
-					while (qe)
+				/* Find queryEnv where parent table is registered */
+				while (qe)
+				{
+					if (get_ENR_withoid(qe, parent_oid, ENR_TSQL_TEMP, false))
 					{
-						if (get_ENR_withoid(qe, parent_oid, ENR_TSQL_TEMP, false))
-						{
-							target_queryEnv = qe;
-							break;
-						}
-						qe = qe->parentEnv;
+						target_queryEnv = qe;
+						break;
 					}
+					qe = qe->parentEnv;
 				}
 			}
 		}

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1407,15 +1407,14 @@ heap_create_with_catalog(const char *relname,
 		if (relkind == RELKIND_TOASTVALUE && strncmp(relname, "#pg_toast_", 10) == 0)
 		{
 			Oid parent_oid = (Oid) strtoul(relname + 10, NULL, 10);
+			QueryEnvironment *parent_queryEnv;
 
-			if (OidIsValid(parent_oid))
-			{
-				QueryEnvironment *parent_queryEnv = find_ENR_queryEnv(parent_oid);
+			Assert(OidIsValid(parent_oid));
 
-				enr->md.parent_oid = parent_oid;
-				if (parent_queryEnv != NULL)
-					target_queryEnv = parent_queryEnv;
-			}
+			enr->md.parent_oid = parent_oid;
+			parent_queryEnv = find_ENR_queryEnv(parent_oid);
+			if (parent_queryEnv != NULL)
+				target_queryEnv = parent_queryEnv;
 		}
 
 		register_ENR(target_queryEnv, enr);

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1402,16 +1402,16 @@ heap_create_with_catalog(const char *relname,
 		enr->md.parent_oid = InvalidOid;
 
 		/*
-		 * For toast tables, register the ENR in the same queryEnv as the parent table.
+		 * For toast tables, register the relation as ENR in the same queryEnv as the parent relation table.
 		 */
 		if (relkind == RELKIND_TOASTVALUE)
 		{
-			Oid parent_oid = get_toast_parent_oid(relname);
+			Oid parent_rel_oid = get_toast_parent_oid(relname);
 
-			Assert(OidIsValid(parent_oid));
+			Assert(OidIsValid(parent_rel_oid));
 
-			enr->md.parent_oid = parent_oid;
-			target_queryEnv = find_ENR_queryEnv(parent_oid);
+			enr->md.parent_oid = parent_rel_oid;
+			target_queryEnv = find_ENR_queryEnv(parent_rel_oid);
 			if (!target_queryEnv)
 				target_queryEnv = currentQueryEnv;
 		}

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1412,8 +1412,7 @@ heap_create_with_catalog(const char *relname,
 
 			enr->md.parent_oid = parent_rel_oid;
 			target_queryEnv = find_ENR_queryEnv(parent_rel_oid);
-			if (!target_queryEnv)
-				target_queryEnv = currentQueryEnv;
+			Assert(target_queryEnv != NULL);
 		}
 
 		register_ENR(target_queryEnv, enr);

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1404,17 +1404,16 @@ heap_create_with_catalog(const char *relname,
 		/*
 		 * For toast tables, register the ENR in the same queryEnv as the parent table.
 		 */
-		if (relkind == RELKIND_TOASTVALUE && strncmp(relname, "#pg_toast_", 10) == 0)
+		if (relkind == RELKIND_TOASTVALUE)
 		{
-			Oid parent_oid = (Oid) strtoul(relname + 10, NULL, 10);
-			QueryEnvironment *parent_queryEnv;
+			Oid parent_oid = get_toast_parent_oid(relname);
 
 			Assert(OidIsValid(parent_oid));
 
 			enr->md.parent_oid = parent_oid;
-			parent_queryEnv = find_ENR_queryEnv(parent_oid);
-			if (parent_queryEnv != NULL)
-				target_queryEnv = parent_queryEnv;
+			target_queryEnv = find_ENR_queryEnv(parent_oid);
+			if (!target_queryEnv)
+				target_queryEnv = currentQueryEnv;
 		}
 
 		register_ENR(target_queryEnv, enr);

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1410,19 +1410,11 @@ heap_create_with_catalog(const char *relname,
 
 			if (OidIsValid(parent_oid))
 			{
-				QueryEnvironment *qe = currentQueryEnv;
-				enr->md.parent_oid = parent_oid;
+				QueryEnvironment *parent_queryEnv = find_ENR_queryEnv(parent_oid);
 
-				/* Find queryEnv where parent table is registered */
-				while (qe)
-				{
-					if (get_ENR_withoid(qe, parent_oid, ENR_TSQL_TEMP, false))
-					{
-						target_queryEnv = qe;
-						break;
-					}
-					qe = qe->parentEnv;
-				}
+				enr->md.parent_oid = parent_oid;
+				if (parent_queryEnv != NULL)
+					target_queryEnv = parent_queryEnv;
 			}
 		}
 

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -1403,7 +1403,6 @@ heap_create_with_catalog(const char *relname,
 
 		/*
 		 * For toast tables, register the ENR in the same queryEnv as the parent table.
-		 * Toast table name format: #pg_toast_<parent_oid>
 		 */
 		if (relkind == RELKIND_TOASTVALUE && strncmp(relname, "#pg_toast_", 10) == 0)
 		{

--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -79,6 +79,7 @@
 #include "utils/inval.h"
 #include "utils/lsyscache.h"
 #include "utils/syscache.h"
+#include "utils/queryenvironment.h"
 
 InvokePreAddConstraintsHook_type InvokePreAddConstraintsHook = NULL;
 transform_check_constraint_expr_hook_type transform_check_constraint_expr_hook = NULL;
@@ -1392,12 +1393,51 @@ heap_create_with_catalog(const char *relname,
 	{
 		MemoryContext oldcontext = MemoryContextSwitchTo(CacheMemoryContext);
 		EphemeralNamedRelation enr = palloc0(sizeof(EphemeralNamedRelationData));
+		QueryEnvironment *target_queryEnv = currentQueryEnv;
+
 		enr->md.name = palloc0(strlen(relname) + 1);
 		strncpy(enr->md.name, relname, strlen(relname) + 1);
 		enr->md.reliddesc = relid;
 		enr->md.enrtype = ENR_TSQL_TEMP;
 		enr->md.parent_oid = InvalidOid;
-		register_ENR(currentQueryEnv, enr);
+
+		/*
+		 * For toast tables, register the ENR in the same queryEnv as the parent table
+		 */
+		if (relkind == RELKIND_TOASTVALUE)
+		{
+			Oid parent_oid = InvalidOid;
+			const char *oid_start = NULL;
+
+			/* Extract parent OID from name pattern */
+			if (strncmp(relname, "#pg_toast_", 10) == 0)
+				oid_start = relname + 10;
+			else if (strncmp(relname, "@pg_toast_", 10) == 0)
+				oid_start = relname + 10;
+
+			if (oid_start)
+			{
+				parent_oid = (Oid) strtoul(oid_start, NULL, 10);
+				if (OidIsValid(parent_oid))
+				{
+					QueryEnvironment *qe = currentQueryEnv;
+					enr->md.parent_oid = parent_oid;
+
+					/* Find queryEnv where parent table is registered */
+					while (qe)
+					{
+						if (get_ENR_withoid(qe, parent_oid, ENR_TSQL_TEMP, false))
+						{
+							target_queryEnv = qe;
+							break;
+						}
+						qe = qe->parentEnv;
+					}
+				}
+			}
+		}
+
+		register_ENR(target_queryEnv, enr);
 		MemoryContextSwitchTo(oldcontext);
 	}
 

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -79,6 +79,7 @@
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
 #include "utils/tuplesort.h"
+#include "utils/queryenvironment.h"
 
 /* Potentially set by pg_upgrade_support functions */
 Oid			binary_upgrade_next_index_pg_class_oid = InvalidOid;
@@ -1010,12 +1011,32 @@ index_create(Relation heapRelation,
 	{
 		MemoryContext oldcontext = MemoryContextSwitchTo(CacheMemoryContext);
 		EphemeralNamedRelation enr = palloc0(sizeof(EphemeralNamedRelationData));
+		QueryEnvironment *target_queryEnv = currentQueryEnv;
+
 		enr->md.name = palloc0(strlen(indexRelationName) + 1);
 		strncpy(enr->md.name, indexRelationName, strlen(indexRelationName) + 1);
 		enr->md.reliddesc = indexRelationId;
 		enr->md.enrtype = ENR_TSQL_TEMP;
 		enr->md.parent_oid = heapRelationId;
-		register_ENR(currentQueryEnv, enr);
+
+		/*
+		 * Find the query environment where the parent temp table's ENR lives.
+		 */
+		if (currentQueryEnv)
+		{
+			QueryEnvironment *qe = currentQueryEnv;
+			while (qe)
+			{
+				if (get_ENR_withoid(qe, heapRelationId, ENR_TSQL_TEMP, false))
+				{
+					target_queryEnv = qe;
+					break;
+				}
+				qe = qe->parentEnv;
+			}
+		}
+
+		register_ENR(target_queryEnv, enr);
 		MemoryContextSwitchTo(oldcontext);
 	}
 

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -1011,7 +1011,7 @@ index_create(Relation heapRelation,
 	{
 		MemoryContext oldcontext = MemoryContextSwitchTo(CacheMemoryContext);
 		EphemeralNamedRelation enr = palloc0(sizeof(EphemeralNamedRelationData));
-		QueryEnvironment *target_queryEnv = currentQueryEnv;
+		QueryEnvironment *target_queryEnv;
 
 		enr->md.name = palloc0(strlen(indexRelationName) + 1);
 		strncpy(enr->md.name, indexRelationName, strlen(indexRelationName) + 1);
@@ -1020,21 +1020,14 @@ index_create(Relation heapRelation,
 		enr->md.parent_oid = heapRelationId;
 
 		/*
-		 * Find the query environment where the parent temp table's ENR lives.
+		 * Register the index ENR in the same queryEnv as its parent table.
+		 * This is important for SP_EXECUTESQL scenarios where the temp table
+		 * is created in an outer scope but the index is created in a nested
+		 * query environment.
 		 */
-		if (currentQueryEnv)
-		{
-			QueryEnvironment *qe = currentQueryEnv;
-			while (qe)
-			{
-				if (get_ENR_withoid(qe, heapRelationId, ENR_TSQL_TEMP, false))
-				{
-					target_queryEnv = qe;
-					break;
-				}
-				qe = qe->parentEnv;
-			}
-		}
+		target_queryEnv = find_ENR_queryEnv(heapRelationId);
+		if (target_queryEnv == NULL)
+			target_queryEnv = currentQueryEnv;
 
 		register_ENR(target_queryEnv, enr);
 		MemoryContextSwitchTo(oldcontext);

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -1011,20 +1011,17 @@ index_create(Relation heapRelation,
 	{
 		MemoryContext oldcontext = MemoryContextSwitchTo(CacheMemoryContext);
 		EphemeralNamedRelation enr = palloc0(sizeof(EphemeralNamedRelationData));
-		QueryEnvironment *target_queryEnv;
+
+		/* Register the index ENR in the same queryEnv as its parent table */
+		QueryEnvironment *target_queryEnv = find_ENR_queryEnv(heapRelationId);
+		if (!target_queryEnv)
+			target_queryEnv = currentQueryEnv;
 
 		enr->md.name = palloc0(strlen(indexRelationName) + 1);
 		strncpy(enr->md.name, indexRelationName, strlen(indexRelationName) + 1);
 		enr->md.reliddesc = indexRelationId;
 		enr->md.enrtype = ENR_TSQL_TEMP;
 		enr->md.parent_oid = heapRelationId;
-
-		/*
-		 * Register the index ENR in the same queryEnv as its parent table.
-		 */
-		target_queryEnv = find_ENR_queryEnv(heapRelationId);
-		if (target_queryEnv == NULL)
-			target_queryEnv = currentQueryEnv;
 
 		register_ENR(target_queryEnv, enr);
 		MemoryContextSwitchTo(oldcontext);

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -1012,7 +1012,7 @@ index_create(Relation heapRelation,
 		MemoryContext oldcontext = MemoryContextSwitchTo(CacheMemoryContext);
 		EphemeralNamedRelation enr = palloc0(sizeof(EphemeralNamedRelationData));
 
-		/* Register the index ENR in the same queryEnv as its parent table */
+		/* Register the index as ENR in the same queryEnv as its parent relation table. */
 		QueryEnvironment *target_queryEnv = find_ENR_queryEnv(heapRelationId);
 		Assert(target_queryEnv != NULL);
 

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -1014,8 +1014,7 @@ index_create(Relation heapRelation,
 
 		/* Register the index ENR in the same queryEnv as its parent table */
 		QueryEnvironment *target_queryEnv = find_ENR_queryEnv(heapRelationId);
-		if (!target_queryEnv)
-			target_queryEnv = currentQueryEnv;
+		Assert(target_queryEnv != NULL);
 
 		enr->md.name = palloc0(strlen(indexRelationName) + 1);
 		strncpy(enr->md.name, indexRelationName, strlen(indexRelationName) + 1);

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -1021,9 +1021,6 @@ index_create(Relation heapRelation,
 
 		/*
 		 * Register the index ENR in the same queryEnv as its parent table.
-		 * This is important for SP_EXECUTESQL scenarios where the temp table
-		 * is created in an outer scope but the index is created in a nested
-		 * query environment.
 		 */
 		target_queryEnv = find_ENR_queryEnv(heapRelationId);
 		if (target_queryEnv == NULL)

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -15188,7 +15188,7 @@ ATExecSetRelOptions(Relation rel, List *defList, AlterTableType operation,
 
 	/* Fetch heap tuple */
 	relid = RelationGetRelid(rel);
-	is_enr = (sql_dialect == SQL_DIALECT_TSQL && get_ENR_withoid(currentQueryEnv, relid, ENR_TSQL_TEMP, false));
+	is_enr = (sql_dialect == SQL_DIALECT_TSQL && get_ENR_withoid(currentQueryEnv, relid, ENR_TSQL_TEMP, true));
 	if (is_enr)
 		tuple = SearchSysCache1(RELOID, ObjectIdGetDatum(relid));
 	else

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -1296,17 +1296,14 @@ void ENRDropEntry(Oid id)
 	if ((sql_dialect != SQL_DIALECT_TSQL && !(is_bbf_tds_connection_hook && is_bbf_tds_connection_hook())) || !currentQueryEnv)
 		return;
 
-	/* Find the ENR and which query environment contains it */
-	queryEnv = currentQueryEnv;
-	while (queryEnv)
-	{
-		if ((enr = get_ENR_withoid(queryEnv, id, ENR_TSQL_TEMP, false)) != NULL)
-			break;
-		queryEnv = queryEnv->parentEnv;
-	}
+	/* Find the query environment containing the ENR */
+	queryEnv = find_ENR_queryEnv(id);
+	if (queryEnv == NULL)
+		return;
 
-	/* ENR not found in any environment */
-	if (!enr)
+	/* Get the ENR from the found query environment */
+	enr = get_ENR_withoid(queryEnv, id, ENR_TSQL_TEMP, false);
+	if (enr == NULL)
 		return;
 
 	oldcxt = MemoryContextSwitchTo(queryEnv->memctx);

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -1966,25 +1966,3 @@ bool has_existing_enr_relations()
 
 	return false;
 }
-
-/*
- * find_ENR_queryEnv
- *
- * Find the query environment where an ENR with the given OID is registered.
- * Searches from currentQueryEnv up through parent environments.
- * Returns the queryEnv where the ENR is found, or NULL if not found.
- */
-QueryEnvironment *
-find_ENR_queryEnv(Oid relid)
-{
-	QueryEnvironment *qe = currentQueryEnv;
-
-	while (qe)
-	{
-		if (get_ENR_withoid(qe, relid, ENR_TSQL_TEMP, false))
-			return qe;
-		qe = qe->parentEnv;
-	}
-
-	return NULL;
-}

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -1969,3 +1969,25 @@ bool has_existing_enr_relations()
 
 	return false;
 }
+
+/*
+ * find_ENR_queryEnv
+ *
+ * Find the query environment where an ENR with the given OID is registered.
+ * Searches from currentQueryEnv up through parent environments.
+ * Returns the queryEnv where the ENR is found, or NULL if not found.
+ */
+QueryEnvironment *
+find_ENR_queryEnv(Oid relid)
+{
+	QueryEnvironment *qe = currentQueryEnv;
+
+	while (qe)
+	{
+		if (get_ENR_withoid(qe, relid, ENR_TSQL_TEMP, false))
+			return qe;
+		qe = qe->parentEnv;
+	}
+
+	return NULL;
+}

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -1298,12 +1298,12 @@ void ENRDropEntry(Oid id)
 
 	/* Find the query environment containing the ENR */
 	queryEnv = find_ENR_queryEnv(id);
-	if (queryEnv == NULL)
+	if (!queryEnv)
 		return;
 
 	/* Get the ENR from the found query environment */
 	enr = get_ENR_withoid(queryEnv, id, ENR_TSQL_TEMP, false);
-	if (enr == NULL)
+	if (!enr)
 		return;
 
 	oldcxt = MemoryContextSwitchTo(queryEnv->memctx);

--- a/src/include/utils/queryenvironment.h
+++ b/src/include/utils/queryenvironment.h
@@ -179,7 +179,6 @@ extern bool IsTsqlTempTable(char relpersistence);
 extern bool UseTempOidBuffer(void);
 extern bool UseTempOidBufferForOid(Oid relId);
 extern bool has_existing_enr_relations(void);
-extern QueryEnvironment *find_ENR_queryEnv(Oid relid);
 
 /* Hooks */
 
@@ -212,6 +211,28 @@ get_toast_parent_oid(const char *relname)
 		strncmp(relname, BBF_TABLEVAR_TOAST_PREFIX, BBF_TOAST_PREFIX_LEN) == 0)
 		return (Oid) strtoul(relname + BBF_TOAST_PREFIX_LEN, NULL, 10);
 	return InvalidOid;
+}
+
+/*
+ * find_ENR_queryEnv
+ *
+ * Find the query environment where an ENR with the given OID is registered.
+ * Searches from currentQueryEnv up through parent environments.
+ * Returns the queryEnv where the ENR is found, or NULL if not found.
+ */
+static inline QueryEnvironment *
+find_ENR_queryEnv(Oid relid)
+{
+	QueryEnvironment *qe = currentQueryEnv;
+
+	while (qe)
+	{
+		if (get_ENR_withoid(qe, relid, ENR_TSQL_TEMP, false))
+			return qe;
+		qe = qe->parentEnv;
+	}
+
+	return NULL;
 }
 
 #endif							/* QUERYENVIRONMENT_H */

--- a/src/include/utils/queryenvironment.h
+++ b/src/include/utils/queryenvironment.h
@@ -190,22 +190,27 @@ typedef bool (*is_enr_to_sys_object_dependency_hook_type) (const ObjectAddress *
 extern PGDLLIMPORT is_enr_to_sys_object_dependency_hook_type is_enr_to_sys_object_dependency_hook;
 
 /*
- * Babelfish temp toast table name prefix and length.
- * Toast tables for temp tables are named "#pg_toast_<parent_oid>".
+ * Babelfish toast table name prefixes and length.
+ * Toast tables for temp tables are named "#pg_toast_<parent_rel_oid>".
+ * Toast tables for table variables are named "@pg_toast_<parent_rel_oid>".
+ * Both prefixes have the same length (10 characters).
  */
 #define BBF_TEMP_TOAST_PREFIX		"#pg_toast_"
-#define BBF_TEMP_TOAST_PREFIX_LEN	10
+#define BBF_TABLEVAR_TOAST_PREFIX	"@pg_toast_"
+#define BBF_TOAST_PREFIX_LEN		10
 
 /*
  * Extract parent table OID from temp toast table name.
- * Toast table names follow the pattern "#pg_toast_<parent_oid>".
- * Returns the parent OID, or InvalidOid if the name doesn't match the pattern.
+ * Toast table names follow the pattern "#pg_toast_<parent_rel_oid>" for temp tables
+ * or "@pg_toast_<parent_rel_oid>" for table variables.
+ * Returns the parent OID, or InvalidOid if the name doesn't match either pattern.
  */
 static inline Oid
 get_toast_parent_oid(const char *relname)
 {
-	if (strncmp(relname, BBF_TEMP_TOAST_PREFIX, BBF_TEMP_TOAST_PREFIX_LEN) == 0)
-		return (Oid) strtoul(relname + BBF_TEMP_TOAST_PREFIX_LEN, NULL, 10);
+	if (strncmp(relname, BBF_TEMP_TOAST_PREFIX, BBF_TOAST_PREFIX_LEN) == 0 ||
+		strncmp(relname, BBF_TABLEVAR_TOAST_PREFIX, BBF_TOAST_PREFIX_LEN) == 0)
+		return (Oid) strtoul(relname + BBF_TOAST_PREFIX_LEN, NULL, 10);
 	return InvalidOid;
 }
 

--- a/src/include/utils/queryenvironment.h
+++ b/src/include/utils/queryenvironment.h
@@ -179,6 +179,7 @@ extern bool IsTsqlTempTable(char relpersistence);
 extern bool UseTempOidBuffer(void);
 extern bool UseTempOidBufferForOid(Oid relId);
 extern bool has_existing_enr_relations(void);
+extern QueryEnvironment *find_ENR_queryEnv(Oid relid);
 
 /* Hooks */
 

--- a/src/include/utils/queryenvironment.h
+++ b/src/include/utils/queryenvironment.h
@@ -189,4 +189,24 @@ extern PGDLLIMPORT find_object_in_enr_hook_type find_object_in_enr_hook;
 typedef bool (*is_enr_to_sys_object_dependency_hook_type) (const ObjectAddress *depender, const ObjectAddress *referenced);
 extern PGDLLIMPORT is_enr_to_sys_object_dependency_hook_type is_enr_to_sys_object_dependency_hook;
 
+/*
+ * Babelfish temp toast table name prefix and length.
+ * Toast tables for temp tables are named "#pg_toast_<parent_oid>".
+ */
+#define BBF_TEMP_TOAST_PREFIX		"#pg_toast_"
+#define BBF_TEMP_TOAST_PREFIX_LEN	10
+
+/*
+ * Extract parent table OID from temp toast table name.
+ * Toast table names follow the pattern "#pg_toast_<parent_oid>".
+ * Returns the parent OID, or InvalidOid if the name doesn't match the pattern.
+ */
+static inline Oid
+get_toast_parent_oid(const char *relname)
+{
+	if (strncmp(relname, BBF_TEMP_TOAST_PREFIX, BBF_TEMP_TOAST_PREFIX_LEN) == 0)
+		return (Oid) strtoul(relname + BBF_TEMP_TOAST_PREFIX_LEN, NULL, 10);
+	return InvalidOid;
+}
+
 #endif							/* QUERYENVIRONMENT_H */


### PR DESCRIPTION
### Description

Index and Toast creation in Case of ENR temp tables were getting registered in CurrentQueryEnv, while the table for which this toast is being created were in the parent queryEnv.
 
Extension PR- https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4596
### Issues Resolved

BABEL -6272

Authored By- ayushhhx(ayushhx@amazon.com)
Signed off by - ayushhhx(ayushhx@amazon.com)
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
