### PR TITLE
Adding hook to enable index matching through type casts

### DIFF
--- a/src/backend/optimizer/path/indxpath.c
+++ b/src/backend/optimizer/path/indxpath.c
@@ -36,6 +36,8 @@
 #include "utils/lsyscache.h"
 #include "utils/selfuncs.h"
 
+/* Hook for extensions to provide index clauses for unmatched OpExpr */
+match_opclause_to_indexcol_hook_type match_opclause_to_indexcol_hook = NULL;
 
 /* XXX see PartCollMatchesExprColl */
 #define IndexCollMatchesExprColl(idxcollation, exprcollation) \
@@ -2964,12 +2966,17 @@ match_opclause_to_indexcol(PlannerInfo *root,
 		 * function for the operator's underlying function.
 		 */
 		set_opfuncid(clause);	/* make sure we have opfuncid */
-		return get_index_clause_from_support(root,
+		iclause = get_index_clause_from_support(root,
 											 rinfo,
 											 clause->opfuncid,
 											 0, /* indexarg on left */
 											 indexcol,
 											 index);
+		if (iclause)
+			return iclause;
+		if (match_opclause_to_indexcol_hook)
+			return match_opclause_to_indexcol_hook(root, rinfo, indexcol, index);
+		return NULL;
 	}
 
 	if (match_index_to_operand(rightop, indexcol, index) &&

--- a/src/backend/optimizer/path/indxpath.c
+++ b/src/backend/optimizer/path/indxpath.c
@@ -3011,12 +3011,17 @@ match_opclause_to_indexcol(PlannerInfo *root,
 		 * function for the operator's underlying function.
 		 */
 		set_opfuncid(clause);	/* make sure we have opfuncid */
-		return get_index_clause_from_support(root,
+		iclause = get_index_clause_from_support(root,
 											 rinfo,
 											 clause->opfuncid,
 											 1, /* indexarg on right */
 											 indexcol,
 											 index);
+		if (iclause)
+			return iclause;
+		if (match_opclause_to_indexcol_hook)
+			return match_opclause_to_indexcol_hook(root, rinfo, indexcol, index);
+		return NULL;
 	}
 
 	return NULL;

--- a/src/include/optimizer/paths.h
+++ b/src/include/optimizer/paths.h
@@ -48,6 +48,13 @@ typedef RelOptInfo *(*join_search_hook_type) (PlannerInfo *root,
 											  List *initial_rels);
 extern PGDLLIMPORT join_search_hook_type join_search_hook;
 
+/* Hook for plugins to provide index clauses for unmatched OpExpr */
+typedef IndexClause *(*match_opclause_to_indexcol_hook_type) (PlannerInfo *root,
+																	 RestrictInfo *rinfo,
+																	 int indexcol,
+																	 IndexOptInfo *index);
+extern PGDLLIMPORT match_opclause_to_indexcol_hook_type match_opclause_to_indexcol_hook;
+
 
 extern RelOptInfo *make_one_rel(PlannerInfo *root, List *joinlist);
 extern RelOptInfo *standard_join_search(PlannerInfo *root, int levels_needed,


### PR DESCRIPTION
### Description

Adding a hook in match_opclause_to_indexcol() that allows babelfish to provide index clauses when the built-in logic cannot match an OpExpr to an index column. This enables extensions to handle type-cast patterns that prevent index usage due to operator family mismatches.
 
### Issues Resolved

Task: BABEL-6814

Authored-by: Rucha Kulkarni [ruchask@amazon.com](mailto:ruchask@amazon.com)
Signed-off-by: Rucha Kulkarni [ruchask@amazon.com](mailto:ruchask@amazon.com)

Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4829
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
