### PR TITLE
[POC] Adding selectivity estimation hooks for OpExpr and NullTest

### DIFF
--- a/src/backend/optimizer/path/clausesel.c
+++ b/src/backend/optimizer/path/clausesel.c
@@ -24,6 +24,9 @@
 #include "utils/lsyscache.h"
 #include "utils/selfuncs.h"
 
+/* Hook for extensions to override OpExpr selectivity */
+opexpr_selectivity_hook_type opexpr_selectivity_hook = NULL;
+
 /*
  * Data structure for accumulating info about possible range-query
  * clause pairs in clauselist_selectivity.
@@ -833,6 +836,7 @@ clause_selectivity_ext(PlannerInfo *root,
 		OpExpr	   *opclause = (OpExpr *) clause;
 		Oid			opno = opclause->opno;
 
+
 		if (treat_as_join_clause(root, clause, rinfo, varRelid, sjinfo))
 		{
 			/* Estimate selectivity for a join clause. */
@@ -844,11 +848,24 @@ clause_selectivity_ext(PlannerInfo *root,
 		}
 		else
 		{
-			/* Estimate selectivity for a restriction clause. */
-			s1 = restriction_selectivity(root, opno,
-										 opclause->args,
-										 opclause->inputcollid,
-										 varRelid);
+			/*
+			 * Allow extensions to override OpExpr selectivity estimation
+			 * via the opexpr_selectivity_hook.
+			 */
+			bool	handled = false;
+
+			if (opexpr_selectivity_hook &&
+				opexpr_selectivity_hook(root, clause, varRelid, jointype,
+										sjinfo, use_extended_stats, &s1))
+				handled = true;
+			if (!handled)
+			{
+				/* Estimate selectivity for a restriction clause. */
+				s1 = restriction_selectivity(root, opno,
+											 opclause->args,
+											 opclause->inputcollid,
+											 varRelid);
+			}
 		}
 
 		/*

--- a/src/backend/optimizer/path/clausesel.c
+++ b/src/backend/optimizer/path/clausesel.c
@@ -23,6 +23,7 @@
 #include "utils/fmgroids.h"
 #include "utils/lsyscache.h"
 #include "utils/selfuncs.h"
+#include "parser/parser.h"
 
 /* Hook for extensions to override OpExpr selectivity */
 opexpr_selectivity_hook_type opexpr_selectivity_hook = NULL;
