### PR TITLE
[BABEL] Moving the functions get_toast_parent_oid, find_ENR_queryEnv from the header files to C file

### DIFF
--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -54,6 +54,9 @@
 #include "utils/rel.h"
 
 #define NUM_ENR_CATALOGS 11
+#define BBF_TEMP_TOAST_PREFIX		"#pg_toast_"
+#define BBF_TABLEVAR_TOAST_PREFIX	"@pg_toast_"
+#define BBF_TOAST_PREFIX_LEN		10
 
 find_object_in_enr_hook_type find_object_in_enr_hook = NULL;
 is_enr_to_sys_object_dependency_hook_type is_enr_to_sys_object_dependency_hook = NULL;
@@ -1965,4 +1968,43 @@ bool has_existing_enr_relations()
 	}
 
 	return false;
+}
+
+/*
+ * get_toast_parent_oid
+ *
+ * Extract parent table OID from temp toast table name.
+ * Toast table names follow the pattern "#pg_toast_<parent_rel_oid>" for temp tables
+ * or "@pg_toast_<parent_rel_oid>" for table variables.
+ * Returns the parent OID, or InvalidOid if the name doesn't match either pattern.
+ */
+inline Oid
+get_toast_parent_oid(const char *relname)
+{
+	if (strncmp(relname, BBF_TEMP_TOAST_PREFIX, BBF_TOAST_PREFIX_LEN) == 0 ||
+		strncmp(relname, BBF_TABLEVAR_TOAST_PREFIX, BBF_TOAST_PREFIX_LEN) == 0)
+		return (Oid) strtoul(relname + BBF_TOAST_PREFIX_LEN, NULL, 10);
+	return InvalidOid;
+}
+
+/*
+ * find_ENR_queryEnv
+ *
+ * Find the query environment where an ENR with the given OID is registered.
+ * Searches from currentQueryEnv up through parent environments.
+ * Returns the queryEnv where the ENR is found, or NULL if not found.
+ */
+inline QueryEnvironment *
+find_ENR_queryEnv(Oid relid)
+{
+	QueryEnvironment *qe = currentQueryEnv;
+
+	while (qe)
+	{
+		if (get_ENR_withoid(qe, relid, ENR_TSQL_TEMP, false))
+			return qe;
+		qe = qe->parentEnv;
+	}
+
+	return NULL;
 }

--- a/src/backend/utils/misc/queryenvironment.c
+++ b/src/backend/utils/misc/queryenvironment.c
@@ -54,9 +54,10 @@
 #include "utils/rel.h"
 
 #define NUM_ENR_CATALOGS 11
-#define BBF_TEMP_TOAST_PREFIX		"#pg_toast_"
-#define BBF_TABLEVAR_TOAST_PREFIX	"@pg_toast_"
-#define BBF_TOAST_PREFIX_LEN		10
+#define BBF_TEMP_TOAST_PREFIX "#pg_toast_"
+#define BBF_TABLEVAR_TOAST_PREFIX "@pg_toast_"
+#define BBF_TOAST_PREFIX_LEN 10
+#define BASE_10 10
 
 find_object_in_enr_hook_type find_object_in_enr_hook = NULL;
 is_enr_to_sys_object_dependency_hook_type is_enr_to_sys_object_dependency_hook = NULL;
@@ -1978,12 +1979,12 @@ bool has_existing_enr_relations()
  * or "@pg_toast_<parent_rel_oid>" for table variables.
  * Returns the parent OID, or InvalidOid if the name doesn't match either pattern.
  */
-inline Oid
+Oid
 get_toast_parent_oid(const char *relname)
 {
 	if (strncmp(relname, BBF_TEMP_TOAST_PREFIX, BBF_TOAST_PREFIX_LEN) == 0 ||
 		strncmp(relname, BBF_TABLEVAR_TOAST_PREFIX, BBF_TOAST_PREFIX_LEN) == 0)
-		return (Oid) strtoul(relname + BBF_TOAST_PREFIX_LEN, NULL, 10);
+		return (Oid) strtoul(relname + BBF_TOAST_PREFIX_LEN, NULL, BASE_10);
 	return InvalidOid;
 }
 
@@ -1994,7 +1995,7 @@ get_toast_parent_oid(const char *relname)
  * Searches from currentQueryEnv up through parent environments.
  * Returns the queryEnv where the ENR is found, or NULL if not found.
  */
