### PR TITLE
BABEL-5975: Add engine hooks for original identifier name resolution in errors

### DIFF
--- a/src/backend/access/nbtree/nbtinsert.c
+++ b/src/backend/access/nbtree/nbtinsert.c
@@ -16,6 +16,7 @@
 #include "postgres.h"
 
 #include "access/nbtree.h"
+#include "executor/executor.h"
 #include "access/nbtxlog.h"
 #include "access/transam.h"
 #include "access/xloginsert.h"
@@ -663,14 +664,33 @@ _bt_check_unique(Relation rel, BTInsertState insertstate, Relation heapRel,
 						key_desc = BuildIndexValueDescription(rel, values,
 															  isnull);
 
-						ereport(ERROR,
-								(errcode(ERRCODE_UNIQUE_VIOLATION),
-								 errmsg("duplicate key value violates unique constraint \"%s\"",
-										RelationGetRelationName(rel)),
-								 key_desc ? errdetail("Key %s already exists.",
-													  key_desc) : 0,
-								 errtableconstraint(heapRel,
-													RelationGetRelationName(rel))));
+						{
+							const char *conname = RelationGetRelationName(rel);
+
+							/*
+							 * BABEL: Resolve the original (pre-truncation) name for
+							 * display in error messages. For Babelfish, identifiers
+							 * longer than NAMEDATALEN are MD5-truncated at storage
+							 * time. The index hook reads pg_class.reloptions to
+							 * recover the original index name, and the constraint hook
+							 * looks up babelfish_identifier_mapping for the full
+							 * constraint name. We chain both: first try the index
+							 * reloptions, then fall back to the identifier mapping if
+							 * the name is still at the truncation boundary.
+							 */
+							if (bbf_get_original_index_name_hook)
+								conname = bbf_get_original_index_name_hook(conname);
+							if (bbf_get_original_constraint_name_hook && strlen(conname) >= NAMEDATALEN - 1)
+								conname = bbf_get_original_constraint_name_hook(conname);
+							ereport(ERROR,
+									(errcode(ERRCODE_UNIQUE_VIOLATION),
+									 errmsg("duplicate key value violates unique constraint \"%s\"",
+											conname),
+									 key_desc ? errdetail("Key %s already exists.",
+														  key_desc) : 0,
+									 errtableconstraint(heapRel,
+														RelationGetRelationName(rel))));
+						}
 					}
 				}
 				else if (all_dead && (!inposting ||

--- a/src/backend/executor/execMain.c
+++ b/src/backend/executor/execMain.c
@@ -65,6 +65,10 @@
 #include "utils/rls.h"
 #include "utils/snapmgr.h"
 
+/* BABEL: Hooks for resolving original long identifier names in constraint errors */
+bbf_get_original_constraint_name_hook_type bbf_get_original_constraint_name_hook = NULL;
+bbf_get_original_index_name_hook_type bbf_get_original_index_name_hook = NULL;
+
 
 /* Hooks for plugins to get control in ExecutorStart/Run/Finish/End */
 ExecutorStart_hook_type ExecutorStart_hook = NULL;
@@ -2096,12 +2100,23 @@ ExecConstraints(ResultRelInfo *resultRelInfo,
 													 tupdesc,
 													 modifiedCols,
 													 64);
+			{
+				const char *display_name = failed;
+
+				/*
+				 * BABEL: Resolve the original constraint name for display in the
+				 * check violation error message. The stored constraint name may
+				 * be MD5-truncated; the hook reverses this via catalog lookup.
+				 */
+				if (bbf_get_original_constraint_name_hook)
+					display_name = bbf_get_original_constraint_name_hook(failed);
 			ereport(ERROR,
 					(errcode(ERRCODE_CHECK_VIOLATION),
 					 errmsg("new row for relation \"%s\" violates check constraint \"%s\"",
-							RelationGetRelationName(orig_rel), failed),
+							RelationGetRelationName(orig_rel), display_name),
 					 val_desc ? errdetail("Failing row contains %s.", val_desc) : 0,
 					 errtableconstraint(orig_rel, failed)));
+			}
 		}
 	}
 }

