### PR TITLE
[OSS-ONLY][BABEL] Fix: Skip ENR check in CheckRelationOidLockedByMe for dependencyLockAndCheckObject

### DIFF
--- a/src/backend/storage/lmgr/lmgr.c
+++ b/src/backend/storage/lmgr/lmgr.c
@@ -336,6 +336,7 @@ CheckRelationLockedByMe(Relation relation, LOCKMODE lockmode, bool orstronger)
 {
 	LOCKTAG		tag;
 
+	/* ENRs are session-local and never locked; simply return true if rel is ENR */
 	if (find_object_in_enr_hook && (*find_object_in_enr_hook)(RelationRelationId, RelationGetRelid(relation), NULL))
 		return true;
 
@@ -355,6 +356,10 @@ bool
 CheckRelationOidLockedByMe(Oid relid, LOCKMODE lockmode, bool orstronger)
 {
 	LOCKTAG		tag;
+
+	/* ENRs are session-local and never locked; simply return true if rel is ENR */
+	if (find_object_in_enr_hook && (*find_object_in_enr_hook) (RelationRelationId, relid, NULL))
+		return true;
 
 	SetLocktagRelationOid(&tag, relid);
 


### PR DESCRIPTION
### Description

Community commit c8cd3d6976f introduced dependencyLockAndCheckObject() which verifies that referenced objects still exist before recording dependencies. For relations, it calls CheckRelationOidLockedByMe() and if not locked, attempts to verify the relation exists via SearchSysCacheExists1.

ENR temp tables and table variables are session-local and never hold real lock entries in shared memory — LockAcquire short-circuits for them. This caused dependencyLockAndCheckObject to erroneously throw "referenced relation was concurrently dropped" when creating the type → relation dependency during temp table or table variable creation.

Fix by returning true from CheckRelationOidLockedByMe for ENR objects, consistent with the existing pattern in CheckRelationLockedByMe.

### Issues Resolved

BABEL-6867
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
