### PR TITLE
[BABEL] Fix for Index creation And toast table registration issue (cherry pick from 5_X)

### DIFF
--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -79,6 +79,7 @@
 #include "utils/inval.h"
 #include "utils/lsyscache.h"
 #include "utils/syscache.h"
+#include "utils/queryenvironment.h"
 
 InvokePreAddConstraintsHook_type InvokePreAddConstraintsHook = NULL;
 transform_check_constraint_expr_hook_type transform_check_constraint_expr_hook = NULL;
@@ -1409,12 +1410,29 @@ heap_create_with_catalog(const char *relname,
 	{
 		MemoryContext oldcontext = MemoryContextSwitchTo(CacheMemoryContext);
 		EphemeralNamedRelation enr = palloc0(sizeof(EphemeralNamedRelationData));
+		QueryEnvironment *target_queryEnv = currentQueryEnv;
+
 		enr->md.name = palloc0(strlen(relname) + 1);
 		strncpy(enr->md.name, relname, strlen(relname) + 1);
 		enr->md.reliddesc = relid;
 		enr->md.enrtype = ENR_TSQL_TEMP;
 		enr->md.parent_oid = InvalidOid;
-		register_ENR(currentQueryEnv, enr);
+
+		/*
+		 * For toast tables, register the relation as ENR in the same queryEnv as the parent relation table.
+		 */
+		if (relkind == RELKIND_TOASTVALUE)
+		{
+			Oid parent_rel_oid = get_toast_parent_oid(relname);
+
+			Assert(OidIsValid(parent_rel_oid));
+
+			enr->md.parent_oid = parent_rel_oid;
+			target_queryEnv = find_ENR_queryEnv(parent_rel_oid);
+			Assert(target_queryEnv != NULL);
+		}
+
+		register_ENR(target_queryEnv, enr);
 		MemoryContextSwitchTo(oldcontext);
 	}
 

--- a/src/backend/catalog/index.c
+++ b/src/backend/catalog/index.c
@@ -80,6 +80,7 @@
 #include "utils/snapmgr.h"
 #include "utils/syscache.h"
 #include "utils/tuplesort.h"
+#include "utils/queryenvironment.h"
 
 /* Potentially set by pg_upgrade_support functions */
 Oid			binary_upgrade_next_index_pg_class_oid = InvalidOid;
@@ -1012,12 +1013,18 @@ index_create(Relation heapRelation,
 	{
 		MemoryContext oldcontext = MemoryContextSwitchTo(CacheMemoryContext);
 		EphemeralNamedRelation enr = palloc0(sizeof(EphemeralNamedRelationData));
+
+		/* Register the index as ENR in the same queryEnv as its parent relation table. */
+		QueryEnvironment *target_queryEnv = find_ENR_queryEnv(heapRelationId);
+		Assert(target_queryEnv != NULL);
+
 		enr->md.name = palloc0(strlen(indexRelationName) + 1);
 		strncpy(enr->md.name, indexRelationName, strlen(indexRelationName) + 1);
 		enr->md.reliddesc = indexRelationId;
 		enr->md.enrtype = ENR_TSQL_TEMP;
 		enr->md.parent_oid = heapRelationId;
-		register_ENR(currentQueryEnv, enr);
+
+		register_ENR(target_queryEnv, enr);
 		MemoryContextSwitchTo(oldcontext);
 	}
 

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -16813,7 +16813,7 @@ ATExecSetRelOptions(Relation rel, List *defList, AlterTableType operation,
 
 	/* Fetch heap tuple */
 	relid = RelationGetRelid(rel);
-	is_enr = (sql_dialect == SQL_DIALECT_TSQL && get_ENR_withoid(currentQueryEnv, relid, ENR_TSQL_TEMP, false));
+	is_enr = (sql_dialect == SQL_DIALECT_TSQL && get_ENR_withoid(currentQueryEnv, relid, ENR_TSQL_TEMP, true));
 	if (is_enr)
 		tuple = SearchSysCache1(RELOID, ObjectIdGetDatum(relid));
 	else

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -1296,16 +1296,13 @@ void ENRDropEntry(Oid id)
 	if ((sql_dialect != SQL_DIALECT_TSQL && !(is_bbf_tds_connection_hook && is_bbf_tds_connection_hook())) || !currentQueryEnv)
 		return;
 
-	/* Find the ENR and which query environment contains it */
-	queryEnv = currentQueryEnv;
-	while (queryEnv)
-	{
-		if ((enr = get_ENR_withoid(queryEnv, id, ENR_TSQL_TEMP, false)) != NULL)
-			break;
-		queryEnv = queryEnv->parentEnv;
-	}
+	/* Find the query environment containing the ENR */
+	queryEnv = find_ENR_queryEnv(id);
+	if (!queryEnv)
+		return;
 
-	/* ENR not found in any environment */
+	/* Get the ENR from the found query environment */
+	enr = get_ENR_withoid(queryEnv, id, ENR_TSQL_TEMP, false);
 	if (!enr)
 		return;
 

--- a/src/include/utils/queryenvironment.h
+++ b/src/include/utils/queryenvironment.h
@@ -188,4 +188,51 @@ extern PGDLLIMPORT find_object_in_enr_hook_type find_object_in_enr_hook;
 typedef bool (*is_enr_to_sys_object_dependency_hook_type) (const ObjectAddress *depender, const ObjectAddress *referenced);
 extern PGDLLIMPORT is_enr_to_sys_object_dependency_hook_type is_enr_to_sys_object_dependency_hook;
 
+/*
+ * Babelfish toast table name prefixes and length.
+ * Toast tables for temp tables are named "#pg_toast_<parent_rel_oid>".
+ * Toast tables for table variables are named "@pg_toast_<parent_rel_oid>".
+ * Both prefixes have the same length (10 characters).
+ */
+#define BBF_TEMP_TOAST_PREFIX		"#pg_toast_"
+#define BBF_TABLEVAR_TOAST_PREFIX	"@pg_toast_"
+#define BBF_TOAST_PREFIX_LEN		10
+
+/*
+ * Extract parent table OID from temp toast table name.
+ * Toast table names follow the pattern "#pg_toast_<parent_rel_oid>" for temp tables
+ * or "@pg_toast_<parent_rel_oid>" for table variables.
+ * Returns the parent OID, or InvalidOid if the name doesn't match either pattern.
+ */
+static inline Oid
+get_toast_parent_oid(const char *relname)
+{
+	if (strncmp(relname, BBF_TEMP_TOAST_PREFIX, BBF_TOAST_PREFIX_LEN) == 0 ||
+		strncmp(relname, BBF_TABLEVAR_TOAST_PREFIX, BBF_TOAST_PREFIX_LEN) == 0)
+		return (Oid) strtoul(relname + BBF_TOAST_PREFIX_LEN, NULL, 10);
+	return InvalidOid;
+}
+
+/*
+ * find_ENR_queryEnv
+ *
+ * Find the query environment where an ENR with the given OID is registered.
+ * Searches from currentQueryEnv up through parent environments.
+ * Returns the queryEnv where the ENR is found, or NULL if not found.
+ */
+static inline QueryEnvironment *
+find_ENR_queryEnv(Oid relid)
+{
+	QueryEnvironment *qe = currentQueryEnv;
+
+	while (qe)
+	{
+		if (get_ENR_withoid(qe, relid, ENR_TSQL_TEMP, false))
+			return qe;
+		qe = qe->parentEnv;
+	}
+
+	return NULL;
+}
+
 #endif							/* QUERYENVIRONMENT_H */


### PR DESCRIPTION
Cherry pick from (#718 )
### Description
Index and Toast creation in Case of ENR temp tables were getting registered in CurrentQueryEnv, while the table for which this toast is being created were in the parent queryEnv.
 
### Issues Resolved

BABEL-6272
 
Authored By- ayushhhx([ayushhx@amazon.com](mailto:ayushhx@amazon.com))
Signed off by - ayushhhx([ayushhx@amazon.com](mailto:ayushhx@amazon.com))

### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
