### PR TITLE
Remove old tuple-store INSERT EXEC implementation

### DIFF
--- a/src/backend/access/common/attmap.c
+++ b/src/backend/access/common/attmap.c
@@ -25,7 +25,6 @@
 #include "access/attmap.h"
 #include "utils/builtins.h"
 
-called_from_tsql_insert_exec_hook_type called_from_tsql_insert_exec_hook = NULL;
 called_for_tsql_itvf_func_hook_type called_for_tsql_itvf_func_hook = NULL;
 
 static bool check_attrmap_match(TupleDesc indesc,
@@ -115,10 +114,9 @@ build_attrmap_by_position(TupleDesc indesc,
 			nincols++;
 
 			/* Found matching column, now check type */
-			/* skip check type if it's tsql insert exec or if it is for tsql inline table valued function */
+			/* skip check type if it is for tsql inline table valued function */
 			if ((atttypid != att->atttypid ||
 				(atttypmod != att->atttypmod && atttypmod >= 0)) &&
-				!(called_from_tsql_insert_exec_hook && called_from_tsql_insert_exec_hook()) &&
 				!(called_for_tsql_itvf_func_hook && called_for_tsql_itvf_func_hook()))
 				ereport(ERROR,
 						(errcode(ERRCODE_DATATYPE_MISMATCH),
@@ -314,10 +312,9 @@ check_attrmap_match(TupleDesc indesc,
 			return false;
 
 		/**
-		 * in tsql insert exec or for tsql inline table valued function, we need a cast
+		 * for tsql inline table valued function, we need a cast
 		 */
-		if (((called_from_tsql_insert_exec_hook && called_from_tsql_insert_exec_hook()) 
-				|| (called_for_tsql_itvf_func_hook && called_for_tsql_itvf_func_hook()))
+		if ((called_for_tsql_itvf_func_hook && called_for_tsql_itvf_func_hook())
 		 	&& (inatt->atttypid != outatt->atttypid ||
 			inatt->atttypmod != outatt->atttypmod))
 			return false;

--- a/src/backend/access/common/tupconvert.c
+++ b/src/backend/access/common/tupconvert.c
@@ -177,10 +177,9 @@ execute_attr_map_tuple(HeapTuple tuple, TupleConversionMap *map)
 		int			j = attrMap->attnums[i];
 
 		/**
-		 * if it's tsql insert exec or if it is for tsql inline table valued function, we'll consider value cast
+		 * if it is for tsql inline table valued function, we'll consider value cast
 		 */
-		if ((called_from_tsql_insert_exec_hook && called_from_tsql_insert_exec_hook())
-			|| (called_for_tsql_itvf_func_hook && called_for_tsql_itvf_func_hook()))
+		if (called_for_tsql_itvf_func_hook && called_for_tsql_itvf_func_hook())
 		{
 			Oid        intypeid;
 			Oid        outtypeid;

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -4057,11 +4057,6 @@ ExecModifyTable(PlanState *pstate)
 	HeapTuple	oldtuple;
 	ItemPointer tupleid;
 	bool		tuplock;
-	/* for INSERT ... EXECUTE */
-	bool 		tsql_insert_exec = node->callStmt != NULL;
-	Tuplestorestate *tss = NULL;
-	TupleDesc 	tupdesc = NULL;
-	DestReceiver *dest = NULL;
 
 	CHECK_FOR_INTERRUPTS();
 
@@ -4105,36 +4100,6 @@ ExecModifyTable(PlanState *pstate)
 	context.estate = estate;
 
 	/*
-	 * If we are here for INSERT ... EXECUTE, create a TuplestoreDestReceiver
-	 * and pass it to the procedure execution. The procedure execution will send
-	 * its result sets to the tuplestore via the receiver function.
-	 */
-	if (tsql_insert_exec)
-	{
-		tss = tuplestore_begin_heap(false, false, work_mem);
-		tupdesc = RelationGetDescr(resultRelInfo->ri_RelationDesc);
-		dest = CreateTuplestoreDestReceiver();
-		SetTuplestoreDestReceiverParams(dest, tss, CurrentMemoryContext, false, NULL, NULL);
-		dest->rStartup(dest, -1, tupdesc);
-
-		switch (nodeTag(node->callStmt))
-		{
-			case T_CallStmt:
-				ExecuteCallStmt((CallStmt *)node->callStmt,
-								pstate->state->es_param_list_info, false, dest);
-				break;
-			case T_DoStmt:
-				ExecuteDoStmtInsertExec((DoStmt *)node->callStmt, false, dest);
-				break;
-			default:
-				ereport(ERROR,
-						(errcode(ERRCODE_SYNTAX_ERROR),
-						 errmsg("Unrecognized stmt in INSERT EXEC")));
-				break;
-		}
-	}
-
-	/*
 	 * Fetch rows from subplan(s), and execute the required table modification
 	 * for each row.
 	 */
@@ -4163,40 +4128,32 @@ ExecModifyTable(PlanState *pstate)
 			break;
 		}
 
-		if (tsql_insert_exec)
+		/*
+		 * If there is a pending MERGE ... WHEN NOT MATCHED [BY TARGET] action
+		 * to execute, do so now --- see the comments in ExecMerge().
+		 */
+		if (node->mt_merge_pending_not_matched != NULL)
 		{
-			context.planSlot = MakeSingleTupleTableSlot(tupdesc, &TTSOpsMinimalTuple);
-			tuplestore_gettupleslot(tss, true, false, context.planSlot);
-		}
-		else
-                {
+			context.planSlot = node->mt_merge_pending_not_matched;
+
+			slot = ExecMergeNotMatched(&context, node->resultRelInfo,
+								   node->canSetTag);
+
+			/* Clear the pending action */
+			node->mt_merge_pending_not_matched = NULL;
+
 			/*
-			 * If there is a pending MERGE ... WHEN NOT MATCHED [BY TARGET] action
-			 * to execute, do so now --- see the comments in ExecMerge().
+			 * If we got a RETURNING result, return it to the caller.  We'll
+			 * continue the work on next call.
 			 */
-			if (node->mt_merge_pending_not_matched != NULL)
-			{
-				context.planSlot = node->mt_merge_pending_not_matched;
+			if (slot)
+				return slot;
 
-				slot = ExecMergeNotMatched(&context, node->resultRelInfo,
-									   node->canSetTag);
-
-				/* Clear the pending action */
-				node->mt_merge_pending_not_matched = NULL;
-
-				/*
-				 * If we got a RETURNING result, return it to the caller.  We'll
-				 * continue the work on next call.
-				 */
-				if (slot)
-					return slot;
-
-				continue;			/* continue with the next tuple */
-			}
-
-			/* Fetch the next row from subplan */
-			context.planSlot = ExecProcNode(subplanstate);
+			continue;			/* continue with the next tuple */
 		}
+
+		/* Fetch the next row from subplan */
+		context.planSlot = ExecProcNode(subplanstate);
 
 		/* No more tuples to process? */
 		if (TupIsNull(context.planSlot))
@@ -4481,21 +4438,12 @@ ExecModifyTable(PlanState *pstate)
 				break;
 		}
 
-		if(tsql_insert_exec)
-			ExecDropSingleTupleTableSlot(context.planSlot);
-
 		/*
 		 * If we got a RETURNING result, return it to caller.  We'll continue
 		 * the work on next call.
 		 */
 		if (slot)
 			return slot;
-	}
-
-	if (tsql_insert_exec && dest)
-	{
-		dest->rShutdown(dest);
-		dest->rDestroy(dest);
 	}
 
 	/*

--- a/src/include/access/attmap.h
+++ b/src/include/access/attmap.h
@@ -50,9 +50,7 @@ extern AttrMap *build_attrmap_by_name_if_req(TupleDesc indesc,
 extern AttrMap *build_attrmap_by_position(TupleDesc indesc,
 										  TupleDesc outdesc,
 										  const char *msg);
-typedef bool (*called_from_tsql_insert_exec_hook_type)();
 typedef bool (*called_for_tsql_itvf_func_hook_type)();
-extern PGDLLEXPORT called_from_tsql_insert_exec_hook_type called_from_tsql_insert_exec_hook;
 extern PGDLLIMPORT called_for_tsql_itvf_func_hook_type called_for_tsql_itvf_func_hook;
 
 #endif							/* ATTMAP_H */


### PR DESCRIPTION
### Description

This PR removes the old tuple-store based INSERT EXEC implementation from the engine side. The INSERT EXEC feature has been reimplemented using a DestReceiver-based approach in the extension side.

**Changes:**
- Remove `called_from_tsql_insert_exec_hook_type` typedef from `src/include/access/attmap.h`
- Remove `called_from_tsql_insert_exec_hook` extern declaration from `attmap.h`
- Remove `called_from_tsql_insert_exec_hook` variable from `src/backend/access/common/attmap.c`
- Remove hook usage from `attmap.c` type checking logic
- Remove hook usage from `src/backend/access/common/tupconvert.c` value casting logic
- Remove entire old tuple-store based INSERT EXEC implementation from `src/backend/executor/nodeModifyTable.c` (~60 lines)

**Why:**
The new DestReceiver-based approach:
1. Uses a temp table to store results instead of tuple store
2. Handles type coercion properly
3. Provides better error handling and transaction semantics

The old engine-side hooks are no longer needed.

**Related Extension PR:** https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4794

### Issues Resolved

Cleanup of deprecated INSERT EXEC engine hooks as part of the DestReceiver-based INSERT EXEC reimplementation.

### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