-inline QueryEnvironment *
+QueryEnvironment *
 find_ENR_queryEnv(Oid relid)
 {
 	QueryEnvironment *qe = currentQueryEnv;

--- a/src/include/utils/queryenvironment.h
+++ b/src/include/utils/queryenvironment.h
@@ -157,8 +157,8 @@ extern bool ENRGetSystableScan(Relation rel, Oid indexoid, int nkeys, ScanKey ke
 extern bool ENRAddTuple(Relation rel, HeapTuple tup);
 extern bool ENRDropTuple(Relation rel, HeapTuple tup);
 extern bool ENRUpdateTuple(Relation rel, HeapTuple tup);
-extern Oid get_toast_parent_oid(const char *relname);
-extern QueryEnvironment *find_ENR_queryEnv(Oid relid);
+extern inline Oid get_toast_parent_oid(const char *relname);
+extern inline QueryEnvironment *find_ENR_queryEnv(Oid relid);
 
 extern void ENRDropEntry(Oid id);
 extern PGDLLEXPORT void ENRDropTempTables(QueryEnvironment *queryEnv);

--- a/src/include/utils/queryenvironment.h
+++ b/src/include/utils/queryenvironment.h
@@ -157,8 +157,8 @@ extern bool ENRGetSystableScan(Relation rel, Oid indexoid, int nkeys, ScanKey ke
 extern bool ENRAddTuple(Relation rel, HeapTuple tup);
 extern bool ENRDropTuple(Relation rel, HeapTuple tup);
 extern bool ENRUpdateTuple(Relation rel, HeapTuple tup);
-extern inline Oid get_toast_parent_oid(const char *relname);
-extern inline QueryEnvironment *find_ENR_queryEnv(Oid relid);
+extern Oid get_toast_parent_oid(const char *relname);
+extern QueryEnvironment *find_ENR_queryEnv(Oid relid);
 
 extern void ENRDropEntry(Oid id);
 extern PGDLLEXPORT void ENRDropTempTables(QueryEnvironment *queryEnv);

--- a/src/include/utils/queryenvironment.h
+++ b/src/include/utils/queryenvironment.h
@@ -190,14 +190,4 @@ extern PGDLLIMPORT find_object_in_enr_hook_type find_object_in_enr_hook;
 typedef bool (*is_enr_to_sys_object_dependency_hook_type) (const ObjectAddress *depender, const ObjectAddress *referenced);
 extern PGDLLIMPORT is_enr_to_sys_object_dependency_hook_type is_enr_to_sys_object_dependency_hook;
 
-/*
- * Babelfish toast table name prefixes and length.
- * Toast tables for temp tables are named "#pg_toast_<parent_rel_oid>".
- * Toast tables for table variables are named "@pg_toast_<parent_rel_oid>".
- * Both prefixes have the same length (10 characters).
- */
-#define BBF_TEMP_TOAST_PREFIX		"#pg_toast_"
-#define BBF_TABLEVAR_TOAST_PREFIX	"@pg_toast_"
-#define BBF_TOAST_PREFIX_LEN		10
-
 #endif							/* QUERYENVIRONMENT_H */

--- a/src/include/utils/queryenvironment.h
+++ b/src/include/utils/queryenvironment.h
@@ -157,6 +157,8 @@ extern bool ENRGetSystableScan(Relation rel, Oid indexoid, int nkeys, ScanKey ke
 extern bool ENRAddTuple(Relation rel, HeapTuple tup);
 extern bool ENRDropTuple(Relation rel, HeapTuple tup);
 extern bool ENRUpdateTuple(Relation rel, HeapTuple tup);
+extern Oid get_toast_parent_oid(const char *relname);
+extern QueryEnvironment *find_ENR_queryEnv(Oid relid);
 
 extern void ENRDropEntry(Oid id);
 extern PGDLLEXPORT void ENRDropTempTables(QueryEnvironment *queryEnv);
@@ -197,42 +199,5 @@ extern PGDLLIMPORT is_enr_to_sys_object_dependency_hook_type is_enr_to_sys_objec
 #define BBF_TEMP_TOAST_PREFIX		"#pg_toast_"
 #define BBF_TABLEVAR_TOAST_PREFIX	"@pg_toast_"
 #define BBF_TOAST_PREFIX_LEN		10
-
-/*
- * Extract parent table OID from temp toast table name.
- * Toast table names follow the pattern "#pg_toast_<parent_rel_oid>" for temp tables
- * or "@pg_toast_<parent_rel_oid>" for table variables.
- * Returns the parent OID, or InvalidOid if the name doesn't match either pattern.
- */
-static inline Oid
-get_toast_parent_oid(const char *relname)
-{
-	if (strncmp(relname, BBF_TEMP_TOAST_PREFIX, BBF_TOAST_PREFIX_LEN) == 0 ||
-		strncmp(relname, BBF_TABLEVAR_TOAST_PREFIX, BBF_TOAST_PREFIX_LEN) == 0)
-		return (Oid) strtoul(relname + BBF_TOAST_PREFIX_LEN, NULL, 10);
-	return InvalidOid;
-}
-
-/*
- * find_ENR_queryEnv
- *
- * Find the query environment where an ENR with the given OID is registered.
- * Searches from currentQueryEnv up through parent environments.
- * Returns the queryEnv where the ENR is found, or NULL if not found.
- */
-static inline QueryEnvironment *
-find_ENR_queryEnv(Oid relid)
-{
-	QueryEnvironment *qe = currentQueryEnv;
-
-	while (qe)
-	{
-		if (get_ENR_withoid(qe, relid, ENR_TSQL_TEMP, false))
-			return qe;
-		qe = qe->parentEnv;
-	}
-
-	return NULL;
-}
 
 #endif							/* QUERYENVIRONMENT_H */


### PR DESCRIPTION
### Description

Moved the inline function from the header file to C file
 
### Issues Resolved

No- JIRA
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
