### PR TITLE
BABEL-5975: Add pg_dump for babelfish_identifier_mapping

### DIFF
--- a/src/backend/catalog/genbki.pl
+++ b/src/backend/catalog/genbki.pl
@@ -68,6 +68,7 @@ my @extension_syscaches = qw(
     PROCNAMENSPSIGNATURE
     SYSNAMESPACENAME
     AUTHIDUSEREXTROLENAME
+    IDENTMAPPINGNAME
 );
 
 foreach my $header (@ARGV)

--- a/src/bin/pg_dump/dump_babel_utils.c
+++ b/src/bin/pg_dump/dump_babel_utils.c
@@ -1056,6 +1056,7 @@ setBabelfishDependenciesForLogicalDatabaseDump(Archive *fout)
 	 * sys.babelfish_namespace_ext
 	 * sys.babelfish_extended_properties
 	 * sys.babelfish_schema_permissions
+	 * sys.babelfish_identifier_mapping
 	 * sys.babelfish_partition_function
 	 * sys.babelfish_partition_scheme
 	 * sys.babelfish_partition_depend
@@ -1065,6 +1066,7 @@ setBabelfishDependenciesForLogicalDatabaseDump(Archive *fout)
 						 "FROM pg_class "
 						 "WHERE relname in ('babelfish_schema_permissions', "
 						 "'babelfish_namespace_ext', "
+						 "'babelfish_identifier_mapping', "
 						 "'babelfish_partition_function', "
 						 "'babelfish_partition_scheme', "
 						 "'babelfish_partition_depend', "
@@ -1137,6 +1139,12 @@ addFromClauseForLogicalDatabaseDump(PQExpBuffer buf, TableInfo *tbinfo)
 						  "ON a.nspname = b.nspname "
 						  "WHERE b.dbid = %d",
 						  fmtQualifiedDumpable(tbinfo), bbf_db_id);
+	else if (strcmp(tbinfo->dobj.name, "babelfish_identifier_mapping") == 0)
+		appendPQExpBuffer(buf, " FROM ONLY %s a "
+						  "INNER JOIN sys.babelfish_namespace_ext b "
+						  "ON a.nspname = b.nspname "
+						  "WHERE b.dbid = %d",
+						  fmtQualifiedDumpable(tbinfo), bbf_db_id);
 	else if(strcmp(tbinfo->dobj.name, "babelfish_authid_user_ext") == 0)
 	{
 		appendPQExpBuffer(buf, " FROM ONLY %s a "
@@ -1200,6 +1208,7 @@ addFromClauseForPhysicalDatabaseDump(PQExpBuffer buf, TableInfo *tbinfo)
 						fmtQualifiedDumpable(tbinfo), babel_init_user);
 	else if(strcmp(tbinfo->dobj.name, "babelfish_domain_mapping") == 0 ||
 			strcmp(tbinfo->dobj.name, "babelfish_function_ext") == 0 ||
+			strcmp(tbinfo->dobj.name, "babelfish_identifier_mapping") == 0 ||
 			strcmp(tbinfo->dobj.name, "babelfish_view_def") == 0 ||
 			strcmp(tbinfo->dobj.name, "babelfish_server_options") == 0 ||
 			strcmp(tbinfo->dobj.name, "babelfish_extended_properties") == 0 ||


### PR DESCRIPTION

 Add engine support for the new sys.babelfish_identifier_mapping catalog table introduced in the extensions PR. This table stores original T-SQL identifier names for objects (sequences, constraints, types, parameters) whose names exceed PostgreSQL's NAMEDATALEN limit.
  
 pg_dump (dump_babel_utils.c):
  - Add babelfish_identifier_mapping to the list of Babelfish system
    tables that participate in logical and physical database dumps
  - Add FROM clause logic for logical database dump: filter rows by
    joining on babelfish_namespace_ext.nspname to dump only mappings
    belonging to the target logical database
  - Add babelfish_identifier_mapping to the physical dump table list
    alongside babelfish_domain_mapping, babelfish_function_ext, etc.
  
  Part 1 of 5 for BABEL-5975 (Long Identifier Support).

Extension PR : https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4921

### Description

[Describe what this change achieves]
 
### Issues Resolved

[List any issues this PR will resolve]
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
