### PR TITLE
Handle Long Identifiers for Babelfish

### DIFF
--- a/src/backend/access/nbtree/nbtinsert.c
+++ b/src/backend/access/nbtree/nbtinsert.c
@@ -16,6 +16,7 @@
 #include "postgres.h"
 
 #include "access/nbtree.h"
+#include "executor/executor.h"
 #include "access/nbtxlog.h"
 #include "access/transam.h"
 #include "access/xloginsert.h"
@@ -663,14 +664,33 @@ _bt_check_unique(Relation rel, BTInsertState insertstate, Relation heapRel,
 						key_desc = BuildIndexValueDescription(rel, values,
 															  isnull);
 
-						ereport(ERROR,
-								(errcode(ERRCODE_UNIQUE_VIOLATION),
-								 errmsg("duplicate key value violates unique constraint \"%s\"",
-										RelationGetRelationName(rel)),
-								 key_desc ? errdetail("Key %s already exists.",
-													  key_desc) : 0,
-								 errtableconstraint(heapRel,
-													RelationGetRelationName(rel))));
+						{
+							const char *conname = RelationGetRelationName(rel);
+
+							/*
+							 * BABEL: Resolve the original (pre-truncation) name for
+							 * display in error messages. For Babelfish, identifiers
+							 * longer than NAMEDATALEN are MD5-truncated at storage
+							 * time. The index hook reads pg_class.reloptions to
+							 * recover the original index name, and the constraint hook
+							 * looks up babelfish_identifier_mapping for the full
+							 * constraint name. We chain both: first try the index
+							 * reloptions, then fall back to the identifier mapping if
+							 * the name is still at the truncation boundary.
+							 */
+							if (bbf_get_original_index_name_hook)
+								conname = bbf_get_original_index_name_hook(conname);
+							if (bbf_get_original_constraint_name_hook && strlen(conname) >= NAMEDATALEN - 1)
+								conname = bbf_get_original_constraint_name_hook(conname);
+							ereport(ERROR,
+									(errcode(ERRCODE_UNIQUE_VIOLATION),
+									 errmsg("duplicate key value violates unique constraint \"%s\"",
+											conname),
+									 key_desc ? errdetail("Key %s already exists.",
+														  key_desc) : 0,
+									 errtableconstraint(heapRel,
+														RelationGetRelationName(rel))));
+						}
 					}
 				}
 				else if (all_dead && (!inposting ||

--- a/src/backend/catalog/genbki.pl
+++ b/src/backend/catalog/genbki.pl
@@ -68,6 +68,7 @@ my @extension_syscaches = qw(
     PROCNAMENSPSIGNATURE
     SYSNAMESPACENAME
     AUTHIDUSEREXTROLENAME
+    IDENTMAPPINGNAME
 );
 
 foreach my $header (@ARGV)

--- a/src/backend/commands/view.c
+++ b/src/backend/commands/view.c
@@ -19,6 +19,8 @@
 #include "catalog/namespace.h"
 #include "commands/tablecmds.h"
 #include "commands/view.h"
+#include "parser/parser.h"
+#include "parser/scansup.h"
 #include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
 #include "parser/analyze.h"
@@ -69,6 +71,20 @@ DefineVirtualRelation(RangeVar *relation, List *tlist, bool replace,
 											exprType((Node *) tle->expr),
 											exprTypmod((Node *) tle->expr),
 											exprCollation((Node *) tle->expr));
+
+			/*
+			 * BABEL: For T-SQL views, column names can be up to 128 chars but
+			 * pg_attribute.attname is limited to NAMEDATALEN (64). Truncate
+			 * long column names here using the MD5 strategy (handled by
+			 * truncate_identifier) so they fit in the catalog. The original
+			 * full-length name is preserved in pg_attribute.attoptions as
+			 * 'bbf_original_name' and resolved at query time via
+			 * bbf_get_view_column_name().
+			 */
+			if (sql_dialect == SQL_DIALECT_TSQL && def->colname &&
+				strlen(def->colname) >= NAMEDATALEN)
+				truncate_identifier(def->colname,
+								strlen(def->colname), false);
 
 			if (inherit_view_constraints_from_table_hook)
 				(*inherit_view_constraints_from_table_hook) (def, tle->resorigtbl, tle->resorigcol);

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -65,6 +65,10 @@
 #include "utils/rls.h"
 #include "utils/snapmgr.h"
 
+/* BABEL: Hooks for resolving original long identifier names in constraint errors */
+bbf_get_original_constraint_name_hook_type bbf_get_original_constraint_name_hook = NULL;
+bbf_get_original_index_name_hook_type bbf_get_original_index_name_hook = NULL;
+
 
 /* Hooks for plugins to get control in ExecutorStart/Run/Finish/End */
 ExecutorStart_hook_type ExecutorStart_hook = NULL;
@@ -2096,12 +2100,23 @@ ExecConstraints(ResultRelInfo *resultRelInfo,
 													 tupdesc,
 													 modifiedCols,
 													 64);
+			{
+				const char *display_name = failed;
+
+				/*
+				 * BABEL: Resolve the original constraint name for display in the
+				 * check violation error message. The stored constraint name may
+				 * be MD5-truncated; the hook reverses this via catalog lookup.
+				 */
+				if (bbf_get_original_constraint_name_hook)
+					display_name = bbf_get_original_constraint_name_hook(failed);
 			ereport(ERROR,
 					(errcode(ERRCODE_CHECK_VIOLATION),
 					 errmsg("new row for relation \"%s\" violates check constraint \"%s\"",
-							RelationGetRelationName(orig_rel), failed),
+							RelationGetRelationName(orig_rel), display_name),
 					 val_desc ? errdetail("Failing row contains %s.", val_desc) : 0,
 					 errtableconstraint(orig_rel, failed)));
+			}
 		}
 	}
 }