@@ -850,15 +851,12 @@ clause_selectivity_ext(PlannerInfo *root,
 		{
 			/*
 			 * Allow extensions to override OpExpr selectivity estimation
-			 * via the opexpr_selectivity_hook.
+			 * via the opexpr_selectivity_hook (Babelfish only).
 			 */
-			bool	handled = false;
-
-			if (opexpr_selectivity_hook &&
-				opexpr_selectivity_hook(root, clause, varRelid, jointype,
-										sjinfo, use_extended_stats, &s1))
-				handled = true;
-			if (!handled)
+			if (!(sql_dialect == SQL_DIALECT_TSQL &&
+				  opexpr_selectivity_hook &&
+				  opexpr_selectivity_hook(root, clause, varRelid, jointype,
+										  sjinfo, use_extended_stats, &s1)))
 			{
 				/* Estimate selectivity for a restriction clause. */
 				s1 = restriction_selectivity(root, opno,

--- a/src/backend/utils/adt/selfuncs.c
+++ b/src/backend/utils/adt/selfuncs.c
@@ -141,6 +141,7 @@
 #include "utils/syscache.h"
 #include "utils/timestamp.h"
 #include "utils/typcache.h"
+#include "parser/parser.h"
 
 /* Hook for extensions to override NullTest selectivity */
 nulltest_selectivity_hook_type nulltest_selectivity_hook = NULL;
@@ -1758,14 +1759,11 @@ nulltestsel(PlannerInfo *root, NullTestType nulltesttype, Node *arg,
 	{
 		/*
 		 * No ANALYZE stats available. Allow extensions to override
-		 * NullTest selectivity via nulltest_selectivity_hook.
+		 * NullTest selectivity via nulltest_selectivity_hook (Babelfish only).
 		 */
-		if (nulltest_selectivity_hook &&
-			nulltest_selectivity_hook(root, nulltesttype, arg, varRelid, &selec))
-		{
-			/* Hook handled it */
-		}
-		else
+		if (!(sql_dialect == SQL_DIALECT_TSQL &&
+			  nulltest_selectivity_hook &&
+			  nulltest_selectivity_hook(root, nulltesttype, arg, varRelid, &selec)))
 		{
 			switch (nulltesttype)
 			{

--- a/src/backend/utils/adt/selfuncs.c
+++ b/src/backend/utils/adt/selfuncs.c
@@ -142,6 +142,9 @@
 #include "utils/timestamp.h"
 #include "utils/typcache.h"
 
+/* Hook for extensions to override NullTest selectivity */
+nulltest_selectivity_hook_type nulltest_selectivity_hook = NULL;
+
 #define DEFAULT_PAGE_CPU_MULTIPLIER 50.0
 
 /* Hooks for plugins to get control when we ask for stats */
@@ -1754,20 +1757,29 @@ nulltestsel(PlannerInfo *root, NullTestType nulltesttype, Node *arg,
 	else
 	{
 		/*
-		 * No ANALYZE stats available, so make a guess
+		 * No ANALYZE stats available. Allow extensions to override
+		 * NullTest selectivity via nulltest_selectivity_hook.
 		 */
-		switch (nulltesttype)
+		if (nulltest_selectivity_hook &&
+			nulltest_selectivity_hook(root, nulltesttype, arg, varRelid, &selec))
 		{
-			case IS_NULL:
-				selec = DEFAULT_UNK_SEL;
-				break;
-			case IS_NOT_NULL:
-				selec = DEFAULT_NOT_UNK_SEL;
-				break;
-			default:
-				elog(ERROR, "unrecognized nulltesttype: %d",
-					 (int) nulltesttype);
-				return (Selectivity) 0; /* keep compiler quiet */
+			/* Hook handled it */
+		}
+		else
+		{
+			switch (nulltesttype)
+			{
+				case IS_NULL:
+					selec = DEFAULT_UNK_SEL;
+					break;
+				case IS_NOT_NULL:
+					selec = DEFAULT_NOT_UNK_SEL;
+					break;
+				default:
+					elog(ERROR, "unrecognized nulltesttype: %d",
+						 (int) nulltesttype);
+					return (Selectivity) 0; /* keep compiler quiet */
+			}
 		}
 	}
 

--- a/src/include/optimizer/optimizer.h
+++ b/src/include/optimizer/optimizer.h
@@ -77,25 +77,6 @@ extern Selectivity clauselist_selectivity_ext(PlannerInfo *root,
 											  bool use_extended_stats);
 
 
-/*
- * Hooks for extensions to override selectivity estimation.
- * Returns true if the hook handled the clause (and set *selec).
- */
-typedef bool (*opexpr_selectivity_hook_type) (PlannerInfo *root,
-											  Node *clause,
-											  int varRelid,
-											  JoinType jointype,
-											  SpecialJoinInfo *sjinfo,
-											  bool use_extended_stats,
-											  Selectivity *selec);
-extern PGDLLIMPORT opexpr_selectivity_hook_type opexpr_selectivity_hook;
-
-typedef bool (*nulltest_selectivity_hook_type) (PlannerInfo *root,
-												NullTestType nulltesttype,
-												Node *arg,
-												int varRelid,
-												Selectivity *selec);
-extern PGDLLIMPORT nulltest_selectivity_hook_type nulltest_selectivity_hook;
 /* in path/costsize.c: */
 
 /* widely used cost parameters */

--- a/src/include/optimizer/optimizer.h
+++ b/src/include/optimizer/optimizer.h
@@ -76,6 +76,26 @@ extern Selectivity clauselist_selectivity_ext(PlannerInfo *root,
 											  SpecialJoinInfo *sjinfo,
 											  bool use_extended_stats);
 
+
+/*
+ * Hooks for extensions to override selectivity estimation.
+ * Returns true if the hook handled the clause (and set *selec).
+ */
+typedef bool (*opexpr_selectivity_hook_type) (PlannerInfo *root,
+											  Node *clause,
+											  int varRelid,
+											  JoinType jointype,
+											  SpecialJoinInfo *sjinfo,
+											  bool use_extended_stats,
+											  Selectivity *selec);
+extern PGDLLIMPORT opexpr_selectivity_hook_type opexpr_selectivity_hook;
+
+typedef bool (*nulltest_selectivity_hook_type) (PlannerInfo *root,
+												NullTestType nulltesttype,
+												Node *arg,
+												int varRelid,
+												Selectivity *selec);
+extern PGDLLIMPORT nulltest_selectivity_hook_type nulltest_selectivity_hook;
 /* in path/costsize.c: */
 
 /* widely used cost parameters */

--- a/src/include/utils/selfuncs.h
+++ b/src/include/utils/selfuncs.h
@@ -248,4 +248,21 @@ extern Selectivity scalararraysel_containment(PlannerInfo *root,
 											  Oid elemtype, bool isEquality, bool useOr,
 											  int varRelid);
 
+/* Babelfish hooks for selectivity estimation override */
+typedef bool (*opexpr_selectivity_hook_type) (PlannerInfo *root,
+											  Node *clause,
+											  int varRelid,
+											  JoinType jointype,
+											  SpecialJoinInfo *sjinfo,
+											  bool use_extended_stats,
+											  Selectivity *selec);
+extern PGDLLEXPORT opexpr_selectivity_hook_type opexpr_selectivity_hook;
+
+typedef bool (*nulltest_selectivity_hook_type) (PlannerInfo *root,
+											    NullTestType nulltesttype,
+											    Node *arg,
+											    int varRelid,
+											    Selectivity *selec);
+extern PGDLLEXPORT nulltest_selectivity_hook_type nulltest_selectivity_hook;
+
 #endif							/* SELFUNCS_H */


### PR DESCRIPTION
### Description

Adding opexpr_selectivity_hook and nulltest_selectivity_hook to allow Babelfish to provide accurate selectivity estimates for CASE expressions and NullTest on SubPlan results. Hooks are guarded by sql_dialect check and only activate for T-SQL sessions.
 
### Issues Resolved

Task: BABEL-6458

Authored-by: Rucha Kulkarni [ruchask@amazon.com](mailto:ruchask@amazon.com)
Signed-off-by: Rucha Kulkarni [ruchask@amazon.com](mailto:ruchask@amazon.com)
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
