### PR TITLE
[BABEL] Fix statement-level trigger firing N times during FK CASCADE

### DIFF
--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -130,6 +130,7 @@ static void set_iot_state(Oid relid, CmdType cmdType, IOTState newState);
 static bool IsCompositeTriggerActive(void);
 static void AddCompositeTriggerLevelData(void);
 static bool IsCompositeTrigger(Oid fn_oid, List *fn_name);
+static void cancel_prior_composite_stmt_triggers(Oid relid, int tgevent);
 
 static bool FreeTriggerTable(int query_depth);
 
@@ -7358,6 +7359,13 @@ cancel_prior_stmt_triggers(Oid relid, CmdType cmdType, int tgevent)
 	}
 done:
 
+	/*
+	 * BABELFISH: Also cancel matching statement-level events in the composite
+	 * trigger event list, which the query_stack scan above does not reach.
+	 */
+	if (table->after_trig_done)
+		cancel_prior_composite_stmt_triggers(relid, tgevent);
+
 	/* In any case, save current insertion point for next time */
 	table->after_trig_done = true;
 	table->after_trig_events = qs->events;
@@ -7394,6 +7402,54 @@ bool IsCompositeTriggerActive(void)
 {
 	return (compositeTriggers.triggers != NULL &&
 			compositeTriggers.triggers->triggerLevel == compositeTriggers.triggerLevel);
+}
+
+/*
+ * cancel_prior_composite_stmt_triggers
+ *
+ * For Babelfish (pltsql) triggers, AFTER STATEMENT events are queued into a
+ * separate event list (compositeTriggers.triggers->data.events) instead of the
+ * query_stack, so the query_stack scan in cancel_prior_stmt_triggers() never
+ * sees them. This function applies the same cancellation to the composite
+ * event list: previously queued AFTER STATEMENT events for the given relation +
+ * operation that have not yet fired are marked DONE, preserving the property
+ * that AFTER STATEMENT triggers fire only once even when several FK enforcement
+ * triggers sequentially queue triggers for the same table into the same trigger
+ * query level.
+ *
+ * Unlike the query_stack scan, we cannot stop at the first non-matching event:
+ * the composite list may interleave events for different relations and
+ * operations, so we scan the whole list and skip non-matching entries.
+ */
+static void
+cancel_prior_composite_stmt_triggers(Oid relid, int tgevent)
+{
+	AfterTriggerEvent event;
+	AfterTriggerEventChunk *chunk;
+
+	/* Nothing to do unless a composite (pltsql) trigger is active */
+	if (!IsCompositeTriggerActive())
+		return;
+
+	for_each_event_chunk(event, chunk, compositeTriggers.triggers->data.events)
+	{
+		AfterTriggerShared evtshared = GetTriggerSharedData(event);
+
+		if (evtshared->ats_relid != relid)
+			continue;
+		if ((evtshared->ats_event & TRIGGER_EVENT_OPMASK) != tgevent)
+			continue;
+		if (!TRIGGER_FIRED_FOR_STATEMENT(evtshared->ats_event))
+			continue;
+		if (!TRIGGER_FIRED_AFTER(evtshared->ats_event))
+			continue;
+		if (event->ate_flags & AFTER_TRIGGER_DONE)
+			continue;
+
+		/* Mark it DONE so it won't fire again */
+		event->ate_flags &= ~AFTER_TRIGGER_IN_PROGRESS;
+		event->ate_flags |= AFTER_TRIGGER_DONE;
+	}
 }
 
 /*
@@ -7466,14 +7522,21 @@ void EndCompositeTriggers(bool error)
 			int before_lxid = MyProc->lxid;
 			ResourceOwner oldOwner = CurrentResourceOwner;
 
-			/* Mark all triggers as IN PROGRESS */
+			/* Mark all triggers as IN PROGRESS, skipping already-cancelled ones */
 			for_each_event_chunk(event, chunk, triggers->data.events)
 			{
 				AfterTriggerShared evtshared = GetTriggerSharedData(event);
 
 				evtshared->ats_firing_id = 0;
-				Assert(!(event->ate_flags &
-						 (AFTER_TRIGGER_DONE | AFTER_TRIGGER_IN_PROGRESS)));
+				/*
+				 * Events may already be marked DONE if cancel_prior_stmt_triggers
+				 * cancelled them (e.g., during FK CASCADE where multiple
+				 * statement-level events were queued for the same relation).
+				 * Skip those — they should not fire.
+				 */
+				if (event->ate_flags & AFTER_TRIGGER_DONE)
+					continue;
+				Assert(!(event->ate_flags & AFTER_TRIGGER_IN_PROGRESS));
 				event->ate_flags |= AFTER_TRIGGER_IN_PROGRESS;
 			}
 			/* Fire all triggers events, deferred is not supported */


### PR DESCRIPTION
### Description

cancel_prior_stmt_triggers() only scanned the query_stack event list to deduplicate statement-level trigger events. Composite (pltsql) trigger events are stored in a separate list and were never cancelled, causing the trigger to fire once per cascaded row instead of once per statement.

Add a scan of the composite trigger event list after the done: label in cancel_prior_stmt_triggers() to cancel prior statement-level events for the same relation and operation.

Also update EndCompositeTriggers() to skip events already marked DONE by the deduplication logic instead of asserting they are fresh.

Author: Rohit Bhagat <rohitbgt@amazon.com>
Signed-off-by: Rohit Bhagat <rohitbgt@amazon.com>

Cherry-picked from: https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/pull/783
Extension PR: https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4945

### Issues Resolved

BABEL-7022
 
### Check List

- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