--- a/src/backend/utils/adt/ri_triggers.c
+++ b/src/backend/utils/adt/ri_triggers.c
@@ -343,14 +343,21 @@ RI_FKey_check(TriggerData *trigdata)
 					 * Not allowed - MATCH FULL says either all or none of the
 					 * attributes can be NULLs
 					 */
-					ereport(ERROR,
-							(errcode(ERRCODE_FOREIGN_KEY_VIOLATION),
-							 errmsg("insert or update on table \"%s\" violates foreign key constraint \"%s\"",
-									RelationGetRelationName(fk_rel),
-									NameStr(riinfo->conname)),
-							 errdetail("MATCH FULL does not allow mixing of null and nonnull key values."),
-							 errtableconstraint(fk_rel,
-												NameStr(riinfo->conname))));
+					{
+						const char *fk_conname = NameStr(riinfo->conname);
+
+						/* BABEL: resolve original FK name for error display */
+						if (bbf_get_original_constraint_name_hook)
+							fk_conname = bbf_get_original_constraint_name_hook(fk_conname);
+						ereport(ERROR,
+								(errcode(ERRCODE_FOREIGN_KEY_VIOLATION),
+								 errmsg("insert or update on table \"%s\" violates foreign key constraint \"%s\"",
+										RelationGetRelationName(fk_rel),
+										fk_conname),
+								 errdetail("MATCH FULL does not allow mixing of null and nonnull key values."),
+								 errtableconstraint(fk_rel,
+													NameStr(riinfo->conname))));
+					}
 					table_close(pk_rel, RowShareLock);
 					return PointerGetDatum(NULL);
 
@@ -1804,14 +1811,21 @@ RI_Initial_Check(Trigger *trigger, Relation fk_rel, Relation pk_rel)
 		 */
 		if (fake_riinfo.confmatchtype == FKCONSTR_MATCH_FULL &&
 			ri_NullCheck(tupdesc, slot, &fake_riinfo, false) != RI_KEYS_NONE_NULL)
+		{
+			const char *fk_conname = NameStr(fake_riinfo.conname);
+
+			/* BABEL: resolve original FK name for error display */
+			if (bbf_get_original_constraint_name_hook)
+				fk_conname = bbf_get_original_constraint_name_hook(fk_conname);
 			ereport(ERROR,
 					(errcode(ERRCODE_FOREIGN_KEY_VIOLATION),
 					 errmsg("insert or update on table \"%s\" violates foreign key constraint \"%s\"",
 							RelationGetRelationName(fk_rel),
-							NameStr(fake_riinfo.conname)),
+							fk_conname),
 					 errdetail("MATCH FULL does not allow mixing of null and nonnull key values."),
 					 errtableconstraint(fk_rel,
 										NameStr(fake_riinfo.conname))));
