### PR TITLE
Support deterministic Stable functions in  Computed Columns

### DIFF
--- a/src/backend/catalog/heap.c
+++ b/src/backend/catalog/heap.c
@@ -84,6 +84,7 @@
 InvokePreAddConstraintsHook_type InvokePreAddConstraintsHook = NULL;
 transform_check_constraint_expr_hook_type transform_check_constraint_expr_hook = NULL;
 drop_relation_refcnt_hook_type drop_relation_refcnt_hook = NULL;
+persisted_col_hook_type persisted_col_hook = NULL;
 
 /* Potentially set by pg_upgrade_support functions */
 Oid			binary_upgrade_next_heap_pg_class_oid = InvalidOid;
@@ -3498,12 +3499,16 @@ cookDefault(ParseState *pstate,
 		/* Disallow refs to other generated columns */
 		check_nested_generated(pstate, expr);
 
-		/* Disallow mutable functions */
-		if (contain_mutable_functions_after_planning((Expr *) expr))
-			ereport(ERROR,
-					(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
-					 errmsg("generation expression is not immutable")));
-
+		/* hook to handle stable func in computed columns */
+		if (!persisted_col_hook ||
+			persisted_col_hook(expr) != NULL)
+		{
+			/* Disallow mutable functions */
+			if (contain_mutable_functions_after_planning((Expr *) expr))
+				ereport(ERROR,
+						(errcode(ERRCODE_INVALID_OBJECT_DEFINITION),
+						 errmsg("generation expression is not immutable")));
+		}
 		/* Check security of expressions for virtual generated column */
 		if (attgenerated == ATTRIBUTE_GENERATED_VIRTUAL)
 			check_virtual_generated_security(pstate, expr);

--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -73,6 +73,8 @@ bool		enable_distinct_reordering = true;
 
 /* Hook for plugins to get control in planner() */
 planner_hook_type planner_hook = NULL;
+/* Hook for persisted computed column re-evaluation in subquery_planner */
+persisted_col_rewrite_hook_type persisted_col_rewrite_hook = NULL;
 /* Hook for plugins to transform qual nodes in planner */
 planner_node_transformer_hook_type planner_node_transformer_hook = NULL;
 /* Hook for plugins to get control when grouping_planner() plans upper rels */
@@ -781,6 +783,13 @@ subquery_planner(PlannerGlobal *glob, Query *parse, PlannerInfo *parent_root,
 	 * query.
 	 */
 	pull_up_subqueries(root);
+
+	/*
+	 * Hook for persisted computed column re-evaluation when session GUCs
+	 * differ from defaults.
+	 */
+	if (persisted_col_rewrite_hook)
+		parse = root->parse = persisted_col_rewrite_hook(root->parse);
 
 	/*
 	 * If this is a simple UNION ALL query, flatten it into an appendrel. We

--- a/src/include/catalog/heap.h
+++ b/src/include/catalog/heap.h
@@ -175,4 +175,7 @@ extern PGDLLEXPORT transform_check_constraint_expr_hook_type transform_check_con
 typedef void (*drop_relation_refcnt_hook_type) (Relation rel);
 extern PGDLLEXPORT drop_relation_refcnt_hook_type drop_relation_refcnt_hook;
 
+typedef Node* (*persisted_col_hook_type)(Node *expr);
+extern PGDLLEXPORT persisted_col_hook_type persisted_col_hook;
+
 #endif							/* HEAP_H */

--- a/src/include/optimizer/planner.h
+++ b/src/include/optimizer/planner.h
@@ -29,6 +29,10 @@ typedef PlannedStmt *(*planner_hook_type) (Query *parse,
 										   ParamListInfo boundParams);
 extern PGDLLEXPORT planner_hook_type planner_hook;
 
+/* Hook for persisted computed column re-evaluation in subquery_planner */
+typedef Query* (*persisted_col_rewrite_hook_type)(Query *parse);
+extern PGDLLEXPORT persisted_col_rewrite_hook_type persisted_col_rewrite_hook;
+
 /* Hook for plugins to transform qual nodes in planner */
 typedef Node* (*planner_node_transformer_hook_type) (PlannerInfo *root,
 												  	 Node *expr,


### PR DESCRIPTION
### Description

Intercepted cook default to skip the immutability check and also implemented Post QueryRewrite hook to handle the re-evaluation / replacement whenever a Computed Column is referenced.
 
### Issues Resolved

BABEL-2022

Extension PR:https://github.com/babelfish-for-postgresql/babelfish_extensions/pull/4948
### Check List

- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the PostgreSQL license, and grant any person obtaining a copy of the contribution permission to relicense all or a portion of my contribution to the PostgreSQL License solely to contribute all or a portion of my contribution to the PostgreSQL open source project.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
