### PR TITLE
[BABEL] Fix Invalid Read in IsTopTransactionName (#739)

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -6453,6 +6453,12 @@ SetTopTransactionName(const char *name)
 	s->name = MemoryContextStrdup(TopTransactionContext, name);
 }
 
+void
+ResetTopTransactionName(void)
+{
+	CurrentTransactionState->name = NULL;
+}
+
 /*
  * IsTrasactionBlockActive
  * If a transaction block is already in progress

--- a/src/include/access/xact.h
+++ b/src/include/access/xact.h
@@ -529,6 +529,7 @@ extern bool IsInParallelMode(void);
 
 extern PGDLLEXPORT bool IsTopTransactionName(const char *name);
 extern PGDLLEXPORT void SetTopTransactionName(const char *name);
+extern PGDLLEXPORT void ResetTopTransactionName(void);
 extern PGDLLEXPORT bool IsTransactionBlockActive(void);
 extern PGDLLEXPORT void RollbackAndReleaseSavepoint(const char *name);
 


### PR DESCRIPTION
### Description

SetTopTransactionName() stores the transaction name in TopTransactionContext memory. When the transaction ends, this memory is freed but the name pointer is not put NULL, leaving a dangling pointer. A subsequent call to IsTopTransactionName() then reads freed memory via strcmp().

So we introduce ResetTopTransactionName() which NULLs out TopTransactionStateData.name. This is called from pltsql_xact_cb to ensure the pointer is reset on every transaction end.

Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4717
 
Cherry-picked from https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/739

### Issues Resolved

Task: BABEL-5245

Authored-by: Rucha Kulkarni [ruchask@amazon.com](mailto:ruchask@amazon.com)
Signed-off-by: Rucha Kulkarni [ruchask@amazon.com](mailto:ruchask@amazon.com)
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
