### PR TITLE
Adding bbf version of pgstat_init_function_usage

### DIFF
--- a/src/backend/utils/activity/pgstat_function.c
+++ b/src/backend/utils/activity/pgstat_function.c
@@ -138,6 +138,76 @@ pgstat_init_function_usage(FunctionCallInfo fcinfo,
 	INSTR_TIME_SET_CURRENT(fcu->start);
 }
 
+void
+pgstat_init_function_usage_no_drop(FunctionCallInfo fcinfo,
+								   PgStat_FunctionCallUsage *fcu)
+{
+	PgStat_EntryRef *entry_ref;
+	PgStat_FunctionCounts *pending;
+	bool		created_entry;
+
+	if (pgstat_track_functions <= fcinfo->flinfo->fn_stats)
+	{
+		/* stats not wanted */
+		fcu->fs = NULL;
+		return;
+	}
+
+	entry_ref = pgstat_prep_pending_entry(PGSTAT_KIND_FUNCTION,
+										  MyDatabaseId,
+										  fcinfo->flinfo->fn_oid,
+										  &created_entry);
+
+	/*
+	 * If no shared entry already exists, check if the function has been
+	 * deleted concurrently. This can go unnoticed until here because
+	 * executing a statement that just calls a function, does not trigger
+	 * cache invalidation processing. The reason we care about this case is
+	 * that otherwise we could create a new stats entry for an already dropped
+	 * function (for relations etc this is not possible because emitting stats
+	 * requires a lock for the relation to already have been acquired).
+	 *
+	 * It's somewhat ugly to have a behavioral difference based on
+	 * track_functions being enabled/disabled. But it seems acceptable, given
+	 * that there's already behavioral differences depending on whether the
+	 * function is the caches etc.
+	 *
+	 * For correctness it'd be sufficient to set ->dropped to true. However,
+	 * the accepted invalidation will commonly cause "low level" failures in
+	 * PL code, with an OID in the error message. Making this harder to
+	 * test...
+	 *
+	 * Unlike pgstat_init_function_usage, we do NOT call
+	 * pgstat_drop_entry here. In Babelfish's concurrent scenarios, 
+	 * calling pgstat_drop_entry conflicts with the transactional
+	 * drop path (AtEOXact_PgStat_DroppedStats), causing a server crash.
+	 * The entry will be cleaned up by the transactional path at commit time.
+	 */
+	if (created_entry)
+	{
+		AcceptInvalidationMessages();
+		if (!SearchSysCacheExists1(PROCOID, ObjectIdGetDatum(fcinfo->flinfo->fn_oid)))
+		{
+			fcu->fs = NULL;
+			ereport(ERROR, errcode(ERRCODE_UNDEFINED_FUNCTION),
+					errmsg("function call to dropped function"));
+		}
+	}
+
+	pending = entry_ref->pending;
+
+	fcu->fs = pending;
+
+	/* save stats for this function, later used to compensate for recursion */
+	fcu->save_f_total_time = pending->total_time;
+
+	/* save current backend-wide total time */
+	fcu->save_total = total_func_time;
+
+	/* get clock time as of function start */
+	INSTR_TIME_SET_CURRENT(fcu->start);
+}
+
 /*
  * Calculate function call usage and update stat counters.
  * Called by the executor after invoking a function.

--- a/src/backend/utils/fmgr/fmgr.c
+++ b/src/backend/utils/fmgr/fmgr.c
@@ -857,13 +857,11 @@ fmgr_security_definer(PG_FUNCTION_ARGS)
 		 * and the dialect is TSQL then we call this func using hook 
 		 * otherwise we will fall back to pgstat_init_function_usage
 		*/
-
-		if(pgstat_function_wrapper_hook && sql_dialect == SQL_DIALECT_TSQL)
+		if (!pgstat_function_wrapper_hook || sql_dialect != SQL_DIALECT_TSQL ||
+			!(*pgstat_function_wrapper_hook)(fcinfo, &fcusage, cacheTupleProcname))
 		{
-			(*pgstat_function_wrapper_hook)(fcinfo, &fcusage, cacheTupleProcname);
+			pgstat_init_function_usage(fcinfo, &fcusage);
 		}
-		
-		pgstat_init_function_usage(fcinfo, &fcusage);
 
 		if(cacheTupleProcname)
 		{

--- a/src/include/pgstat.h
+++ b/src/include/pgstat.h
@@ -865,7 +865,7 @@ extern PGDLLEXPORT invalidate_stat_table_hook_type invalidate_stat_table_hook;
 typedef bool (*tsql_has_pgstat_permissions_hook_type) (Oid role);
 extern PGDLLEXPORT tsql_has_pgstat_permissions_hook_type tsql_has_pgstat_permissions_hook;
 
-typedef void (*pgstat_function_wrapper_hook_type)(FunctionCallInfo, PgStat_FunctionCallUsage *, char *);
+typedef bool (*pgstat_function_wrapper_hook_type)(FunctionCallInfo, PgStat_FunctionCallUsage *, char *);
 extern PGDLLEXPORT pgstat_function_wrapper_hook_type pgstat_function_wrapper_hook;
 
 typedef void (*pltsql_pgstat_end_function_usage_hook_type) (FunctionCallInfo fcinfo, 
@@ -874,5 +874,8 @@ typedef void (*pltsql_pgstat_end_function_usage_hook_type) (FunctionCallInfo fci
 extern PGDLLEXPORT pltsql_pgstat_end_function_usage_hook_type pltsql_pgstat_end_function_usage_hook;
 
 extern bool lookup_pgstat_entry_in_cache(PgStat_Kind kind, Oid dboid, Oid objoid);
+
+extern void pgstat_init_function_usage_no_drop(FunctionCallInfo fcinfo,
+											   PgStat_FunctionCallUsage *fcu);
 
 #endif							/* PGSTAT_H */


### PR DESCRIPTION
### Description

 Adding pgstat_init_function_usage_no_drop, a Babelfish-specific version of pgstat_init_function_usage that does not call pgstat_drop_entry when a function is found to be concurrently dropped. This prevents a server crash caused by double-drop of pgstat entries during concurrent DROP+CREATE+EXEC with track_functions=all.
  
Changing pgstat_function_wrapper_hook return type from void to bool to allow the hook to skip the engine's pgstat_init_function_usage.

Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4859
 
### Issues Resolved

Task: BABEL-6405

Authored-by: Rucha Kulkarni [ruchask@amazon.com](mailto:ruchask@amazon.com)
Signed-off-by: Rucha Kulkarni [ruchask@amazon.com](mailto:ruchask@amazon.com)
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
