### PR TITLE
[BABEL] Fix: Replace pltsql_get_tsql_enr_from_oid_hook check with find_object_in_enr_hook instead (#717)

### DIFF
--- a/src/backend/storage/lmgr/lmgr.c
+++ b/src/backend/storage/lmgr/lmgr.c
@@ -332,7 +332,7 @@ CheckRelationLockedByMe(Relation relation, LOCKMODE lockmode, bool orstronger)
 {
 	LOCKTAG		tag;
 
-	if (pltsql_get_tsql_enr_from_oid_hook && (*pltsql_get_tsql_enr_from_oid_hook)(RelationGetRelid(relation)))
+	if (find_object_in_enr_hook && (*find_object_in_enr_hook)(RelationRelationId, RelationGetRelid(relation), NULL))
 		return true;
 
 	SET_LOCKTAG_RELATION(tag,

--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -37,6 +37,7 @@
 #include "access/twophase_rmgr.h"
 #include "access/xlog.h"
 #include "access/xlogutils.h"
+#include "catalog/pg_class.h"
 #include "miscadmin.h"
 #include "pg_trace.h"
 #include "storage/proc.h"

--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -850,8 +850,7 @@ LockAcquireExtended(const LOCKTAG *locktag,
 	LWLock	   *partitionLock;
 	bool		found_conflict;
 	bool		log_lock = false;
-	bool		is_temp_relation_lock = pltsql_get_tsql_enr_from_oid_hook && locktag->locktag_type == LOCKTAG_RELATION && 
-										(*pltsql_get_tsql_enr_from_oid_hook)(locktag->locktag_field2);
+	bool		is_temp_relation_lock = find_object_in_enr_hook && locktag->locktag_type == LOCKTAG_RELATION && (*find_object_in_enr_hook) (RelationRelationId, locktag->locktag_field2, NULL);
 	bool		is_temp_object_lock = find_object_in_enr_hook && locktag->locktag_type == LOCKTAG_OBJECT && (*find_object_in_enr_hook) (locktag->locktag_field2, locktag->locktag_field3, NULL);
 
 	if (lockmethodid <= 0 || lockmethodid >= lengthof(LockMethods))
@@ -2048,6 +2047,7 @@ LockRelease(const LOCKTAG *locktag, LOCKMODE lockmode, bool sessionLock)
 	PROCLOCK   *proclock;
 	LWLock	   *partitionLock;
 	bool		wakeupNeeded;
+	bool		is_temp_relation_lock = find_object_in_enr_hook && locktag->locktag_type == LOCKTAG_RELATION && (*find_object_in_enr_hook) (RelationRelationId, locktag->locktag_field2, NULL);
 
 	if (lockmethodid <= 0 || lockmethodid >= lengthof(LockMethods))
 		elog(ERROR, "unrecognized lock method: %d", lockmethodid);
@@ -2055,8 +2055,7 @@ LockRelease(const LOCKTAG *locktag, LOCKMODE lockmode, bool sessionLock)
 	if (lockmode <= 0 || lockmode > lockMethodTable->numLockModes)
 		elog(ERROR, "unrecognized lock mode: %d", lockmode);
 	
-	if (pltsql_get_tsql_enr_from_oid_hook && locktag->locktag_type == LOCKTAG_RELATION && 
-		(*pltsql_get_tsql_enr_from_oid_hook)(locktag->locktag_field2))
+	if (is_temp_relation_lock)
 		return true;
 
 #ifdef LOCK_DEBUG

--- a/src/backend/utils/cache/inval.c
+++ b/src/backend/utils/cache/inval.c
@@ -460,7 +460,7 @@ AddRelcacheInvalidationMessage(InvalidationMsgsGroup *group,
 	msg.rc.id = SHAREDINVALRELCACHE_ID;
 	msg.rc.dbId = dbId;
 	msg.rc.relId = relId;
-	msg.rc.local_only = (pltsql_get_tsql_enr_from_oid_hook && (*pltsql_get_tsql_enr_from_oid_hook)(relId));
+	msg.rc.local_only = (find_object_in_enr_hook && (*find_object_in_enr_hook)(RelationRelationId, relId, NULL));
 	/* check AddCatcacheInvalidationMessage() for an explanation */
 	VALGRIND_MAKE_MEM_DEFINED(&msg, sizeof(msg));
 

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -55,7 +55,6 @@
 
 #define NUM_ENR_CATALOGS 11
 
-pltsql_get_tsql_enr_from_oid_hook_type pltsql_get_tsql_enr_from_oid_hook = NULL;
 find_object_in_enr_hook_type find_object_in_enr_hook = NULL;
 is_enr_to_sys_object_dependency_hook_type is_enr_to_sys_object_dependency_hook = NULL;
 

--- a/src/include/utils/queryenvironment.h
+++ b/src/include/utils/queryenvironment.h
@@ -181,8 +181,6 @@ extern bool UseTempOidBufferForOid(Oid relId);
 extern bool has_existing_enr_relations(void);
 
 /* Hooks */
-typedef EphemeralNamedRelation (*pltsql_get_tsql_enr_from_oid_hook_type) (Oid oid);
-extern PGDLLIMPORT pltsql_get_tsql_enr_from_oid_hook_type pltsql_get_tsql_enr_from_oid_hook;
 
 typedef EphemeralNamedRelation (*find_object_in_enr_hook_type) (Oid catalog_oid, Oid object_id, QueryEnvironment *qe);
 extern PGDLLIMPORT find_object_in_enr_hook_type find_object_in_enr_hook;


### PR DESCRIPTION
### Description

pltsql_get_tsql_enr_from_oid_hook checks if temp_oid_buffer is enabled and only then search for ENRs. However, temp_oid_buffer does not dictate if the relation goes into ENR or not. Intention with CheckRelationLockedByMe is to skip checking if the rel is ENR, hence we will simply replace this check with a simpler one - find_object_in_enr_hook.

ATRewriteTable now assumes that the new relation will be locked by the caller, however, if the rel is an ENR we skip locking it.

Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4594

Community commit which makes this assumption - https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/commit/0eb763c691771fcb92af0143cb22219b08be798f

Task: BABEL-6284


(cherry picked from commit 990d52025ef06671d1ebbecbd9a2d47e08b4106d)

 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
