### PR TITLE
Externalize xpath_internal() for extension PR 4920 for XML methods in C

### DIFF
--- a/src/backend/utils/adt/xml.c
+++ b/src/backend/utils/adt/xml.c
@@ -4323,8 +4323,7 @@ xml_xpathobjtoxmlarray(xmlXPathObjectPtr xpathobj,
  * an XML document - XPath doesn't work easily on fragments without
  * a context node being known.
  */
-void
-//static void
+static void
 xpath_internal(text *xpath_expr_text, xmltype *data, ArrayType *namespaces,
 			   int *res_nitems, ArrayBuildState *astate)
 {
@@ -4394,7 +4393,6 @@ xpath_internal(text *xpath_expr_text, xmltype *data, ArrayType *namespaces,
 	string = pg_xmlCharStrndup(datastr, len);
 	xpath_expr = pg_xmlCharStrndup(VARDATA_ANY(xpath_expr_text), xpath_len);
 
-printf("*** xpath_internal:xpath_expr=[%s] xmldata=[%s]\n", (char *)xpath_expr, (char *)string);
 	/*
 	 * In a UTF8 database, skip any xml declaration, which might assert
 	 * another encoding.  Ignore parse_xml_decl() failure, letting
@@ -4511,6 +4509,16 @@ printf("*** xpath_internal:xpath_expr=[%s] xmldata=[%s]\n", (char *)xpath_expr, 
 	xmlFreeParserCtxt(ctxt);
 
 	pg_xml_done(xmlerrcxt, false);
+}
+
+/*
+ * Wrapper around xpath_internal(), used by Babelfish
+ */
+void
+xpath_internal_wrapper(text *xpath_expr_text, xmltype *data, ArrayType *namespaces,
+			   int *res_nitems, ArrayBuildState *astate)
+{
+	xpath_internal(xpath_expr_text, data, namespaces, res_nitems, astate);
 }
 #endif							/* USE_LIBXML */
 

--- a/src/backend/utils/adt/xml.c
+++ b/src/backend/utils/adt/xml.c
@@ -4323,7 +4323,8 @@ xml_xpathobjtoxmlarray(xmlXPathObjectPtr xpathobj,
  * an XML document - XPath doesn't work easily on fragments without
  * a context node being known.
  */
-static void
+void
+//static void
 xpath_internal(text *xpath_expr_text, xmltype *data, ArrayType *namespaces,
 			   int *res_nitems, ArrayBuildState *astate)
 {
@@ -4344,7 +4345,6 @@ xpath_internal(text *xpath_expr_text, xmltype *data, ArrayType *namespaces,
 	Datum	   *ns_names_uris;
 	bool	   *ns_names_uris_nulls;
 	int			ns_count;
-
 	/*
 	 * Namespace mappings are passed as text[].  If an empty array is passed
 	 * (ndim = 0, "0-dimensional"), then there are no namespace mappings.
@@ -4394,6 +4394,7 @@ xpath_internal(text *xpath_expr_text, xmltype *data, ArrayType *namespaces,
 	string = pg_xmlCharStrndup(datastr, len);
 	xpath_expr = pg_xmlCharStrndup(VARDATA_ANY(xpath_expr_text), xpath_len);
 
+printf("*** xpath_internal:xpath_expr=[%s] xmldata=[%s]\n", (char *)xpath_expr, (char *)string);
 	/*
 	 * In a UTF8 database, skip any xml declaration, which might assert
 	 * another encoding.  Ignore parse_xml_decl() failure, letting

--- a/src/include/utils/xml.h
+++ b/src/include/utils/xml.h
@@ -110,7 +110,7 @@ extern PGDLLIMPORT int xmloption;	/* XmlOptionType, but int for guc enum */
 
 extern PGDLLIMPORT const TableFuncRoutine XmlTableRoutine;
 
-extern void xpath_internal(text *xpath_expr_text, xmltype *data,
+extern void xpath_internal_wrapper(text *xpath_expr_text, xmltype *data,
                           ArrayType *namespaces, int *res_nitems,
                           ArrayBuildState *astate);
 

--- a/src/include/utils/xml.h
+++ b/src/include/utils/xml.h
@@ -102,6 +102,10 @@ extern int	parse_xml_decl_wrapper(const xmlChar *str, size_t *lenp,
 /* Hook function type for TSQL OPENXML namespace handling */
 typedef void (*openxml_set_namespaces_hook_type) (xmlXPathContext * xpathctx, PgXmlErrorContext *xmlerrcxt, char *doc_id_str);
 extern PGDLLIMPORT openxml_set_namespaces_hook_type openxml_set_namespaces_hook;
+
+extern void xpath_internal_wrapper(text *xpath_expr_text, xmltype *data,
+                          ArrayType *namespaces, int *res_nitems,
+                          ArrayBuildState *astate);
 #endif							/* USE_LIBXML */
 
 extern PGDLLIMPORT int xmlbinary;	/* XmlBinaryType, but int for guc enum */
@@ -109,9 +113,5 @@ extern PGDLLIMPORT int xmlbinary;	/* XmlBinaryType, but int for guc enum */
 extern PGDLLIMPORT int xmloption;	/* XmlOptionType, but int for guc enum */
 
 extern PGDLLIMPORT const TableFuncRoutine XmlTableRoutine;
-
-extern void xpath_internal_wrapper(text *xpath_expr_text, xmltype *data,
-                          ArrayType *namespaces, int *res_nitems,
-                          ArrayBuildState *astate);
 
 #endif							/* XML_H */

--- a/src/include/utils/xml.h
+++ b/src/include/utils/xml.h
@@ -22,6 +22,7 @@
 #ifdef USE_LIBXML
 #include <libxml/tree.h>
 #include <libxml/xpath.h>
+#include "utils/array.h"
 #endif
 
 typedef struct varlena xmltype;
@@ -108,5 +109,9 @@ extern PGDLLIMPORT int xmlbinary;	/* XmlBinaryType, but int for guc enum */
 extern PGDLLIMPORT int xmloption;	/* XmlOptionType, but int for guc enum */
 
 extern PGDLLIMPORT const TableFuncRoutine XmlTableRoutine;
+
+extern void xpath_internal(text *xpath_expr_text, xmltype *data,
+                          ArrayType *namespaces, int *res_nitems,
+                          ArrayBuildState *astate);
 
 #endif							/* XML_H */


### PR DESCRIPTION
### Description

Externalize xpath_internal() for performance improvements in PR https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4920 (implementing XML nodes() and other XML methods in C)

Signed-off-by: Rob Verschoor [rcv@amazon.com](mailto:rcv@amazon.com)

### Issues Resolved

See https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4920

### Test Scenarios Covered

See https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4920
 
### Check List

- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
