### PR TITLE
[OSS-ONLY] [BABEL] Add PLtsql node serialization support for ANTLR parse tree caching

### DIFF
--- a/src/backend/nodes/read.c
+++ b/src/backend/nodes/read.c
@@ -31,6 +31,18 @@
 /* Static state for pg_strtok */
 static const char *pg_strtok_ptr = NULL;
 
+/*
+ * pg_strtok_init - set the input string for pg_strtok.
+ *
+ * Allows extensions to initialize the tokenizer state for their own
+ * deserialization without needing access to the static pg_strtok_ptr.
+ */
+void
+pg_strtok_init(const char *str)
+{
+	pg_strtok_ptr = str;
+}
+
 /* State flag that determines how readfuncs.c should treat location fields */
 #ifdef WRITE_READ_PARSE_PLAN_TREES
 bool		restore_location_fields = false;

--- a/src/include/nodes/readfuncs.h
+++ b/src/include/nodes/readfuncs.h
@@ -27,6 +27,7 @@ extern PGDLLIMPORT bool restore_location_fields;
  * prototypes for functions in read.c (the lisp token parser)
  */
 extern const char *pg_strtok(int *length);
+extern void pg_strtok_init(const char *str);
 extern char *debackslash(const char *token, int length);
 extern void *nodeRead(const char *token, int tok_len);
 


### PR DESCRIPTION
### Description
BABEL-6037: Add pg_strtok_init() for extension-side node deserialization.

The Babelfish extension implements cross-session ANTLR parse tree caching for T-SQL routines (procedures and functions). Serialized parse trees are stored in sys.babelfish_function_ext and deserialized on first execution in new sessions to skip redundant ANTLR parsing.

The extension handles all PLtsql node serialization and deserialization on its own side (under babelfish_extensions/contrib/babelfishpg_tsql/src/pltsql_node/, specifically pltsql_nodeio.c), replicating the necessary engine-side internal macros from outfuncs.c and readfuncs.c (WRITE_*/READ_* macros in pltsql_node_macros.h) and PR serialization/deserialization (NodeToString()/StringToNode()) functions (from outfuncs.c,read.c), delegating to PG's public APIs (outNode(), nodeRead(), parseNodeString()) for standard PG types. (refer: postgresql_modified_for_babelfish/src/backend/nodes/*)

For deserialization, the extension needs to point pg_strtok at its own input string before calling its reader. Since `pg_strtok_ptr` is static in read.c, this PR adds a minimal public setter function.

Changes
- pg_strtok_init (read.c, readfuncs.h)
- read.c: Add pg_strtok_init(const char *str) — sets the static pg_strtok_ptr so babelfish extensions can initialize the tokenizer for their own deserialization
- readfuncs.h: Add extern declaration

### Issues Resolved

BABEL-6037

(cherry picked from commit [3a9910d606ef97d4b26022e7ae33891cf3f1a03d](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/commit/3a9910d606ef97d4b26022e7ae33891cf3f1a03d))
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