--- a/src/backend/parser/parse_clause.c
+++ b/src/backend/parser/parse_clause.c
@@ -2115,7 +2115,7 @@ findTargetlistEntrySQL92(ParseState *pstate, Node *node, List **tlist,
 					((!tle_name_comparison_hook &&
 					  strcmp(tle->resname, name) == 0) ||
 					 (tle_name_comparison_hook &&
-					  (*tle_name_comparison_hook)(tle->resname, name))))
+					  (*tle_name_comparison_hook)(tle->resname, name, pstate->p_sourcetext, location))))
 				{
 					if (target_result != NULL)
 					{

--- a/src/backend/rewrite/rewriteDefine.c
+++ b/src/backend/rewrite/rewriteDefine.c
@@ -28,6 +28,8 @@
 #include "parser/parse_utilcmd.h"
 #include "rewrite/rewriteDefine.h"
 #include "rewrite/rewriteManip.h"
+#include "parser/parser.h"
+#include "parser/scansup.h"
 #include "rewrite/rewriteSupport.h"
 #include "utils/acl.h"
 #include "utils/builtins.h"
@@ -562,7 +564,18 @@ checkRuleResultList(List *targetList, TupleDesc resultDesc, bool isSelect,
 					 errmsg("cannot create a RETURNING list for a relation containing dropped columns")));
 
 		/* Check name match if required; no need for two error texts here */
-		if (requireColumnNameMatch && strcmp(tle->resname, attname) != 0)
+		/*
+		 * BABEL: For T-SQL views with long column names (>= NAMEDATALEN), the
+		 * SELECT target list entry retains the full-length name while attname
+		 * holds the MD5-truncated version. Allow the mismatch when truncating
+		 * the full name produces the stored attname. Without this, CREATE OR
+		 * REPLACE VIEW would fail for views with long column aliases.
+		 */
+		if (requireColumnNameMatch && strcmp(tle->resname, attname) != 0 &&
+			!(sql_dialect == SQL_DIALECT_TSQL &&
+			  strlen(tle->resname) >= NAMEDATALEN &&
+			  strlen(attname) < NAMEDATALEN &&
+			  pg_strcasecmp(downcase_truncate_identifier(tle->resname, strlen(tle->resname), false), attname) == 0))
 			ereport(ERROR,
 					(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
 					 errmsg("SELECT rule's target entry %d has different column name from column \"%s\"",

--- a/src/backend/utils/adt/ri_triggers.c
+++ b/src/backend/utils/adt/ri_triggers.c
@@ -343,14 +343,21 @@ RI_FKey_check(TriggerData *trigdata)
 					 * Not allowed - MATCH FULL says either all or none of the
 					 * attributes can be NULLs
 					 */
-					ereport(ERROR,
-							(errcode(ERRCODE_FOREIGN_KEY_VIOLATION),
-							 errmsg("insert or update on table \"%s\" violates foreign key constraint \"%s\"",
-									RelationGetRelationName(fk_rel),
-									NameStr(riinfo->conname)),
-							 errdetail("MATCH FULL does not allow mixing of null and nonnull key values."),
-							 errtableconstraint(fk_rel,
-												NameStr(riinfo->conname))));
+					{
+						const char *fk_conname = NameStr(riinfo->conname);
+
+						/* BABEL: resolve original FK name for error display */
+						if (bbf_get_original_constraint_name_hook)
+							fk_conname = bbf_get_original_constraint_name_hook(fk_conname);
+						ereport(ERROR,
+								(errcode(ERRCODE_FOREIGN_KEY_VIOLATION),
+								 errmsg("insert or update on table \"%s\" violates foreign key constraint \"%s\"",
+										RelationGetRelationName(fk_rel),
+										fk_conname),
+								 errdetail("MATCH FULL does not allow mixing of null and nonnull key values."),
+								 errtableconstraint(fk_rel,
+													NameStr(riinfo->conname))));
+					}
 					table_close(pk_rel, RowShareLock);
 					return PointerGetDatum(NULL);
 
@@ -1804,14 +1811,21 @@ RI_Initial_Check(Trigger *trigger, Relation fk_rel, Relation pk_rel)
 		 */
 		if (fake_riinfo.confmatchtype == FKCONSTR_MATCH_FULL &&
 			ri_NullCheck(tupdesc, slot, &fake_riinfo, false) != RI_KEYS_NONE_NULL)
+		{
+			const char *fk_conname = NameStr(fake_riinfo.conname);
+
+			/* BABEL: resolve original FK name for error display */
+			if (bbf_get_original_constraint_name_hook)
+				fk_conname = bbf_get_original_constraint_name_hook(fk_conname);
 			ereport(ERROR,
 					(errcode(ERRCODE_FOREIGN_KEY_VIOLATION),
 					 errmsg("insert or update on table \"%s\" violates foreign key constraint \"%s\"",
 							RelationGetRelationName(fk_rel),
-							NameStr(fake_riinfo.conname)),
+							fk_conname),
 					 errdetail("MATCH FULL does not allow mixing of null and nonnull key values."),
 					 errtableconstraint(fk_rel,
 										NameStr(fake_riinfo.conname))));
+		}
 
 		/*
 		 * We tell ri_ReportViolation we were doing the RI_PLAN_CHECK_LOOKUPPK
@@ -2694,6 +2708,7 @@ ri_ReportViolation(const RI_ConstraintInfo *riinfo,
 	Oid			rel_oid;
 	AclResult	aclresult;
 	bool		has_perm = true;
+	const char *conname_display;
 
 	/*
 	 * Determine which relation to complain about.  If tupdesc wasn't passed
@@ -2792,12 +2807,22 @@ ri_ReportViolation(const RI_ConstraintInfo *riinfo,
 		}
 	}
 
+	/*
+	 * BABEL: Resolve the original (pre-truncation) FK constraint name for
+	 * display in error messages. The stored conname may be MD5-truncated;
+	 * the hook reverses this via babelfish_identifier_mapping catalog lookup.
+	 * This ensures cross-session FK violations show the full user-visible name.
+	 */
+	conname_display = NameStr(riinfo->conname);
+	if (bbf_get_original_constraint_name_hook)
+		conname_display = bbf_get_original_constraint_name_hook(conname_display);
+
 	if (partgone)
 		ereport(ERROR,
 				(errcode(ERRCODE_FOREIGN_KEY_VIOLATION),
 				 errmsg("removing partition \"%s\" violates foreign key constraint \"%s\"",
 						RelationGetRelationName(pk_rel),
-						NameStr(riinfo->conname)),
+						conname_display),
 				 errdetail("Key (%s)=(%s) is still referenced from table \"%s\".",
 						   key_names.data, key_values.data,
 						   RelationGetRelationName(fk_rel)),
@@ -2807,7 +2832,7 @@ ri_ReportViolation(const RI_ConstraintInfo *riinfo,
 				(errcode(ERRCODE_FOREIGN_KEY_VIOLATION),
 				 errmsg("insert or update on table \"%s\" violates foreign key constraint \"%s\"",
 						RelationGetRelationName(fk_rel),
-						NameStr(riinfo->conname)),
+						conname_display),
 				 has_perm ?
 				 errdetail("Key (%s)=(%s) is not present in table \"%s\".",
 						   key_names.data, key_values.data,
@@ -2820,7 +2845,7 @@ ri_ReportViolation(const RI_ConstraintInfo *riinfo,
 				(errcode(ERRCODE_RESTRICT_VIOLATION),
 				 errmsg("update or delete on table \"%s\" violates RESTRICT setting of foreign key constraint \"%s\" on table \"%s\"",
 						RelationGetRelationName(pk_rel),
-						NameStr(riinfo->conname),
+						conname_display,
 						RelationGetRelationName(fk_rel)),
 				 has_perm ?
 				 errdetail("Key (%s)=(%s) is referenced from table \"%s\".",
@@ -2834,7 +2859,7 @@ ri_ReportViolation(const RI_ConstraintInfo *riinfo,
 				(errcode(ERRCODE_FOREIGN_KEY_VIOLATION),
 				 errmsg("update or delete on table \"%s\" violates foreign key constraint \"%s\" on table \"%s\"",
 						RelationGetRelationName(pk_rel),
-						NameStr(riinfo->conname),
+						conname_display,
 						RelationGetRelationName(fk_rel)),
 				 has_perm ?
 				 errdetail("Key (%s)=(%s) is still referenced from table \"%s\".",

--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -1056,6 +1056,7 @@ setBabelfishDependenciesForLogicalDatabaseDump(Archive *fout)
 	 * sys.babelfish_namespace_ext
 	 * sys.babelfish_extended_properties
 	 * sys.babelfish_schema_permissions
+	 * sys.babelfish_identifier_mapping
 	 * sys.babelfish_partition_function
 	 * sys.babelfish_partition_scheme
 	 * sys.babelfish_partition_depend
@@ -1065,6 +1066,7 @@ setBabelfishDependenciesForLogicalDatabaseDump(Archive *fout)
 						 "FROM pg_class "
 						 "WHERE relname in ('babelfish_schema_permissions', "
 						 "'babelfish_namespace_ext', "
+						 "'babelfish_identifier_mapping', "
 						 "'babelfish_partition_function', "
 						 "'babelfish_partition_scheme', "
 						 "'babelfish_partition_depend', "
@@ -1137,6 +1139,16 @@ addFromClauseForLogicalDatabaseDump(PQExpBuffer buf, TableInfo *tbinfo)
 						  "ON a.nspname = b.nspname "
 						  "WHERE b.dbid = %d",
 						  fmtQualifiedDumpable(tbinfo), bbf_db_id);
+	/*
+	 * BABEL: Include babelfish_identifier_mapping in per-database logical dumps.
+	 * Filter rows by matching the physical schema (nspname) to the target database.
+	 */
+	else if (strcmp(tbinfo->dobj.name, "babelfish_identifier_mapping") == 0)
+		appendPQExpBuffer(buf, " FROM ONLY %s a "
+						  "INNER JOIN sys.babelfish_namespace_ext b "
+						  "ON a.nspname = b.nspname "
+						  "WHERE b.dbid = %d",
+						  fmtQualifiedDumpable(tbinfo), bbf_db_id);
 	else if(strcmp(tbinfo->dobj.name, "babelfish_authid_user_ext") == 0)
 	{
 		appendPQExpBuffer(buf, " FROM ONLY %s a "
@@ -1200,6 +1212,7 @@ addFromClauseForPhysicalDatabaseDump(PQExpBuffer buf, TableInfo *tbinfo)
 						fmtQualifiedDumpable(tbinfo), babel_init_user);
 	else if(strcmp(tbinfo->dobj.name, "babelfish_domain_mapping") == 0 ||
 			strcmp(tbinfo->dobj.name, "babelfish_function_ext") == 0 ||
+			strcmp(tbinfo->dobj.name, "babelfish_identifier_mapping") == 0 ||
 			strcmp(tbinfo->dobj.name, "babelfish_view_def") == 0 ||
 			strcmp(tbinfo->dobj.name, "babelfish_server_options") == 0 ||
 			strcmp(tbinfo->dobj.name, "babelfish_extended_properties") == 0 ||

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -101,6 +101,12 @@ extern PGDLLEXPORT TriggerRecuresiveCheck_hook_type TriggerRecuresiveCheck_hook;
 typedef bool (*bbfViewHasInsteadofTrigger_hook_type) (Relation view, CmdType event);
 extern PGDLLIMPORT bbfViewHasInsteadofTrigger_hook_type bbfViewHasInsteadofTrigger_hook;
 
+typedef const char *(*bbf_get_original_constraint_name_hook_type)(const char *conname);
+extern PGDLLIMPORT bbf_get_original_constraint_name_hook_type bbf_get_original_constraint_name_hook;
+
+typedef const char *(*bbf_get_original_index_name_hook_type)(const char *idxname);
+extern PGDLLIMPORT bbf_get_original_index_name_hook_type bbf_get_original_index_name_hook;
+
 typedef Datum (*adjust_numeric_result_hook_type) (Plan *plan, Node *expr, Datum result, bool result_isnull, Oid result_type, int32 result_typmod);
 extern PGDLLIMPORT adjust_numeric_result_hook_type adjust_numeric_result_hook;
 

--- a/src/include/parser/parse_clause.h
+++ b/src/include/parser/parse_clause.h
@@ -51,7 +51,7 @@ extern List *addTargetToSortList(ParseState *pstate, TargetEntry *tle,
 extern Index assignSortGroupRef(TargetEntry *tle, List *tlist);
 extern bool targetIsInSortList(TargetEntry *tle, Oid sortop, List *sortList);
 
-typedef bool (*tle_name_comparison_hook_type)(const char *tlename, const char *identifier);
+typedef bool (*tle_name_comparison_hook_type)(const char *tlename, const char *identifier, const char *sourcetext, int location);
 extern PGDLLEXPORT tle_name_comparison_hook_type tle_name_comparison_hook;
 
 typedef void (*sortby_nulls_hook_type)(SortGroupClause *sortcl, bool reverse);


### PR DESCRIPTION
### Description

Engine-side changes to support long identifier handling in Babelfish.
  
  1. **New hooks** (`bbf_get_original_constraint_name_hook`, `bbf_get_original_index_name_hook`) allow the extension to resolve original constraint/index names in unique violation and check constraint error messages.
  
  2. **`tle_name_comparison_hook` extended** with `sourcetext` and `location`parameters so ORDER BY clauses can match long column aliases by extracting the full identifier from the raw query text.
  
  3. **View column truncation** — When `sql_dialect == SQL_DIALECT_TSQL` and a view column name exceeds `NAMEDATALEN`, it is MD5-truncated before storage in `pg_attribute`.
  
  4. **Rule rewrite tolerance** — `checkRuleResultList` in `rewriteDefine.c` now allows a long SELECT column name to match its truncated `attname` counterpart for TSQL views.
  
  5. **Dump support** — `babelfish_identifier_mapping` added to logical and physical dump paths.
  
  6. **Syscache** — `IDENTMAPPINGNAME` registered for the new identifier mapping catalog
  
  **Extension PR** : https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4866
 
### Issues Resolved

BABEL-2564, BABEL-5975, BABEL-5321, BABEL-2650, BABEL-6817, BABEL-1518, BABEL-5207, BABEL-5650, BABEL-5416, BABEL-1519
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
