### PR TITLE
[BABEL] Remove tuple-store INSERT EXEC implementation (#771)

### DIFF
--- a/src/backend/access/common/attmap.c
+++ b/src/backend/access/common/attmap.c
@@ -25,7 +25,6 @@
 #include "access/attmap.h"
 #include "utils/builtins.h"
 
-called_from_tsql_insert_exec_hook_type called_from_tsql_insert_exec_hook = NULL;
 called_for_tsql_itvf_func_hook_type called_for_tsql_itvf_func_hook = NULL;
 
 static bool check_attrmap_match(TupleDesc indesc,
@@ -115,10 +114,9 @@ build_attrmap_by_position(TupleDesc indesc,
 			nincols++;
 
 			/* Found matching column, now check type */
-			/* skip check type if it's tsql insert exec or if it is for tsql inline table valued function */
-			if ((atttypid != att->atttypid ||
-				(atttypmod != att->atttypmod && atttypmod >= 0)) &&
-				!(called_from_tsql_insert_exec_hook && called_from_tsql_insert_exec_hook()) &&
+			/* skip check type if it is for tsql inline table valued function */
+			if ((outatt->atttypid != inatt->atttypid ||
+				(outatt->atttypmod != inatt->atttypmod && outatt->atttypmod >= 0)) &&
 				!(called_for_tsql_itvf_func_hook && called_for_tsql_itvf_func_hook()))
 				ereport(ERROR,
 						(errcode(ERRCODE_DATATYPE_MISMATCH),
@@ -314,12 +312,11 @@ check_attrmap_match(TupleDesc indesc,
 			return false;
 
 		/**
-		 * in tsql insert exec or for tsql inline table valued function, we need a cast
+		 * for tsql inline table valued function, we need a cast
 		 */
-		if (((called_from_tsql_insert_exec_hook && called_from_tsql_insert_exec_hook()) 
-				|| (called_for_tsql_itvf_func_hook && called_for_tsql_itvf_func_hook()))
-		 	&& (inatt->atttypid != outatt->atttypid ||
-			inatt->atttypmod != outatt->atttypmod))
+		if ((called_for_tsql_itvf_func_hook && called_for_tsql_itvf_func_hook())
+		 	&& (inatt_form_attributes->atttypid != outatt_form_attributes->atttypid ||
+			inatt_form_attributes->atttypmod != outatt_form_attributes->atttypmod))
 			return false;
 
 		if (attrMap->attnums[i] == (i + 1))

--- a/src/backend/access/common/attmap.c
+++ b/src/backend/access/common/attmap.c
@@ -115,8 +115,8 @@ build_attrmap_by_position(TupleDesc indesc,
 
 			/* Found matching column, now check type */
 			/* skip check type if it is for tsql inline table valued function */
-			if ((outatt->atttypid != inatt->atttypid ||
-				(outatt->atttypmod != inatt->atttypmod && outatt->atttypmod >= 0)) &&
+			if ((atttypid != att->atttypid ||
+				(atttypmod != att->atttypmod && atttypmod >= 0)) &&
 				!(called_for_tsql_itvf_func_hook && called_for_tsql_itvf_func_hook()))
 				ereport(ERROR,
 						(errcode(ERRCODE_DATATYPE_MISMATCH),
@@ -315,8 +315,8 @@ check_attrmap_match(TupleDesc indesc,
 		 * for tsql inline table valued function, we need a cast
 		 */
 		if ((called_for_tsql_itvf_func_hook && called_for_tsql_itvf_func_hook())
-		 	&& (inatt_form_attributes->atttypid != outatt_form_attributes->atttypid ||
-			inatt_form_attributes->atttypmod != outatt_form_attributes->atttypmod))
+		 	&& (inatt->atttypid != outatt->atttypid ||
+			inatt->atttypmod != outatt->atttypmod))
 			return false;
 
 		if (attrMap->attnums[i] == (i + 1))

--- a/src/backend/access/common/tupconvert.c
+++ b/src/backend/access/common/tupconvert.c
@@ -177,10 +177,9 @@ execute_attr_map_tuple(HeapTuple tuple, TupleConversionMap *map)
 		int			j = attrMap->attnums[i];
 
 		/**
-		 * if it's tsql insert exec or if it is for tsql inline table valued function, we'll consider value cast
+		 * if it is for tsql inline table valued function, we'll consider value cast
 		 */
-		if ((called_from_tsql_insert_exec_hook && called_from_tsql_insert_exec_hook())
-			|| (called_for_tsql_itvf_func_hook && called_for_tsql_itvf_func_hook()))
+		if (called_for_tsql_itvf_func_hook && called_for_tsql_itvf_func_hook())
 		{
 			Oid        intypeid;
 			Oid        outtypeid;

--- a/src/backend/commands/functioncmds.c
+++ b/src/backend/commands/functioncmds.c
@@ -2203,115 +2203,6 @@ ExecuteDoStmt(ParseState *pstate, DoStmt *stmt, bool atomic)
 }
 
 /*
- * ExecuteDoStmtInsertExec
- *		Execute inline procedural-language code for INSERT EXEC
- *
- * Similar to ExecuteDoStmt(), but adjusted to work for INSERT EXEC
- */
-void
-ExecuteDoStmtInsertExec(DoStmt *stmt, bool atomic, DestReceiver *dest)
-{
-	InlineCodeBlock *codeblock = makeNode(InlineCodeBlock);
-	ListCell   *arg;
-	DefElem    *as_item = NULL;
-	DefElem    *language_item = NULL;
-	char	   *language;
-	Oid			laninline;
-	HeapTuple	languageTuple;
-	Form_pg_language languageStruct;
-
-	/* Process options we got from gram.y */
-	foreach(arg, stmt->args)
-	{
-		DefElem    *defel = (DefElem *) lfirst(arg);
-
-		if (strcmp(defel->defname, "as") == 0)
-		{
-			if (as_item)
-				ereport(ERROR,
-						(errcode(ERRCODE_SYNTAX_ERROR),
-						 errmsg("conflicting or redundant options")));
-			as_item = defel;
-		}
-		else if (strcmp(defel->defname, "language") == 0)
-		{
-			if (language_item)
-				ereport(ERROR,
-						(errcode(ERRCODE_SYNTAX_ERROR),
-						 errmsg("conflicting or redundant options")));
-			language_item = defel;
-		}
-		else
-			elog(ERROR, "option \"%s\" not recognized",
-				 defel->defname);
-	}
-
-	if (as_item)
-		codeblock->source_text = strVal(as_item->arg);
-	else
-		ereport(ERROR,
-				(errcode(ERRCODE_SYNTAX_ERROR),
-				 errmsg("no inline code specified")));
-
-	/* if LANGUAGE option wasn't specified, use the default (pltsql) */
-	if (language_item)
-		language = strVal(language_item->arg);
-	else
-		language = "pltsql";
-
-	/* Look up the language and validate permissions */
-	languageTuple = SearchSysCache1(LANGNAME, PointerGetDatum(language));
-	if (!HeapTupleIsValid(languageTuple))
-		ereport(ERROR,
-				(errcode(ERRCODE_UNDEFINED_OBJECT),
-				 errmsg("language \"%s\" does not exist", language),
-				 (extension_file_exists(language) ?
-				  errhint("Use CREATE EXTENSION to load the language into the database.") : 0)));
-
-	languageStruct = (Form_pg_language) GETSTRUCT(languageTuple);
-	codeblock->langOid = languageStruct->oid;
-	codeblock->langIsTrusted = languageStruct->lanpltrusted;
-	codeblock->atomic = atomic;
-
-	if (languageStruct->lanpltrusted)
-	{
-		/* if trusted language, need USAGE privilege */
-		AclResult	aclresult;
-
-		aclresult = object_aclcheck(LanguageRelationId, codeblock->langOid, GetUserId(),
-										 ACL_USAGE);
-		if (aclresult != ACLCHECK_OK)
-			aclcheck_error(aclresult, OBJECT_LANGUAGE,
-						   NameStr(languageStruct->lanname));
-	}
-	else
-	{
-		/* if untrusted language, must be superuser */
-		if (!superuser())
-			aclcheck_error(ACLCHECK_NO_PRIV, OBJECT_LANGUAGE,
-						   NameStr(languageStruct->lanname));
-	}
-
-	/* get the handler function's OID */
-	laninline = languageStruct->laninline;
-	if (!OidIsValid(laninline))
-		ereport(ERROR,
-				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-				 errmsg("language \"%s\" does not support inline code execution",
-						NameStr(languageStruct->lanname))));
-
-	ReleaseSysCache(languageTuple);
-
-	/* for INSERT EXEC */
-	codeblock->relation = stmt->relation;
-	codeblock->attrnos = stmt->attrnos;
-	codeblock->dest = (Node *) dest;
-
-	/* execute the inline handler */
-	OidFunctionCall1(laninline, PointerGetDatum(codeblock));
-}
-
-/*
  * Execute CALL statement
  *
  * Inside a top-level CALL statement, transaction-terminating commands such as
@@ -2355,7 +2246,6 @@ ExecuteCallStmt(CallStmt *stmt, ParamListInfo params, bool atomic, DestReceiver 
 	HeapTuple	tp;
 	PgStat_FunctionCallUsage fcusage;
 	Datum		retval;
-	ReturnSetInfo rsinfo; /* for INSERT ... EXECUTE */
 
 	fexpr = stmt->funcexpr;
 	Assert(fexpr);
@@ -2448,65 +2338,6 @@ ExecuteCallStmt(CallStmt *stmt, ParamListInfo params, bool atomic, DestReceiver 
 		i++;
 	}
 
-	/* BABELFISH
-	 * If we are here for INSERT ... EXECUTE, prepare a resultinfo node for
-	 * communication before invoking the function, which can accumulate the
-	 * result sets.
-	 */
-	if (stmt->relation && stmt->attrnos)
-	{
-		/*
-		 * If CallStmt->relation and stmt->attrnos are provided, then we need to
-		 * build a TupleDesc for the ReturnSetInfo.
-		 */
-		Oid reltypeid;
-		TupleDesc reldesc;
-		TupleDesc retdesc;
-		int natts = 0;
-		ListCell *list_cell;
-		ListCell *next;
-
-		/* look up the INSERT target relation rowtype's tupdesc */
-		reltypeid = get_rel_type_id(stmt->relation);
-		reldesc = lookup_rowtype_tupdesc(reltypeid, -1);
-
-		/* build a tupdesc that only contains relevant INSERT columns */
-		retdesc = CreateTemplateTupleDesc(list_length(stmt->attrnos));
-		for (list_cell = list_head(stmt->attrnos); list_cell != NULL; list_cell = next)
-		{
-			natts += 1;
-			TupleDescCopyEntry(retdesc, natts, reldesc, lfirst_int(list_cell));
-			next = lnext(stmt->attrnos, list_cell);
-		}
-
-		fcinfo->resultinfo = (Node *) &rsinfo;
-		rsinfo.type = T_ReturnSetInfo;
-		rsinfo.econtext = econtext;
-		rsinfo.expectedDesc = retdesc;
-		rsinfo.allowedModes = (int) (SFRM_ValuePerCall | SFRM_Materialize);
-		/* note we do not set SFRM_Materialize_Random or _Preferred */
-		rsinfo.returnMode = SFRM_ValuePerCall;
-		rsinfo.isDone = ExprSingleResult;
-		rsinfo.setResult = NULL;
-		rsinfo.setDesc = NULL;
-	}
-	else if (stmt->retdesc && stmt->dest)
-	{
-		/*
-		 * If CallStmt->retdesc is provided, use it for the ReturnSetInfo.
-		 */
-		fcinfo->resultinfo = (Node *) &rsinfo;
-		rsinfo.type = T_ReturnSetInfo;
-		rsinfo.econtext = econtext;
-		rsinfo.expectedDesc = (TupleDesc) stmt->retdesc;
-		rsinfo.allowedModes = (int) (SFRM_ValuePerCall | SFRM_Materialize);
-		/* note we do not set SFRM_Materialize_Random or _Preferred */
-		rsinfo.returnMode = SFRM_ValuePerCall;
-		rsinfo.isDone = ExprSingleResult;
-		rsinfo.setResult = NULL;
-		rsinfo.setDesc = NULL;
-	}
-
 	/* Get rid of temporary snapshot for arguments, if we made one */
 	if (!atomic)
 		PopActiveSnapshot();
@@ -2524,29 +2355,7 @@ ExecuteCallStmt(CallStmt *stmt, ParamListInfo params, bool atomic, DestReceiver 
 	}
 
 	/* Handle the procedure's outputs */
-	if (((stmt->relation && stmt->attrnos) || (stmt->retdesc && stmt->dest)) &&
-		rsinfo.setDesc && rsinfo.setResult)
-	{
-		/* BABELFISH
-		 * If we are here for INSERT ... EXECUTE, send all tuples accumulated in
-		 * resultinfo to the DestReceiver, which will later be consumed by the
-		 * INSERT execution.
-		 */
-		TupleTableSlot *slot = MakeSingleTupleTableSlot(rsinfo.expectedDesc,
-														&TTSOpsMinimalTuple);
-		for (;;)
-		{
-			if (!tuplestore_gettupleslot(rsinfo.setResult, true, false, slot))
-				break;
-			if (stmt->dest)
-				((DestReceiver *)stmt->dest)->receiveSlot(slot, (DestReceiver *)stmt->dest);
-			else
-				dest->receiveSlot(slot, dest);
-			ExecClearTuple(slot);
-		}
-		ExecDropSingleTupleTableSlot(slot);
-	}
-	else if (fexpr->funcresulttype == VOIDOID)
+	if (fexpr->funcresulttype == VOIDOID)
 	{
 		/* do nothing */
 	}

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -4140,7 +4140,6 @@ ExecModifyTable(PlanState *pstate)
 		if (node->mt_merge_pending_not_matched != NULL)
 		{
 			context.planSlot = node->mt_merge_pending_not_matched;
-			context.cpDeletedSlot = NULL;
 
 			slot = ExecMergeNotMatched(&context, node->resultRelInfo,
 								   node->canSetTag);
@@ -4160,7 +4159,6 @@ ExecModifyTable(PlanState *pstate)
 
 		/* Fetch the next row from subplan */
 		context.planSlot = ExecProcNode(subplanstate);
-		context.cpDeletedSlot = NULL;
 
 		/* No more tuples to process? */
 		if (TupIsNull(context.planSlot))

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -4062,11 +4062,6 @@ ExecModifyTable(PlanState *pstate)
 	HeapTuple	oldtuple;
 	ItemPointer tupleid;
 	bool		tuplock;
-	/* for INSERT ... EXECUTE */
-	bool 		tsql_insert_exec = node->callStmt != NULL;
-	Tuplestorestate *tss = NULL;
-	TupleDesc 	tupdesc = NULL;
-	DestReceiver *dest = NULL;
 
 	CHECK_FOR_INTERRUPTS();
 
@@ -4110,36 +4105,6 @@ ExecModifyTable(PlanState *pstate)
 	context.estate = estate;
 
 	/*
-	 * If we are here for INSERT ... EXECUTE, create a TuplestoreDestReceiver
-	 * and pass it to the procedure execution. The procedure execution will send
-	 * its result sets to the tuplestore via the receiver function.
-	 */
-	if (tsql_insert_exec)
-	{
-		tss = tuplestore_begin_heap(false, false, work_mem);
-		tupdesc = RelationGetDescr(resultRelInfo->ri_RelationDesc);
-		dest = CreateTuplestoreDestReceiver();
-		SetTuplestoreDestReceiverParams(dest, tss, CurrentMemoryContext, false, NULL, NULL);
-		dest->rStartup(dest, -1, tupdesc);
-
-		switch (nodeTag(node->callStmt))
-		{
-			case T_CallStmt:
-				ExecuteCallStmt((CallStmt *)node->callStmt,
-								pstate->state->es_param_list_info, false, dest);
-				break;
-			case T_DoStmt:
-				ExecuteDoStmtInsertExec((DoStmt *)node->callStmt, false, dest);
-				break;
-			default:
-				ereport(ERROR,
-						(errcode(ERRCODE_SYNTAX_ERROR),
-						 errmsg("Unrecognized stmt in INSERT EXEC")));
-				break;
-		}
-	}
-
-	/*
 	 * Fetch rows from subplan(s), and execute the required table modification
 	 * for each row.
 	 */
@@ -4168,40 +4133,34 @@ ExecModifyTable(PlanState *pstate)
 			break;
 		}
 
-		if (tsql_insert_exec)
+		/*
+		 * If there is a pending MERGE ... WHEN NOT MATCHED [BY TARGET] action
+		 * to execute, do so now --- see the comments in ExecMerge().
+		 */
+		if (node->mt_merge_pending_not_matched != NULL)
 		{
-			context.planSlot = MakeSingleTupleTableSlot(tupdesc, &TTSOpsMinimalTuple);
-			tuplestore_gettupleslot(tss, true, false, context.planSlot);
-		}
-		else
-                {
+			context.planSlot = node->mt_merge_pending_not_matched;
+			context.cpDeletedSlot = NULL;
+
+			slot = ExecMergeNotMatched(&context, node->resultRelInfo,
+								   node->canSetTag);
+
+			/* Clear the pending action */
+			node->mt_merge_pending_not_matched = NULL;
+
 			/*
-			 * If there is a pending MERGE ... WHEN NOT MATCHED [BY TARGET] action
-			 * to execute, do so now --- see the comments in ExecMerge().
+			 * If we got a RETURNING result, return it to the caller.  We'll
+			 * continue the work on next call.
 			 */
-			if (node->mt_merge_pending_not_matched != NULL)
-			{
-				context.planSlot = node->mt_merge_pending_not_matched;
+			if (slot)
+				return slot;
 
-				slot = ExecMergeNotMatched(&context, node->resultRelInfo,
-									   node->canSetTag);
-
-				/* Clear the pending action */
-				node->mt_merge_pending_not_matched = NULL;
-
-				/*
-				 * If we got a RETURNING result, return it to the caller.  We'll
-				 * continue the work on next call.
-				 */
-				if (slot)
-					return slot;
-
-				continue;			/* continue with the next tuple */
-			}
-
-			/* Fetch the next row from subplan */
-			context.planSlot = ExecProcNode(subplanstate);
+			continue;			/* continue with the next tuple */
 		}
+
+		/* Fetch the next row from subplan */
+		context.planSlot = ExecProcNode(subplanstate);
+		context.cpDeletedSlot = NULL;
 
 		/* No more tuples to process? */
 		if (TupIsNull(context.planSlot))
@@ -4486,21 +4445,12 @@ ExecModifyTable(PlanState *pstate)
 				break;
 		}
 
-		if(tsql_insert_exec)
-			ExecDropSingleTupleTableSlot(context.planSlot);
-
 		/*
 		 * If we got a RETURNING result, return it to caller.  We'll continue
 		 * the work on next call.
 		 */
 		if (slot)
 			return slot;
-	}
-
-	if (tsql_insert_exec && dest)
-	{
-		dest->rShutdown(dest);
-		dest->rDestroy(dest);
 	}
 
 	/*
@@ -4628,8 +4578,6 @@ ExecInitModifyTable(ModifyTable *node, EState *estate, int eflags)
 	mtstate->mt_nrels = nrels;
 	mtstate->resultRelInfo = (ResultRelInfo *)
 		palloc(nrels * sizeof(ResultRelInfo));
-
-	mtstate->callStmt = node->callStmt;
 
 	mtstate->mt_merge_pending_not_matched = NULL;
 	mtstate->mt_merge_inserted = 0;

--- a/src/backend/executor/spi.c
+++ b/src/backend/executor/spi.c
@@ -2709,13 +2709,8 @@ _SPI_execute_plan(SPIPlanPtr plan, const SPIExecuteOptions *options,
 			else
 				dest = CreateDestReceiver(DestSPI);
 
-			if (stmt->utilityStmt == NULL || stmt->commandType == CMD_INSERT)
+			if (stmt->utilityStmt == NULL)
 			{
-				/*
-				 * INSERT ... EXECUTE stmt can also have a utilityStmt attached,
-				 * and here we should treat it like an INSERT stmt, and let it
-				 * handle the EXECUTE during its execution.
-				 */
 				QueryDesc  *qdesc;
 				Snapshot	snap;
 

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -424,12 +424,6 @@ standard_planner(Query *parse, const char *query_string, int cursorOptions,
 	best_path = get_cheapest_fractional_path(final_rel, tuple_fraction);
 
 	top_plan = create_plan(root, best_path);
-	/*
-	 * For INSERT ... EXECUTE, add the utilityStmt (if any) from the Query to
-	 * the plan node.
-	 */
-	if (nodeTag(top_plan) == T_ModifyTable)
-		((ModifyTable *)top_plan)->callStmt = parse->utilityStmt;
 
 	/*
 	 * If creating a plan for a scrollable cursor, make sure it can run

--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -732,39 +732,6 @@ transformInsertStmt(ParseState *pstate, InsertStmt *stmt)
 	Assert(list_length(icolumns) == list_length(attrnos));
 
 	/*
-	 * For INSERT ... EXECUTE, transform the CallStmt/DoStmt, and attach it to
-	 * the Query's utilityStmt.
-	 */
-	if (stmt->execStmt)
-	{
-		switch (nodeTag(stmt->execStmt))
-		{
-			case T_CallStmt:
-				{
-					Query *callStmtQry = transformCallStmt(pstate, (CallStmt *)stmt->execStmt);
-					((CallStmt *) stmt->execStmt)->relation = pstate->p_target_relation->rd_id;
-					((CallStmt *) stmt->execStmt)->attrnos = attrnos;
-					((CallStmt *) stmt->execStmt)->retdesc = NULL;
-					((CallStmt *) stmt->execStmt)->dest = NULL;
-					qry->utilityStmt = callStmtQry->utilityStmt;
-				}
-				break;
-			case T_DoStmt:
-				((DoStmt *) stmt->execStmt)->relation = pstate->p_target_relation->rd_id;
-				((DoStmt *) stmt->execStmt)->attrnos = attrnos;
-				qry->utilityStmt = stmt->execStmt;
-				break;
-			default:
-				ereport(ERROR,
-						(errcode(ERRCODE_SYNTAX_ERROR),
-						 errmsg("Unrecognized stmt in INSERT EXEC"),
-						 parser_errposition(pstate,
-											exprLocation((Node *) stmt->execStmt))));
-				break;
-		}
-	}
-
-	/*
 	 * Determine which variant of INSERT we have.
 	 */
 	if (selectStmt == NULL)

--- a/src/include/access/attmap.h
+++ b/src/include/access/attmap.h
@@ -50,9 +50,7 @@ extern AttrMap *build_attrmap_by_name_if_req(TupleDesc indesc,
 extern AttrMap *build_attrmap_by_position(TupleDesc indesc,
 										  TupleDesc outdesc,
 										  const char *msg);
-typedef bool (*called_from_tsql_insert_exec_hook_type)();
 typedef bool (*called_for_tsql_itvf_func_hook_type)();
-extern PGDLLEXPORT called_from_tsql_insert_exec_hook_type called_from_tsql_insert_exec_hook;
 extern PGDLLIMPORT called_for_tsql_itvf_func_hook_type called_for_tsql_itvf_func_hook;
 
 #endif							/* ATTMAP_H */

--- a/src/include/commands/defrem.h
+++ b/src/include/commands/defrem.h
@@ -58,7 +58,6 @@ extern ObjectAddress CreateTransform(CreateTransformStmt *stmt);
 extern void IsThereFunctionInNamespace(const char *proname, int pronargs,
 									   oidvector *proargtypes, Oid nspOid);
 extern void ExecuteDoStmt(ParseState *pstate, DoStmt *stmt, bool atomic);
-extern void ExecuteDoStmtInsertExec(DoStmt *stmt, bool atomic, DestReceiver *dest);
 extern void ExecuteCallStmt(CallStmt *stmt, ParamListInfo params, bool atomic, DestReceiver *dest);
 extern TupleDesc CallStmtResultDesc(CallStmt *stmt);
 extern Oid	get_transform_oid(Oid type_id, Oid lang_id, bool missing_ok);

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -1411,9 +1411,6 @@ typedef struct ModifyTableState
 	/* controls transition table population for INSERT...ON CONFLICT UPDATE */
 	struct TransitionCaptureState *mt_oc_transition_capture;
 
-	/* CallStmt for INSERT ... EXECUTE */
-	Node	   *callStmt;
-
 	/* Flags showing which subcommands are present INS/UPD/DEL/DO NOTHING */
 	int			mt_merge_subcommands;
 

--- a/src/include/nodes/parsenodes.h
+++ b/src/include/nodes/parsenodes.h
@@ -2051,7 +2051,6 @@ typedef struct InsertStmt
 	List	   *returningList;	/* list of expressions to return */
 	WithClause *withClause;		/* WITH clause */
 	OverridingKind override;	/* OVERRIDING clause */
-	Node	   *execStmt; 		/* for INSERT ... EXECUTE */
 	Node       *limitCount;		/* used by INSERT TOP in T-SQL*/
 } InsertStmt;
 
@@ -3495,9 +3494,6 @@ typedef struct DoStmt
 {
 	NodeTag		type;
 	List	   *args;			/* List of DefElem nodes */
-	/* for INSERT ... EXECUTE */
-	Oid 		relation;		/* INSERT target relation */
-	List 	   *attrnos; 		/* columns list by attnum */
 } DoStmt;
 
 typedef struct InlineCodeBlock
@@ -3509,10 +3505,6 @@ typedef struct InlineCodeBlock
 	Oid			langOid;		/* OID of selected language */
 	bool		langIsTrusted;	/* trusted property of the language */
 	bool		atomic;			/* atomic execution context */
-	/* for INSERT ... EXECUTE */
-	Oid 		relation;		/* INSERT target relation */
-	List 	   *attrnos; 		/* columns list by attnum */
-	Node 	   *dest; 			/* dest receiver */
 } InlineCodeBlock;
 
 /* ----------------------
@@ -3535,17 +3527,6 @@ typedef struct CallStmt
 	FuncExpr   *funcexpr;
 	/* transformed output-argument expressions */
 	List	   *outargs;
-	/* for INSERT ... EXECUTE */
-	Oid 		relation;		/* INSERT target relation */
-	List 	   *attrnos; 		/* columns list by attnum */
-	/*
-	 * for nested CallStmt under INSERT ... EXECUTE
-	 * for example, in query "INSERT INTO t1 EXEC ('EXEC p1')"
-	 * the CallStmt of the inner "EXEC p1" will have the following two fields
-	 * filled in based on the outer "INSERT INTO t1 EXEC"
-	 */
-	void 	   *retdesc; 		/* expected TupleDesc of the result rows */
-	void 	   *dest; 			/* DestReceiver to send the result rows */
 } CallStmt;
 
 typedef struct CallContext


### PR DESCRIPTION
### Description

This PR removes the old tuple-store based INSERT EXEC implementation from the engine side. The INSERT EXEC feature has been reimplemented using a DestReceiver-based approach in the extension side.

Changes:

Remove `called_from_tsql_insert_exec_hook_type` typedef from src/include/access/attmap.h
Remove `called_from_tsql_insert_exec_hook` extern declaration from attmap.h
Remove `called_from_tsql_insert_exec_hook` variable from src/backend/access/common/attmap.c
Remove hook usage from attmap.c type checking logic
Remove hook usage from src/backend/access/common/tupconvert.c value casting logic
Remove entire old tuple-store based INSERT EXEC implementation from src/backend/executor/nodeModifyTable.c (~60 lines)
Why:
The new DestReceiver-based approach:

Uses a temp table to store results instead of tuple store
Handles type coercion properly
Provides better error handling and transaction semantics
The old engine-side hooks are no longer needed.
 
 Cherry-pick from https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/771
 Related Extension PR:
### Issues Resolved

Cleanup of deprecated INSERT EXEC engine hooks as part of the DestReceiver-based INSERT EXEC reimplementation.
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