+		}
 
 		/*
 		 * We tell ri_ReportViolation we were doing the RI_PLAN_CHECK_LOOKUPPK
@@ -2694,6 +2708,7 @@ ri_ReportViolation(const RI_ConstraintInfo *riinfo,
 	Oid			rel_oid;
 	AclResult	aclresult;
 	bool		has_perm = true;
+	const char *conname_display;
 
 	/*
 	 * Determine which relation to complain about.  If tupdesc wasn't passed
@@ -2792,12 +2807,22 @@ ri_ReportViolation(const RI_ConstraintInfo *riinfo,
 		}
 	}
 
+	/*
+	 * BABEL: Resolve the original (pre-truncation) FK constraint name for
+	 * display in error messages. The stored conname may be MD5-truncated;
+	 * the hook reverses this via babelfish_identifier_mapping catalog lookup.
+	 * This ensures cross-session FK violations show the full user-visible name.
+	 */
+	conname_display = NameStr(riinfo->conname);
+	if (bbf_get_original_constraint_name_hook)
+		conname_display = bbf_get_original_constraint_name_hook(conname_display);
+
 	if (partgone)
 		ereport(ERROR,
 				(errcode(ERRCODE_FOREIGN_KEY_VIOLATION),
 				 errmsg("removing partition \"%s\" violates foreign key constraint \"%s\"",
 						RelationGetRelationName(pk_rel),
-						NameStr(riinfo->conname)),
+						conname_display),
 				 errdetail("Key (%s)=(%s) is still referenced from table \"%s\".",
 						   key_names.data, key_values.data,
 						   RelationGetRelationName(fk_rel)),
@@ -2807,7 +2832,7 @@ ri_ReportViolation(const RI_ConstraintInfo *riinfo,
 				(errcode(ERRCODE_FOREIGN_KEY_VIOLATION),
 				 errmsg("insert or update on table \"%s\" violates foreign key constraint \"%s\"",
 						RelationGetRelationName(fk_rel),
-						NameStr(riinfo->conname)),
+						conname_display),
 				 has_perm ?
 				 errdetail("Key (%s)=(%s) is not present in table \"%s\".",
 						   key_names.data, key_values.data,
@@ -2820,7 +2845,7 @@ ri_ReportViolation(const RI_ConstraintInfo *riinfo,
 				(errcode(ERRCODE_RESTRICT_VIOLATION),
 				 errmsg("update or delete on table \"%s\" violates RESTRICT setting of foreign key constraint \"%s\" on table \"%s\"",
 						RelationGetRelationName(pk_rel),
-						NameStr(riinfo->conname),
+						conname_display,
 						RelationGetRelationName(fk_rel)),
 				 has_perm ?
 				 errdetail("Key (%s)=(%s) is referenced from table \"%s\".",
@@ -2834,7 +2859,7 @@ ri_ReportViolation(const RI_ConstraintInfo *riinfo,
 				(errcode(ERRCODE_FOREIGN_KEY_VIOLATION),
 				 errmsg("update or delete on table \"%s\" violates foreign key constraint \"%s\" on table \"%s\"",
 						RelationGetRelationName(pk_rel),
-						NameStr(riinfo->conname),
+						conname_display,
 						RelationGetRelationName(fk_rel)),
 				 has_perm ?
 				 errdetail("Key (%s)=(%s) is still referenced from table \"%s\".",

--- a/src/include/executor/executor.h
+++ b/src/include/executor/executor.h
@@ -101,6 +101,12 @@ extern PGDLLEXPORT TriggerRecuresiveCheck_hook_type TriggerRecuresiveCheck_hook;
 typedef bool (*bbfViewHasInsteadofTrigger_hook_type) (Relation view, CmdType event);
 extern PGDLLIMPORT bbfViewHasInsteadofTrigger_hook_type bbfViewHasInsteadofTrigger_hook;
 
+typedef const char *(*bbf_get_original_constraint_name_hook_type)(const char *conname);
+extern PGDLLIMPORT bbf_get_original_constraint_name_hook_type bbf_get_original_constraint_name_hook;
+
+typedef const char *(*bbf_get_original_index_name_hook_type)(const char *idxname);
+extern PGDLLIMPORT bbf_get_original_index_name_hook_type bbf_get_original_index_name_hook;
+
 typedef Datum (*adjust_numeric_result_hook_type) (Plan *plan, Node *expr, Datum result, bool result_isnull, Oid result_type, int32 result_typmod);
 extern PGDLLIMPORT adjust_numeric_result_hook_type adjust_numeric_result_hook;
 


### PR DESCRIPTION
This PR adds hooks that allow the Babelfish extension to resolve original full-length names at error emission sites, so TDS clients see meaningful names instead of truncated internal ones.

 Hooks (executor.h):
  - bbf_get_original_constraint_name_hook: called to resolve the original
    constraint name before emitting constraint violation errors
  - bbf_get_original_index_name_hook: called to resolve the original
    index name before emitting unique violation errors

Part 5 of 5 for BABEL-5975 (Long Identifier Support).

extension : https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4924

### Description

[Describe what this change achieves]
 
### Issues Resolved

[List any issues this PR will resolve]
 
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
